### PR TITLE
feat: stamp runs with version metadata

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -84,7 +84,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
     [ ] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [ ] Create nightly full evaluation job with retention and tagging
-    [ ] Implement version stamping (git SHA, Docker digest, seeds) in runs
+    [~] Implement version stamping (git SHA, Docker digest, seeds) in runs
     [ ] Configure GitHub Pages publish for latest report artifacts
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -24,15 +24,23 @@ def get_runs(offset: int = 0, limit: int = 10):
 
 
 @app.post("/train", response_model=Run)
-def start_train(config: Dict[str, str] | None = None):
-    run = registry.create_run(config)
+def start_train(
+    config: Dict[str, str] | None = None,
+    seed: Optional[int] = None,
+    docker_digest: Optional[str] = None,
+):
+    run = registry.create_run(config, seed=seed, docker_digest=docker_digest)
     registry.update_status(run.id, "training")
     return run
 
 
 @app.post("/eval", response_model=Run)
-def start_eval(config: Dict[str, str] | None = None):
-    run = registry.create_run(config)
+def start_eval(
+    config: Dict[str, str] | None = None,
+    seed: Optional[int] = None,
+    docker_digest: Optional[str] = None,
+):
+    run = registry.create_run(config, seed=seed, docker_digest=docker_digest)
     registry.update_status(run.id, "evaluating")
     return run
 

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -3,12 +3,30 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 from itertools import count
+import subprocess
+from pathlib import Path
+
+
+def _get_git_sha() -> str:
+    """Return the current git commit SHA or 'unknown' if not available."""
+    try:
+        repo_root = Path(__file__).resolve().parent.parent
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root)
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return "unknown"
 
 
 class Run(BaseModel):
     id: int
     config: Dict[str, str] = Field(default_factory=dict)
     status: str = "pending"
+    git_sha: str = Field(default_factory=_get_git_sha)
+    docker_digest: Optional[str] = None
+    seed: Optional[int] = None
 
 
 class RunRegistry:
@@ -19,9 +37,19 @@ class RunRegistry:
     def __init__(self) -> None:
         self._runs: Dict[int, Run] = {}
 
-    def create_run(self, config: Optional[Dict[str, str]] = None) -> Run:
+    def create_run(
+        self,
+        config: Optional[Dict[str, str]] = None,
+        seed: Optional[int] = None,
+        docker_digest: Optional[str] = None,
+    ) -> Run:
         run_id = next(self._id_counter)
-        run = Run(id=run_id, config=config or {})
+        run = Run(
+            id=run_id,
+            config=config or {},
+            seed=seed,
+            docker_digest=docker_digest,
+        )
         self._runs[run_id] = run
         return run
 

--- a/tests/test_run_registry.py
+++ b/tests/test_run_registry.py
@@ -1,0 +1,11 @@
+import re
+from hrm_coder.run_registry import RunRegistry, _get_git_sha
+
+
+def test_create_run_version_stamp():
+    registry = RunRegistry()
+    run = registry.create_run(seed=123, docker_digest="sha256:deadbeef")
+    assert run.git_sha == _get_git_sha()
+    assert run.seed == 123
+    assert run.docker_digest == "sha256:deadbeef"
+    assert re.fullmatch(r"[0-9a-f]{40}", run.git_sha) or run.git_sha == "unknown"


### PR DESCRIPTION
## Summary
- capture git commit, docker digest, and seed when creating runs
- expose version metadata through the API
- track progress in Phase 8 checklist

## Testing
- `pip install httpx -q`
- `pip install tree-sitter-languages -q`
- `pip install tree_sitter -q`
- `PYTHONPATH=. pytest -q` *(fails: TypeError: __init__() takes exactly 1 argument (2 given))*

------
https://chatgpt.com/codex/tasks/task_e_68a03669dcf08331976af9e2837fb90b