### PR TITLE
feat: add HRM training loop skeleton

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -67,8 +67,8 @@ Save new code files in: C:\repos\hrm-coder
 ** [~] Phase 6: HRM Training Loop Integration
     [X] Implement CodeEncoder interface and tokenizer utilities for C++ syntax
     [ ] Add optional SFT training path on canonical C++ solutions
-    [ ] Integrate REINFORCE with value baseline and entropy regularization
-    [ ] Implement curriculum toggles for visible versus hidden tests
+    [~] Integrate REINFORCE with value baseline and entropy regularization
+    [~] Implement curriculum toggles for visible versus hidden tests
     [X] Add checkpointing, resume logic, and deterministic dataloaders
     [ ] Create 5-task smoke run pipeline for CI runtime budgets
 

--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -1,13 +1,15 @@
 """Utility classes for HRM code tasks.
 
-This package currently exposes a C++ tokenizer and a simple
-`CodeEncoder` wrapper used by the training loop.  These utilities
-progress Phase 6 of the project plan by providing the minimal
-infrastructure required to tokenize C++ snippets and convert them to
-integer token ids for HRM models.
+The package bundles small helpers used in Phase 6 of the development
+roadmap.  In addition to a C++ tokenizer and naïve ``CodeEncoder`` it now
+exposes :class:`~hrm.training_loop.HRMTrainer` which implements a minimal
+training loop with supervised fine‑tuning and REINFORCE support.  These
+utilities provide the scaffolding required to experiment with HRM models
+on code tasks.
 """
 
 from .code_tokenizer import CppTokenizer
 from .code_encoder import CodeEncoder
+from .training_loop import HRMTrainer, HRMTrainingConfig
 
-__all__ = ["CppTokenizer", "CodeEncoder"]
+__all__ = ["CppTokenizer", "CodeEncoder", "HRMTrainer", "HRMTrainingConfig"]

