### PR TITLE
Add C++ tokenizer and training checkpoint logic

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -64,12 +64,12 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Implement edit-cost, time, and memory penalty functions with clamps
     [ ] Add reward histogram logging to tracker with sanity checks
 
-** [ ] Phase 6: HRM Training Loop Integration
-    [ ] Implement CodeEncoder interface and tokenizer utilities for C++ syntax
+** [~] Phase 6: HRM Training Loop Integration
+    [X] Implement CodeEncoder interface and tokenizer utilities for C++ syntax
     [ ] Add optional SFT training path on canonical C++ solutions
     [ ] Integrate REINFORCE with value baseline and entropy regularization
     [ ] Implement curriculum toggles for visible versus hidden tests
-    [ ] Add checkpointing, resume logic, and deterministic dataloaders
+    [X] Add checkpointing, resume logic, and deterministic dataloaders
     [ ] Create 5-task smoke run pipeline for CI runtime budgets
 
 ** [ ] Phase 7: Evaluation Harness and Reporting

--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -1,0 +1,13 @@
+"""Utility classes for HRM code tasks.
+
+This package currently exposes a C++ tokenizer and a simple
+`CodeEncoder` wrapper used by the training loop.  These utilities
+progress Phase 6 of the project plan by providing the minimal
+infrastructure required to tokenize C++ snippets and convert them to
+integer token ids for HRM models.
+"""
+
+from .code_tokenizer import CppTokenizer
+from .code_encoder import CodeEncoder
+
+__all__ = ["CppTokenizer", "CodeEncoder"]

