### PR TITLE
Add C++ AST editing utilities

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -89,11 +89,11 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)
-    [ ] Integrate Tree-sitter C++ grammar and bindings
+    [~] Integrate Tree-sitter C++ grammar and bindings
     [ ] Implement node type schema and AST embedding encoder for C++
-    [ ] Define edit action space for insert, replace, and delete operations
+    [~] Define edit action space for insert, replace, and delete operations
     [ ] Implement cursor policy module for region selection by HRM high-level
-    [ ] Implement decoder constraint checker to avoid invalid AST states
+    [~] Implement decoder constraint checker to avoid invalid AST states
     [ ] Add ablation job configs and comparison report against token baseline
 
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ wandb
 omegaconf
 hydra-core
 huggingface_hub
+tree_sitter
+tree_sitter_languages

--- a/tests/test_ast_edit.py
+++ b/tests/test_ast_edit.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils.ast_edit import CppAst
+
+
+CPP_SNIPPET = """int add(int a, int b) { return a + b; }"""
+
+
+def test_parse_and_basic_edits():
+    ast = CppAst()
+    tree = ast.parse(CPP_SNIPPET)
+    assert tree.root_node.type == "translation_unit"
+
+    # Replace the return expression
+    func = tree.root_node.children[0]
+    return_node = func.child_by_field_name("body").child(1)
+    edited = ast.replace(CPP_SNIPPET, return_node, "return a - b;")
+    assert ast.is_valid(edited.code)
+
+    # Insert a simple comment at the beginning
+    inserted = ast.insert(edited.code, 0, "// add two numbers\n")
+    assert ast.is_valid(inserted.code)
+
+    # Delete the comment
+    comment_node = ast.parse(inserted.code).root_node.child(0)
+    deleted = ast.delete(inserted.code, comment_node)
+    assert ast.is_valid(deleted.code)
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for HRM and HRM Coder."""
+
+# Re-export commonly used helpers.
+from .functions import load_model_class, get_model_source_path  # noqa: F401
+

--- a/utils/ast_edit.py
+++ b/utils/ast_edit.py
@@ -1,0 +1,96 @@
+"""Utilities for editing C++ code through its AST.
+
+This module exposes a small wrapper around the `tree_sitter` parser that
+allows basic edit operations on C++ source strings.  It is an early step
+toward Phase 9 (AST-edit action space) of the HRM Coder roadmap.
+
+The `CppAst` class offers:
+
+* `parse` – parse code into a `tree_sitter` tree.
+* `replace` – replace the text spanned by a node.
+* `insert` – insert text at a byte offset.
+* `delete` – remove the text spanned by a node.
+* `is_valid` – check that edited code still forms a valid C++ AST.
+
+The implementation intentionally keeps the API small; later phases can build
+on top with node embeddings and higher level edit policies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from tree_sitter import Node, Tree
+from tree_sitter_languages import get_parser
+
+
+@dataclass
+class EditResult:
+    """Result of an edit operation.
+
+    Attributes:
+        code: The updated source string.
+        tree: The parsed tree for ``code`` if ``reparse`` was requested.
+    """
+
+    code: str
+    tree: Optional[Tree] = None
+
+
+class CppAst:
+    """Thin wrapper around a Tree-sitter C++ parser."""
+
+    def __init__(self) -> None:
+        self.parser = get_parser("cpp")
+
+    def parse(self, code: str) -> Tree:
+        """Parse ``code`` into a :class:`Tree`."""
+
+        return self.parser.parse(bytes(code, "utf8"))
+
+    def replace(self, code: str, node: Node, replacement: str, *, reparse: bool = True) -> EditResult:
+        """Replace the text covered by ``node`` with ``replacement``.
+
+        Parameters
+        ----------
+        code:
+            Original source code.
+        node:
+            Node whose span will be replaced.
+        replacement:
+            Text to insert in place of the node.
+        reparse:
+            Whether to reparse the updated code and include the new tree in
+            the result.
+        """
+
+        new_code = code[: node.start_byte] + replacement + code[node.end_byte :]
+        new_tree = self.parse(new_code) if reparse else None
+        return EditResult(new_code, new_tree)
+
+    def insert(self, code: str, position: int, text: str, *, reparse: bool = True) -> EditResult:
+        """Insert ``text`` at ``position`` (byte offset).
+
+        ``position`` must be a byte index into ``code``.  The new tree is
+        returned when ``reparse`` is True.
+        """
+
+        new_code = code[:position] + text + code[position:]
+        new_tree = self.parse(new_code) if reparse else None
+        return EditResult(new_code, new_tree)
+
+    def delete(self, code: str, node: Node, *, reparse: bool = True) -> EditResult:
+        """Remove the text covered by ``node``."""
+
+        return self.replace(code, node, "", reparse=reparse)
+
+    def is_valid(self, code: str) -> bool:
+        """Return True if ``code`` parses successfully as C++."""
+
+        try:
+            self.parse(code)
+            return True
+        except Exception:
+            return False
+


### PR DESCRIPTION
## Summary
- add Tree-sitter based `CppAst` helper with basic insert/replace/delete editing
- exercise edits with new unit test
- note Phase 9 progress in HRM Coder checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a02f60d9048331b6a71558d685349c