### PR TITLE
feat: scaffold fastapi backend

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -30,14 +30,14 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [ ] Implement environment pinning and seed/tz/locale normalization module
 
-** [ ] Phase 2: GUI Stub and Backend Skeleton
-    [ ] Scaffold FastAPI app with /runs, /train, /eval, /logs/ws endpoints
-    [ ] Implement mock run registry with in-memory store and pagination
+** [~] Phase 2: GUI Stub and Backend Skeleton
+    [X] Scaffold FastAPI app with /runs, /train, /eval, /logs/ws endpoints
+    [X] Implement mock run registry with in-memory store and pagination
     [ ] Build Run Console page with config pickers and action buttons
     [ ] Build Jobs list page with sortable metrics and artifact links
     [ ] Implement artifact static server for JUnit XML and lcov/llvm-cov HTML
     [ ] Add WebSocket log streamer with tail-follow behavior
-    [ ] Provide GUI quickstart docs and sample configs
+    [X] Provide GUI quickstart docs and sample configs
 
 ** [ ] Phase 3: Deterministic Dataset Pipeline (C++)
     [ ] Implement HumanEval-CPP builder with harness generator and reference solutions

--- a/docs/hrmCoder_gui_quickstart.md
+++ b/docs/hrmCoder_gui_quickstart.md
@@ -1,0 +1,19 @@
+# HRM Coder GUI Quickstart
+
+This stub GUI exposes a FastAPI backend for managing training and evaluation runs.
+
+## Running the server
+
+```
+uvicorn hrm_coder:app --reload
+```
+
+## Example usage
+
+```
+# List runs
+curl http://localhost:8000/runs
+
+# Start a training run
+curl -X POST http://localhost:8000/train -H 'Content-Type: application/json' -d '{}'
+```

--- a/hrm_coder/__init__.py
+++ b/hrm_coder/__init__.py
@@ -1,0 +1,3 @@
+"""HRM Coder backend stub for Phase 2."""
+
+from .api import app  # noqa: F401

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict
+from fastapi import FastAPI, WebSocket
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+
+from .run_registry import registry, Run
+
+app = FastAPI(title="HRM Coder")
+
+# Allow local development origins
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/runs", response_model=list[Run])
+def get_runs(offset: int = 0, limit: int = 10):
+    return registry.list_runs(offset, limit)
+
+
+@app.post("/train", response_model=Run)
+def start_train(config: Dict[str, str] | None = None):
+    run = registry.create_run(config)
+    registry.update_status(run.id, "training")
+    return run
+
+
+@app.post("/eval", response_model=Run)
+def start_eval(config: Dict[str, str] | None = None):
+    run = registry.create_run(config)
+    registry.update_status(run.id, "evaluating")
+    return run
+
+
+@app.websocket("/logs/ws")
+async def websocket_logs(ws: WebSocket):
+    await ws.accept()
+    await ws.send_text("log stream started")
+    await ws.close()

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+from itertools import count
+
+
+class Run(BaseModel):
+    id: int
+    config: Dict[str, str] = Field(default_factory=dict)
+    status: str = "pending"
+
+
+class RunRegistry:
+    """In-memory store for run metadata."""
+
+    _id_counter = count(1)
+
+    def __init__(self) -> None:
+        self._runs: Dict[int, Run] = {}
+
+    def create_run(self, config: Optional[Dict[str, str]] = None) -> Run:
+        run_id = next(self._id_counter)
+        run = Run(id=run_id, config=config or {})
+        self._runs[run_id] = run
+        return run
+
+    def list_runs(self, offset: int = 0, limit: int = 10) -> List[Run]:
+        runs = list(self._runs.values())
+        return runs[offset : offset + limit]
+
+    def update_status(self, run_id: int, status: str) -> None:
+        if run_id in self._runs:
+            self._runs[run_id].status = status
+
+
+registry = RunRegistry()

--- a/hrm_coder/sample_config.yaml
+++ b/hrm_coder/sample_config.yaml
@@ -1,0 +1,4 @@
+# Example configuration for HRM Coder runs
+model: small
+learning_rate: 1e-3
+dataset: humaneval-cpp

--- a/hrm_coder/tests/test_api.py
+++ b/hrm_coder/tests/test_api.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from hrm_coder import app
+
+
+def test_run_lifecycle():
+    client = TestClient(app)
+
+    # Initially empty
+    assert client.get("/runs").json() == []
+
+    # Start training run
+    resp = client.post("/train", json={"foo": "bar"})
+    run = resp.json()
+    assert run["status"] == "training"
+
+    # Listing returns the run
+    runs = client.get("/runs").json()
+    assert len(runs) == 1
+    assert runs[0]["id"] == run["id"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ wandb
 omegaconf
 hydra-core
 huggingface_hub
+
+fastapi
+uvicorn
+pytest


### PR DESCRIPTION
## Summary
- add FastAPI server with run registry and basic endpoints
- include GUI quickstart doc and sample config
- update checklist to reflect Phase 2 progress

## Testing
- `PYTHONPATH=. pytest hrm_coder/tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a02f4fc9b48331b8e0fd8708f01e6b