### PR TITLE
Add initial C++ CI workflow

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -1,0 +1,36 @@
+name: C++ Lint and Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang tools
+        run: sudo apt-get update && sudo apt-get install -y clang-format clang-tidy cmake build-essential
+
+      - name: C++ lint
+        run: |
+          files=$(git ls-files '*.cpp' '*.hpp' '*.cc' '*.hh' '*.h' '*.cxx' '*.hxx')
+          if [ -n "$files" ]; then
+            clang-format --dry-run --Werror $files
+            clang-tidy $files -- -std=c++17
+          else
+            echo "No C++ files to lint."
+          fi
+
+      - name: Build and test
+        run: |
+          if [ -f CMakeLists.txt ]; then
+            mkdir build && cd build
+            cmake ..
+            make
+            ctest --output-on-failure
+          else
+            echo "No C++ tests found."
+          fi

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -81,7 +81,7 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Implement artifact bundler and uploader for reports and raw JSON
 
 ** [ ] Phase 8: CI/CD and Automation
-    [ ] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
+    [~] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
     [ ] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [ ] Create nightly full evaluation job with retention and tagging
     [ ] Implement version stamping (git SHA, Docker digest, seeds) in runs


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs clang tools and runs lint/tests for C++ sources
- mark Phase 8 task as in progress in hrmCoder checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a02f5d8fd883318a72e5dc731207e1