### PR TITLE
Add reward aggregator and update phase 5 checklist

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -57,12 +57,12 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)
 
 ** [ ] Phase 5: Reward Shaping and Safety Gates
-    [ ] Implement reward aggregator with weighted compile/link status, tests, and coverage signals
+    [X] Implement reward aggregator with weighted compile/link status, tests, and coverage signals
     [ ] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
     [ ] Integrate static analysis (cppcheck) scoring and normalization
     [ ] Implement coverage delta computation using gcov/lcov or llvm-cov
-    [ ] Implement edit-cost, time, and memory penalty functions with clamps
-    [ ] Add reward histogram logging to tracker with sanity checks
+    [X] Implement edit-cost, time, and memory penalty functions with clamps
+    [X] Add reward histogram logging to tracker with sanity checks
 
 ** [ ] Phase 6: HRM Training Loop Integration
     [ ] Implement CodeEncoder interface and tokenizer utilities for C++ syntax

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -1,0 +1,44 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.reward import RewardAggregator
+
+
+def test_reward_aggregator_basic():
+    agg = RewardAggregator(weights={'compile': 0.1, 'tests': 0.7, 'coverage': 0.2},
+                           max_edit_penalty=0.05,
+                           max_time_penalty=0.05,
+                           max_memory_penalty=0.05)
+
+    # Perfect run within limits
+    r1 = agg.compute(
+        compile_success=True,
+        tests_passed=5,
+        tests_total=5,
+        coverage=1.0,
+        edit_cost=0,
+        time_used=1.0,
+        memory_used=1.0,
+        time_limit=2.0,
+        memory_limit=2.0,
+    )
+    assert abs(r1 - 1.0) < 1e-6
+
+    # Failure with penalties
+    r2 = agg.compute(
+        compile_success=False,
+        tests_passed=0,
+        tests_total=5,
+        coverage=0.0,
+        edit_cost=10.0,
+        time_used=3.0,
+        memory_used=3.0,
+        time_limit=2.0,
+        memory_limit=2.0,
+    )
+    assert r2 <= -0.1
+
+    hist = agg.histogram()
+    assert sum(hist) == 2

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -1,0 +1,100 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+import logging
+
+
+@dataclass
+class RewardAggregator:
+    """Aggregates multiple reward signals into a single scalar.
+
+    Parameters
+    ----------
+    weights: mapping of signal name to weight. Supported keys are
+        ``compile``, ``tests`` and ``coverage``.
+    max_edit_penalty: maximum penalty applied for edit cost.
+    max_time_penalty: maximum penalty applied when runtime exceeds the limit.
+    max_memory_penalty: maximum penalty applied when memory use exceeds the limit.
+    """
+
+    weights: Dict[str, float]
+    max_edit_penalty: float = 0.1
+    max_time_penalty: float = 0.1
+    max_memory_penalty: float = 0.1
+    history: List[float] = field(default_factory=list)
+
+    def compute(
+        self,
+        compile_success: bool,
+        tests_passed: int,
+        tests_total: int,
+        coverage: float,
+        edit_cost: float,
+        time_used: float,
+        memory_used: float,
+        time_limit: float | None = None,
+        memory_limit: float | None = None,
+    ) -> float:
+        """Compute aggregate reward with penalties.
+
+        Parameters
+        ----------
+        compile_success: whether compilation (and link) succeeded.
+        tests_passed: number of unit tests passed.
+        tests_total: total number of unit tests executed.
+        coverage: code coverage ratio in [0, 1].
+        edit_cost: number of edit operations performed.
+        time_used: wall-clock seconds consumed.
+        memory_used: peak memory usage in megabytes.
+        time_limit: optional runtime limit.
+        memory_limit: optional memory limit.
+        """
+
+        reward = 0.0
+
+        compile_score = 1.0 if compile_success else 0.0
+        test_score = tests_passed / tests_total if tests_total else 0.0
+        coverage_score = max(0.0, min(coverage, 1.0))
+
+        reward += self.weights.get("compile", 0.0) * compile_score
+        reward += self.weights.get("tests", 0.0) * test_score
+        reward += self.weights.get("coverage", 0.0) * coverage_score
+
+        # Penalties
+        reward -= min(edit_cost * self.max_edit_penalty, self.max_edit_penalty)
+
+        if time_limit and time_used > time_limit:
+            over = (time_used - time_limit) / time_limit
+            reward -= min(over * self.max_time_penalty, self.max_time_penalty)
+
+        if memory_limit and memory_used > memory_limit:
+            over = (memory_used - memory_limit) / memory_limit
+            reward -= min(over * self.max_memory_penalty, self.max_memory_penalty)
+
+        # Record history for histogram logging
+        self.history.append(reward)
+        return reward
+
+    def histogram(self, bins: int = 10) -> List[int]:
+        """Return a simple histogram of historical rewards."""
+
+        if not self.history:
+            return [0] * bins
+
+        mn, mx = min(self.history), max(self.history)
+        step = (mx - mn) / bins if mx > mn else 1.0
+        hist = [0] * bins
+        for value in self.history:
+            idx = int((value - mn) / step) if step else 0
+            idx = min(idx, bins - 1)
+            hist[idx] += 1
+        return hist
+
+    def log_histogram(self, logger: logging.Logger | None = None) -> None:
+        """Log histogram of rewards with a sanity range check."""
+
+        logger = logger or logging.getLogger(__name__)
+        hist = self.histogram()
+        if any(r < -1.0 or r > 1.0 for r in self.history):
+            logger.warning("reward out of expected [-1,1] range")
+        logger.debug("reward histogram: %s", hist)
+        


### PR DESCRIPTION
## Summary
- add RewardAggregator for weighted signals and penalties
- update checklist with completed Phase 5 tasks
- cover aggregator with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a02f56e5108331acdefa4eed8c16c2