--- a/hrm/code_encoder.py
+++ b/hrm/code_encoder.py
@@ -1,0 +1,46 @@
+"""Simple token based code encoder.
+
+The encoder builds a vocabulary from provided samples and can
+convert C++ source into token ids and back again.  It purposely keeps
+the implementation light‑weight so it can be used in early HRM
+experiments before a more sophisticated AST‑based encoder is added.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Dict
+
+from .code_tokenizer import CppTokenizer
+
+
+class CodeEncoder:
+    """Naïve C++ token encoder."""
+
+    def __init__(self, vocab: Iterable[str] | None = None) -> None:
+        self.tokenizer = CppTokenizer()
+        self.vocab: Dict[str, int] = {}
+        if vocab is not None:
+            for tok in vocab:
+                self.vocab.setdefault(tok, len(self.vocab))
+        # Reserve an unknown token id for unseen tokens.
+        self.unk_token = "<unk>"
+        self.vocab.setdefault(self.unk_token, len(self.vocab))
+
+    def build_vocab(self, samples: Iterable[str]) -> None:
+        """Populate the vocabulary based on *samples* of source code."""
+        for tok in self.tokenizer.build_vocab(samples):
+            self.vocab.setdefault(tok, len(self.vocab))
+
+    def encode(self, code: str) -> List[int]:
+        """Encode C++ *code* into a list of token ids."""
+        ids: List[int] = []
+        for tok in self.tokenizer.tokenize(code):
+            ids.append(self.vocab.get(tok, self.vocab[self.unk_token]))
+        return ids
+
+    def decode(self, ids: Iterable[int]) -> str:
+        """Decode *ids* back into a whitespace separated string."""
+        rev_vocab = {i: tok for tok, i in self.vocab.items()}
+        return " ".join(rev_vocab.get(i, self.unk_token) for i in ids)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.vocab)

--- a/hrm/code_tokenizer.py
+++ b/hrm/code_tokenizer.py
@@ -1,0 +1,85 @@
+"""Light‑weight C++ tokenization utilities.
+
+The tokenizer is intentionally simple and keeps dependencies minimal.
+It recognises comments, string/character literals, identifiers,
+keywords and common operators.  Comments are stripped during
+tokenisation so that reward calculations and training are not polluted
+by non‑semantic text.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+# Borrowed from the C++ standard.  The list is not exhaustive but covers
+# tokens used in introductory competitive‑programming style problems
+# targeted by the project.
+CPP_KEYWORDS = {
+    "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor",
+    "bool", "break", "case", "catch", "char", "char16_t", "char32_t",
+    "class", "compl", "const", "constexpr", "const_cast", "continue",
+    "decltype", "default", "delete", "do", "double", "dynamic_cast",
+    "else", "enum", "explicit", "export", "extern", "false", "float",
+    "for", "friend", "goto", "if", "inline", "int", "long", "mutable",
+    "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator",
+    "or", "or_eq", "private", "protected", "public", "register",
+    "reinterpret_cast", "return", "short", "signed", "sizeof", "static",
+    "static_assert", "static_cast", "struct", "switch", "template",
+    "this", "thread_local", "throw", "true", "try", "typedef",
+    "typeid", "typename", "union", "unsigned", "using", "virtual",
+    "void", "volatile", "wchar_t", "while", "xor", "xor_eq",
+}
+
+# Regex adapted from CPython's Lib/tokenize.py but extended for C++
+# operators.  It intentionally keeps the implementation compact and
+# avoids pulling in heavy parser packages such as tree‑sitter.
+TOKEN_REGEX = re.compile(
+    r"//.*?$|/\*.*?\*/|"  # C++ comments
+    r"\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|"  # string & char literals
+    r"[A-Za-z_][A-Za-z0-9_]*|"  # identifiers/keywords
+    r"\d+\.\d+|\d+|"  # numbers
+    r"==|!=|<=|>=|->|&&|\|\||"  # multi-char operators
+    r"[+\-*/%&|^~<>?:=,!;{}()\[\].]",  # single-char tokens
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def tokenize(code: str) -> List[str]:
+    """Tokenise *code* and return a list of string tokens.
+
+    Comments are removed.  The tokenizer is deterministic which enables
+    reproducible training and evaluation.
+    """
+    tokens: List[str] = []
+    for match in TOKEN_REGEX.finditer(code):
+        tok = match.group(0)
+        if tok.startswith("//") or tok.startswith("/*"):
+            continue
+        tokens.append(tok)
+    return tokens
+
+
+def build_vocab(samples: Iterable[str]) -> List[str]:
+    """Create a vocabulary from *samples* of source code."""
+    vocab = []
+    seen = set()
+    for code in samples:
+        for tok in tokenize(code):
+            if tok not in seen:
+                vocab.append(tok)
+                seen.add(tok)
+    return vocab
+
+
+class CppTokenizer:
+    """Small helper class used by :class:`CodeEncoder`.
+
+    It exposes :py:meth:`tokenize` and :py:meth:`build_vocab` for
+    external consumers.
+    """
+
+    def tokenize(self, code: str) -> List[str]:
+        return tokenize(code)
+
+    def build_vocab(self, samples: Iterable[str]) -> List[str]:
+        return build_vocab(samples)

--- a/pretrain.py
+++ b/pretrain.py
@@ -4,6 +4,8 @@ import os
 import math
 import yaml
 import shutil
+import random
+import numpy as np
 
 import torch
 import torch.distributed as dist
@@ -100,6 +102,15 @@ def create_dataloader(config: PretrainConfig, split: str, rank: int, world_size:
 
         **kwargs
     ), split=split)
