### PR TITLE
Add isolate sandbox adapter skeleton

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -49,7 +49,7 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Implement dataset split manager for train/val/test with fixed seeds
 
 ** [ ] Phase 4: Sandbox Executor
-    [ ] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
+    [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
     [ ] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
     [ ] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
     [ ] Implement caching layer keyed by prompt+code+tests+limits hash

--- a/runners/isolate.py
+++ b/runners/isolate.py
@@ -1,0 +1,97 @@
+import shutil
+import subprocess
+from typing import List, Optional
+
+
+class SandboxError(RuntimeError):
+    """Raised when the sandbox cannot execute a command."""
+
+
+class IsolateRunner:
+    """Adapter for the ``isolate`` sandbox tool.
+
+    This minimal wrapper constructs and runs ``isolate`` commands with
+    resource limits. It does not depend on the actual presence of the
+    ``isolate`` binary until :meth:`run` is invoked, enabling unit tests
+    to validate command construction without the binary installed.
+    """
+
+    def __init__(self, isolate_path: str = "isolate") -> None:
+        self.isolate_path = isolate_path
+
+    def build_command(
+        self,
+        command: List[str],
+        *,
+        time_limit: int = 5,
+        wall_time: int = 5,
+        memory: int = 256 * 1024,
+        processes: int = 1,
+        network: bool = False,
+    ) -> List[str]:
+        """Build an ``isolate`` invocation.
+
+        Parameters
+        ----------
+        command:
+            The command to execute inside the sandbox.
+        time_limit:
+            CPU time limit in seconds.
+        wall_time:
+            Wall clock limit in seconds.
+        memory:
+            Memory limit in kilobytes.
+        processes:
+            Maximum number of allowed processes.
+        network:
+            Allow network access if ``True``.
+        """
+        isolate_cmd = [
+            self.isolate_path,
+            "--cg",
+            f"--time={time_limit}",
+            f"--wall={wall_time}",
+            f"--mem={memory}",
+            f"--processes={processes}",
+        ]
+        if not network:
+            isolate_cmd.append("--net=none")
+        isolate_cmd.append("--")
+        isolate_cmd.extend(command)
+        return isolate_cmd
+
+    def run(
+        self,
+        command: List[str],
+        *,
+        time_limit: int = 5,
+        wall_time: int = 5,
+        memory: int = 256 * 1024,
+        processes: int = 1,
+        network: bool = False,
+        stdin: Optional[bytes] = None,
+    ) -> subprocess.CompletedProcess:
+        """Execute a command within ``isolate``.
+
+        Returns the :class:`subprocess.CompletedProcess` object produced
+        by :func:`subprocess.run`.
+        """
+        if shutil.which(self.isolate_path) is None:
+            raise SandboxError(
+                f"isolate executable not found: {self.isolate_path}"
+            )
+        cmd = self.build_command(
+            command,
+            time_limit=time_limit,
+            wall_time=wall_time,
+            memory=memory,
+            processes=processes,
+            network=network,
+        )
+        return subprocess.run(
+            cmd,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+        )

--- a/tests/test_isolate.py
+++ b/tests/test_isolate.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from runners.isolate import IsolateRunner
+
+
+def test_build_command_has_no_network_by_default():
+    runner = IsolateRunner(isolate_path="isolate")
+    cmd = runner.build_command(
+        ["/bin/echo", "hello"],
+        time_limit=1,
+        wall_time=2,
+        memory=1024,
+        processes=1,
+    )
+    assert cmd[0] == "isolate"
+    assert "--net=none" in cmd
+    assert "--" in cmd
+    assert cmd[-2:] == ["/bin/echo", "hello"]
+


### PR DESCRIPTION
## Summary
- add minimal `IsolateRunner` wrapper to build and execute `isolate` sandbox commands
- track Phase 4 progress in docs
- unit test to ensure network is disabled by default

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a02f54b6f48331b8d055fb47ce8bfd