### PR TITLE
Implement diagnostic scoring and coverage delta for reward shaping

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -58,9 +58,9 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 5: Reward Shaping and Safety Gates
     [X] Implement reward aggregator with weighted compile/link status, tests, and coverage signals
-    [ ] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
-    [ ] Integrate static analysis (cppcheck) scoring and normalization
-    [ ] Implement coverage delta computation using gcov/lcov or llvm-cov
+    [~] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
+    [~] Integrate static analysis (cppcheck) scoring and normalization
+    [~] Implement coverage delta computation using gcov/lcov or llvm-cov
     [X] Implement edit-cost, time, and memory penalty functions with clamps
     [X] Add reward histogram logging to tracker with sanity checks
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,22 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.diagnostics import clang_tidy_score, cppcheck_score, coverage_delta
+
+
+def test_clang_tidy_score():
+    output = "foo.cpp:1:1: warning: something [misc]"
+    assert clang_tidy_score(output) == 0.9
+    assert clang_tidy_score("") == 1.0
+
+
+def test_cppcheck_score():
+    output = "[warning] variable unused\n[error] something bad"
+    assert cppcheck_score(output) == 0.8
+
+
+def test_coverage_delta():
+    assert coverage_delta(0.2, 0.5) == 0.3
+    assert coverage_delta(0.6, 0.2) == 0.0

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -42,3 +42,34 @@ def test_reward_aggregator_basic():
 
     hist = agg.histogram()
     assert sum(hist) == 2
+
+
+def test_reward_with_lint_static_and_coverage_delta():
+    agg = RewardAggregator(
+        weights={
+            'compile': 0.1,
+            'tests': 0.3,
+            'coverage': 0.2,
+            'coverage_delta': 0.2,
+            'lint': 0.1,
+            'static': 0.1,
+        },
+        max_edit_penalty=0.0,
+        max_time_penalty=0.0,
+        max_memory_penalty=0.0,
+    )
+
+    r = agg.compute(
+        compile_success=True,
+        tests_passed=3,
+        tests_total=4,
+        coverage=0.6,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        lint_score=0.5,
+        static_score=0.8,
+        prev_coverage=0.4,
+    )
+
+    assert abs(r - 0.615) < 1e-6

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,4 +2,9 @@
 
 # Re-export commonly used helpers.
 from .functions import load_model_class, get_model_source_path  # noqa: F401
+from .diagnostics import (  # noqa: F401
+    clang_tidy_score,
+    cppcheck_score,
+    coverage_delta,
+)
 

--- a/utils/diagnostics.py
+++ b/utils/diagnostics.py
@@ -1,0 +1,39 @@
+"""Helpers for scoring build and static-analysis diagnostics."""
+
+from __future__ import annotations
+
+import re
+
+
+def clang_tidy_score(output: str) -> float:
+    """Return a normalized score from clang-tidy/clang diagnostics.
+
+    Parameters
+    ----------
+    output:
+        Raw stderr/stdout produced by clang-tidy or clang++ with
+        ``-Wall -Wextra -Werror`` enabled.
+    """
+    problems = len(re.findall(r": (?:warning|error|note):", output))
+    return max(0.0, 1.0 - 0.1 * problems)
+
+
+def cppcheck_score(output: str) -> float:
+    """Return a normalized score from cppcheck output.
+
+    Each ``[warning]`` or ``[error]`` decreases the score by 0.1.
+    """
+    problems = len(re.findall(r"\[(?:error|warning)\]", output))
+    return max(0.0, 1.0 - 0.1 * problems)
+
+
+def coverage_delta(previous: float, current: float) -> float:
+    """Compute non-negative coverage improvement.
+
+    Both ``previous`` and ``current`` are clipped to ``[0, 1]`` before the
+    delta is taken.
+    """
+    prev = max(0.0, min(previous, 1.0))
+    curr = max(0.0, min(current, 1.0))
+    return max(0.0, curr - prev)
+

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -10,7 +10,8 @@ class RewardAggregator:
     Parameters
     ----------
     weights: mapping of signal name to weight. Supported keys are
-        ``compile``, ``tests`` and ``coverage``.
+        ``compile``, ``tests``, ``coverage``, ``coverage_delta``,
+        ``lint`` and ``static``.
     max_edit_penalty: maximum penalty applied for edit cost.
     max_time_penalty: maximum penalty applied when runtime exceeds the limit.
     max_memory_penalty: maximum penalty applied when memory use exceeds the limit.
@@ -31,6 +32,9 @@ class RewardAggregator:
         edit_cost: float,
         time_used: float,
         memory_used: float,
+        lint_score: float = 1.0,
+        static_score: float = 1.0,
+        prev_coverage: float | None = None,
         time_limit: float | None = None,
         memory_limit: float | None = None,
     ) -> float:
@@ -45,6 +49,9 @@ class RewardAggregator:
         edit_cost: number of edit operations performed.
         time_used: wall-clock seconds consumed.
         memory_used: peak memory usage in megabytes.
+        lint_score: normalized score from clang-tidy/clang diagnostics.
+        static_score: normalized score from static analysis tools (e.g. cppcheck).
+        prev_coverage: previous coverage value used to compute coverage delta.
         time_limit: optional runtime limit.
         memory_limit: optional memory limit.
         """
@@ -54,10 +61,15 @@ class RewardAggregator:
         compile_score = 1.0 if compile_success else 0.0
         test_score = tests_passed / tests_total if tests_total else 0.0
         coverage_score = max(0.0, min(coverage, 1.0))
+        prev_cov = max(0.0, min(prev_coverage, 1.0)) if prev_coverage is not None else None
+        coverage_delta = max(0.0, coverage_score - prev_cov) if prev_cov is not None else 0.0
 
         reward += self.weights.get("compile", 0.0) * compile_score
         reward += self.weights.get("tests", 0.0) * test_score
         reward += self.weights.get("coverage", 0.0) * coverage_score
+        reward += self.weights.get("coverage_delta", 0.0) * coverage_delta
+        reward += self.weights.get("lint", 0.0) * max(0.0, min(lint_score, 1.0))
+        reward += self.weights.get("static", 0.0) * max(0.0, min(static_score, 1.0))
 
         # Penalties
         reward -= min(edit_cost * self.max_edit_penalty, self.max_edit_penalty)


### PR DESCRIPTION
## Summary
- extend reward aggregator with lint, static analysis, and coverage delta signals
- add helper utilities to score clang-tidy, cppcheck, and coverage improvements
- mark Phase 5 tasks in checklist as in progress and add unit tests

## Testing
- `pytest tests/test_reward.py tests/test_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68a036602ad8833191dfc63c6ebd72bd