### PR TITLE
Add initial environment scaffold for Phase 1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+        files: \.(cpp|hpp|cc|cxx|c|h)$
+  - repo: https://github.com/cpplint/cpplint
+    rev: 1.6.1
+    hooks:
+      - id: cpplint
+        files: \.(cpp|hpp|cc|cxx|c|h)$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: data build_runner train eval report
+
+# Placeholder targets for Phase 1 scaffold
+
+data:
+	@echo "Data pipeline not implemented yet"
+
+build_runner:
+	docker build -f runner.Dockerfile -t hrm-runner .
+
+train:
+	python train.py
+
+eval:
+	python evaluate.py
+
+report:
+	@echo "Report generation not implemented yet"

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -23,11 +23,11 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 1: Repo Scaffold & Deterministic Environment
     [X] Generate project layout scaffold script for hrm-coder directory tree
-    [ ] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
-    [ ] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
-    [ ] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
+    [~] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
+    [~] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
+    [~] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
     [ ] Define Hydra config schema and default configs under conf/
-    [ ] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
+    [~] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [X] Implement environment pinning and seed/tz/locale normalization module
 
 ** [~] Phase 2: GUI Stub and Backend Skeleton

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -1,0 +1,27 @@
+# runner.Dockerfile - base image for C++ execution environment
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        clang-format \
+        clang-tidy \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        libgtest-dev \
+        ninja-build \
+        python3 \
+        python3-pip \
+        isolate \
+    && rm -rf /var/lib/apt/lists/*
+
+# TODO: Install nsjail and sanitizer tools
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/trainer.Dockerfile
+++ b/trainer.Dockerfile
@@ -1,0 +1,15 @@
+# trainer.Dockerfile - image for HRM training environment
+FROM pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=0 \
+    CUBLAS_WORKSPACE_CONFIG=:4096:8 \
+    CUDA_LAUNCH_BLOCKING=1
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
+    pip install --no-cache-dir pre-commit
+
+WORKDIR /workspace
+
+CMD ["bash"]


### PR DESCRIPTION
## Summary
- add skeleton runner and trainer Dockerfiles
- introduce Makefile with basic data/train/eval/report targets
- configure initial pre-commit hooks and update checklist

## Testing
- `pre-commit run --files runner.Dockerfile trainer.Dockerfile Makefile docs/hrmCoder_checklist.md`
- `PYTHONPATH=. pytest` *(fails: TypeError in tree_sitter parser)*

------
https://chatgpt.com/codex/tasks/task_e_68a036508d288331ab64554f974e4c8c