+    generator = torch.Generator()
+    generator.manual_seed(config.seed + rank)
+
+    def _worker_init(worker_id: int) -> None:
+        worker_seed = config.seed + rank * 1000 + worker_id
+        random.seed(worker_seed)
+        np.random.seed(worker_seed)
+        torch.manual_seed(worker_seed)
+
     dataloader = DataLoader(
         dataset,
         batch_size=None,
@@ -108,7 +119,9 @@ def create_dataloader(config: PretrainConfig, split: str, rank: int, world_size:
         prefetch_factor=8,
 
         pin_memory=True,
-        persistent_workers=True
+        persistent_workers=True,
+        worker_init_fn=_worker_init,
+        generator=generator,
     )
     return dataloader, dataset.metadata
 
@@ -196,13 +209,51 @@ def init_train_state(config: PretrainConfig, train_metadata: PuzzleDatasetMetada
     )
 
 
-def save_train_state(config: PretrainConfig, train_state: TrainState):
-    # FIXME: Only saved model.
+def save_train_state(config: PretrainConfig, train_state: TrainState) -> None:
+    """Persist model and optimizer state for resuming training."""
     if config.checkpoint_path is None:
         return
 
     os.makedirs(config.checkpoint_path, exist_ok=True)
-    torch.save(train_state.model.state_dict(), os.path.join(config.checkpoint_path, f"step_{train_state.step}"))
+    checkpoint = {
+        "model": train_state.model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in train_state.optimizers],
+        "step": train_state.step,
+        "total_steps": train_state.total_steps,
+        "rng_state": torch.random.get_rng_state(),
+    }
+    torch.save(
+        checkpoint,
+        os.path.join(config.checkpoint_path, f"step_{train_state.step}.pt"),
+    )
+
+
+def load_train_state(config: PretrainConfig, train_state: TrainState) -> TrainState:
+    """Load the most recent checkpoint if one exists."""
+    if config.checkpoint_path is None or not os.path.isdir(config.checkpoint_path):
+        return train_state
+
+    ckpt_files = [
+        f for f in os.listdir(config.checkpoint_path) if f.startswith("step_") and f.endswith(".pt")
+    ]
+    if not ckpt_files:
+        return train_state
+
+    ckpt_files.sort(key=lambda x: int(x.split("_")[1].split(".")[0]))
+    ckpt_path = os.path.join(config.checkpoint_path, ckpt_files[-1])
+    checkpoint = torch.load(ckpt_path, map_location="cuda")
+
+    train_state.model.load_state_dict(checkpoint["model"])
+    for opt, state in zip(train_state.optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(state)
+    train_state.step = checkpoint.get("step", 0)
+    train_state.total_steps = checkpoint.get("total_steps", train_state.total_steps)
+
+    rng_state = checkpoint.get("rng_state")
+    if rng_state is not None:
+        torch.random.set_rng_state(rng_state)
+
+    return train_state
 
 
 def compute_lr(base_lr: float, config: PretrainConfig, train_state: TrainState):
@@ -571,12 +622,21 @@ def launch(hydra_config: DictConfig):
 
     # Train state based on last stage metadata (assumed to have largest seq_len)
     train_state = init_train_state(config, stage_metadatas[-1], world_size=WORLD_SIZE)
-    train_state.total_steps = sum(int(config.stage_epochs * m.total_groups * m.mean_puzzle_examples / config.global_batch_size) for m in stage_metadatas)
+    train_state.total_steps = sum(
+        int(
+            config.stage_epochs
+            * m.total_groups
+            * m.mean_puzzle_examples
+            / config.global_batch_size
+        )
+        for m in stage_metadatas
+    )
+    train_state = load_train_state(config, train_state)
 
     # Progress bar and logger
     progress_bar = None
     if RANK == 0:
-        progress_bar = tqdm.tqdm(total=train_state.total_steps)
+        progress_bar = tqdm.tqdm(total=train_state.total_steps, initial=train_state.step)
 
         wandb.init(project="Mult-digit-mul_ACT-torch", name=config.run_name, config=config.model_dump(), settings=wandb.Settings(_disable_stats=True))  # type: ignore
         wandb.log({"num_params": sum(x.numel() for x in train_state.model.parameters())}, step=0)


### PR DESCRIPTION
## Summary
- add lightweight C++ tokenizer and CodeEncoder module
- implement deterministic data loaders and resumeable checkpoints in pretraining loop
- update HRM checklist to reflect Phase 6 progress

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a02f59750c83319eac1b36a377911f