### PR TITLE
feat: add env pinning and scaffold tools

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -22,13 +22,13 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Create initial risk register and mitigation plan
 
 ** [ ] Phase 1: Repo Scaffold & Deterministic Environment
-    [ ] Generate project layout scaffold script for hrm-coder directory tree
+    [X] Generate project layout scaffold script for hrm-coder directory tree
     [ ] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
     [ ] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
     [ ] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
     [ ] Define Hydra config schema and default configs under conf/
     [ ] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
-    [ ] Implement environment pinning and seed/tz/locale normalization module
+    [X] Implement environment pinning and seed/tz/locale normalization module
 
 ** [ ] Phase 2: GUI Stub and Backend Skeleton
     [ ] Scaffold FastAPI app with /runs, /train, /eval, /logs/ws endpoints

--- a/hrm_coder/env.py
+++ b/hrm_coder/env.py
@@ -1,0 +1,56 @@
+"""Environment pinning utilities for deterministic behavior."""
+from __future__ import annotations
+
+import locale
+import os
+import random
+import time
+from typing import Optional
+
+
+def pin_environment(seed: int = 0, timezone: str = "UTC", locale_name: str = "C") -> None:
+    """Pin PRNG seeds and normalize process-wide environment.
+
+    Parameters
+    ----------
+    seed:
+        Seed used for Python's ``random`` and, if available, NumPy and PyTorch.
+    timezone:
+        Timezone used for the process. Defaults to ``UTC``.
+    locale_name:
+        Locale identifier passed to :func:`locale.setlocale`.
+    """
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+
+    # Optional libraries
+    try:
+        import numpy as np  # type: ignore
+
+        np.random.seed(seed)
+    except Exception:
+        pass
+
+    try:
+        import torch  # type: ignore
+
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+        try:
+            torch.use_deterministic_algorithms(True)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+    os.environ["TZ"] = timezone
+    try:
+        time.tzset()
+    except AttributeError:
+        pass
+
+    try:
+        locale.setlocale(locale.LC_ALL, locale_name)
+    except locale.Error:
+        pass

--- a/hrm_coder/scaffold.py
+++ b/hrm_coder/scaffold.py
@@ -1,0 +1,45 @@
+"""Utility to generate the hrm-coder project skeleton."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+# Directory layout inspired by docs/hrmCoder_plan.md
+LAYOUT = [
+    "conf",
+    "docker",
+    "hrm",
+    "runners",
+    "cpp/harness",
+    "cpp/cmake",
+    "datasets",
+    "orchestration",
+    "scripts",
+    "tests",
+    "reports",
+    "docs",
+]
+
+
+def create_scaffold(root: Path) -> None:
+    """Create the directory tree under ``root``.
+
+    Existing directories are left untouched.
+    """
+    for rel_path in LAYOUT:
+        path = root / rel_path
+        path.mkdir(parents=True, exist_ok=True)
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "root", type=Path, nargs="?", default=Path("hrm-coder"), help="Root path for scaffold"
+    )
+    args = parser.parse_args()
+    create_scaffold(args.root)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,16 @@
+import random
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path for module resolution
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from hrm_coder.env import pin_environment
+
+
+def test_random_seed_reproducibility():
+    pin_environment(42)
+    first = random.random()
+    pin_environment(42)
+    second = random.random()
+    assert first == second


### PR DESCRIPTION
## Summary
- add utilities to pin RNG seeds and locale/zone for reproducible runs
- scaffold script to create hrm-coder directory layout
- track phase-1 progress in checklist and add basic determinism test

## Testing
- `pytest tests/test_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a02f4c8b48833181af7856223a76dd