--- a/hrm/training_loop.py
+++ b/hrm/training_loop.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""Training helpers for Phase 6 HRM integration.
+
+This module implements a light‑weight training loop that supports both
+supervised fine‑tuning (SFT) and reinforcement learning (REINFORCE) with a
+value baseline and entropy regularisation.  The goal is not to be feature
+complete but to provide a concrete starting point that unblocks Phase 6
+development.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+@dataclass
+class HRMTrainingConfig:
+    """Configuration values controlling the training loop."""
+
+    baseline_coef: float = 0.5
+    entropy_coef: float = 1e-4
+    curriculum_stage: str = "visible"  # toggled between "visible" and "hidden"
+
+
+class HRMTrainer:
+    """Utility wrapper implementing common training operations.
+
+    Parameters
+    ----------
+    model:
+        A module returning ``(logits, value)`` when called.  ``logits`` are used
+        for policy decisions while ``value`` estimates the baseline reward.
+    optimizer:
+        Optimiser used to update ``model`` parameters.
+    config:
+        ``HRMTrainingConfig`` controlling loss coefficients and curriculum
+        stage.
+    """
+
+    def __init__(self, model: nn.Module, optimizer: torch.optim.Optimizer,
+                 config: Optional[HRMTrainingConfig] = None) -> None:
+        self.model = model
+        self.optimizer = optimizer
+        self.config = config or HRMTrainingConfig()
+
+    # ------------------------------------------------------------------
+    # Curriculum handling
+    # ------------------------------------------------------------------
+    def toggle_curriculum(self) -> None:
+        """Switch between visible and hidden test stages."""
+        if self.config.curriculum_stage == "visible":
+            self.config.curriculum_stage = "hidden"
+        else:
+            self.config.curriculum_stage = "visible"
+
+    # ------------------------------------------------------------------
+    # Supervised fine‑tuning
+    # ------------------------------------------------------------------
+    def sft_step(self, inputs: torch.Tensor, targets: torch.Tensor) -> float:
+        """Perform a single supervised fine‑tuning step.
+
+        ``inputs`` and ``targets`` are expected to be tensor batches compatible
+        with the wrapped model.  The method returns the scalar loss value for
+        logging purposes.
+        """
+        self.model.train()
+        logits, _ = self.model(inputs)
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)),
+                               targets.view(-1),
+                               ignore_index=-100)
+        loss.backward()
+        self.optimizer.step()
+        self.optimizer.zero_grad(set_to_none=True)
+        return float(loss.detach())
+
+    # ------------------------------------------------------------------
+    # Reinforcement learning (REINFORCE with baseline)
+    # ------------------------------------------------------------------
+    def reinforce_step(
+        self,
+        inputs: torch.Tensor,
+        reward_fn: Callable[[torch.Tensor], torch.Tensor],
+    ) -> Dict[str, float]:
+        """Run a REINFORCE update using ``reward_fn``.
+
+        The model is expected to output ``(logits, value)``.  ``reward_fn`` is a
+        callable that receives sampled actions and returns a reward tensor.  A
+        dictionary containing basic metrics is returned to aid debugging.
+        """
+        self.model.train()
+        logits, value = self.model(inputs)
+        log_probs = F.log_softmax(logits, dim=-1)
+        probs = log_probs.exp()
+        actions = torch.multinomial(probs, num_samples=1)
+        selected_logp = log_probs.gather(-1, actions).squeeze(-1)
+        reward = reward_fn(actions.squeeze(-1))
+
+        advantage = reward - value.detach()
+        policy_loss = -(advantage * selected_logp).mean()
+        value_loss = F.mse_loss(value, reward)
+        entropy = -(probs * log_probs).sum(-1).mean()
+
+        total_loss = policy_loss + self.config.baseline_coef * value_loss
+        total_loss -= self.config.entropy_coef * entropy
+        total_loss.backward()
+        self.optimizer.step()
+        self.optimizer.zero_grad(set_to_none=True)
+
+        return {
+            "policy_loss": float(policy_loss.detach()),
+            "value_loss": float(value_loss.detach()),
+            "entropy": float(entropy.detach()),
+            "reward": float(reward.detach().mean()),
+        }
+
+
+__all__ = ["HRMTrainer", "HRMTrainingConfig"]

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -1,0 +1,52 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import torch
+from torch import nn
+
+from hrm.training_loop import HRMTrainer, HRMTrainingConfig
+
+
+class DummyModel(nn.Module):
+    """Tiny model returning logits and a value estimate."""
+
+    def __init__(self, vocab_size: int = 2):
+        super().__init__()
+        self.linear = nn.Linear(vocab_size, vocab_size)
+        self.value = nn.Linear(vocab_size, 1)
+
+    def forward(self, x):
+        logits = self.linear(x)
+        baseline = self.value(x).squeeze(-1)
+        return logits, baseline
+
+
+def test_reinforce_step_updates_model():
+    torch.manual_seed(0)
+    model = DummyModel()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = HRMTrainer(model, opt, HRMTrainingConfig())
+
+    inputs = torch.eye(2)
+
+    def reward_fn(actions: torch.Tensor) -> torch.Tensor:
+        # Reward action 1, penalise action 0
+        return torch.where(actions == 1, torch.tensor(1.0), torch.tensor(0.0))
+
+    before = model.linear.weight.clone()
+    info = trainer.reinforce_step(inputs, reward_fn)
+    after = model.linear.weight
+
+    assert not torch.allclose(before, after)
+    assert "policy_loss" in info and "value_loss" in info
+
+
+def test_curriculum_toggle():
+    model = DummyModel()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = HRMTrainer(model, opt)
+    assert trainer.config.curriculum_stage == "visible"
+    trainer.toggle_curriculum()
+    assert trainer.config.curriculum_stage == "hidden"


### PR DESCRIPTION
## Summary
- add HRMTrainer with SFT and REINFORCE support
- expose trainer utilities in `hrm` package and document Phase 6 progress
- track Phase 6 reinforcement and curriculum tasks in checklist

## Testing
- `pytest tests/test_training_loop.py -q`
- `PYTHONPATH=. pytest -q` *(fails: TypeError in tree_sitter_languages/core.pyx:14 during tests/test_ast_edit.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a03663dd448331ae240d741f4c3781