### PR TITLE
feat: add C++ AST editor

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -89,11 +89,11 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)
-    [~] Integrate Tree-sitter C++ grammar and bindings
-    [ ] Implement node type schema and AST embedding encoder for C++
-    [~] Define edit action space for insert, replace, and delete operations
+    [X] Integrate Tree-sitter C++ grammar and bindings
+    [~] Implement node type schema and AST embedding encoder for C++
+    [X] Define edit action space for insert, replace, and delete operations
     [ ] Implement cursor policy module for region selection by HRM high-level
-    [~] Implement decoder constraint checker to avoid invalid AST states
+    [X] Implement decoder constraint checker to avoid invalid AST states
     [ ] Add ablation job configs and comparison report against token baseline
 
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)

--- a/hrm_coder/__init__.py
+++ b/hrm_coder/__init__.py
@@ -1,3 +1,4 @@
 """HRM Coder backend stub for Phase 2."""
 
 from .api import app  # noqa: F401
+from .ast_edit import ASTEditor, Delete, Insert, Replace  # noqa: F401

--- a/hrm_coder/ast_edit.py
+++ b/hrm_coder/ast_edit.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+"""Utilities for editing C++ code via Tree-sitter ASTs.
+
+This module provides a minimal AST representation and an edit action
+space supporting insert, replace, and delete operations. A simple
+constraint checker ensures edits maintain a valid tree structure.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from tree_sitter import Parser
+from tree_sitter_languages import get_language
+
+
+_PARSER: Optional[Parser] = None
+
+
+def _get_parser() -> Parser:
+    """Lazily initialize and return a Tree-sitter parser for C++."""
+    global _PARSER
+    if _PARSER is None:
+        parser = Parser()
+        parser.set_language(get_language("cpp"))
+        _PARSER = parser
+    return _PARSER
+
+
+@dataclass
+class ASTNode:
+    """Simplified AST node used for editing."""
+
+    type: str
+    start_byte: int
+    end_byte: int
+    children: List["ASTNode"]
+
+    @classmethod
+    def from_ts(cls, node) -> "ASTNode":
+        return cls(
+            type=node.type,
+            start_byte=node.start_byte,
+            end_byte=node.end_byte,
+            children=[cls.from_ts(child) for child in node.children],
+        )
+
+
+def parse_cpp(code: str) -> ASTNode:
+    """Parse C++ source code into an ``ASTNode`` tree."""
+    parser = _get_parser()
+    tree = parser.parse(code.encode("utf8"))
+    return ASTNode.from_ts(tree.root_node)
+
+
+def node_embedding(node: ASTNode, depth: int = 0, parent: Optional[str] = None) -> dict:
+    """Return a minimal embedding for ``node`` with type/depth/parent info."""
+    return {"type": node.type, "depth": depth, "parent": parent}
+
+
+# --- Edit action space ----------------------------------------------------
+
+
+@dataclass
+class Insert:
+    parent_path: List[int]
+    index: int
+    code: str
+
+
+@dataclass
+class Replace:
+    target_path: List[int]
+    code: str
+
+
+@dataclass
+class Delete:
+    target_path: List[int]
+
+
+Action = Union[Insert, Replace, Delete]
+
+
+def _get_node(root: ASTNode, path: List[int]) -> ASTNode:
+    node = root
+    for idx in path:
+        if idx < 0 or idx >= len(node.children):
+            raise ValueError(f"invalid path {path}")
+        node = node.children[idx]
+    return node
+
+
+def _parse_snippet(code: str) -> ASTNode:
+    """Parse a C++ snippet and return its first child node."""
+    snippet_root = parse_cpp(code)
+    if not snippet_root.children:
+        raise ValueError("snippet produced empty AST")
+    return snippet_root.children[0]
+
+
+def check_action(root: ASTNode, action: Action) -> None:
+    """Validate that ``action`` is applicable to ``root``."""
+    if isinstance(action, Insert):
+        parent = _get_node(root, action.parent_path)
+        if action.index < 0 or action.index > len(parent.children):
+            raise ValueError("invalid insert position")
+        _parse_snippet(action.code)
+    elif isinstance(action, Replace):
+        _get_node(root, action.target_path)
+        _parse_snippet(action.code)
+    elif isinstance(action, Delete):
+        _get_node(root, action.target_path)
+    else:  # pragma: no cover - defensive
+        raise TypeError("unknown action")
+
+
+class ASTEditor:
+    """In-memory AST editor for C++ source."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        self.root = parse_cpp(code)
+
+    def apply(self, action: Action) -> None:
+        """Apply ``action`` to the parsed AST."""
+        check_action(self.root, action)
+        if isinstance(action, Insert):
+            parent = _get_node(self.root, action.parent_path)
+            node = _parse_snippet(action.code)
+            parent.children.insert(action.index, node)
+        elif isinstance(action, Replace):
+            parent_path = action.target_path[:-1]
+            idx = action.target_path[-1]
+            node = _parse_snippet(action.code)
+            if parent_path:
+                parent = _get_node(self.root, parent_path)
+                parent.children[idx] = node
+            else:
+                self.root = node
+        elif isinstance(action, Delete):
+            parent_path = action.target_path[:-1]
+            idx = action.target_path[-1]
+            parent = _get_node(self.root, parent_path)
+            del parent.children[idx]
+        else:  # pragma: no cover - defensive
+            raise TypeError("unknown action")

--- a/hrm_coder/tests/test_api.py
+++ b/hrm_coder/tests/test_api.py
@@ -1,5 +1,9 @@
+import sys
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 from hrm_coder import app
 
 

--- a/hrm_coder/tests/test_ast_edit_module.py
+++ b/hrm_coder/tests/test_ast_edit_module.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from hrm_coder.ast_edit import ASTEditor, Delete, Insert, node_embedding, parse_cpp
+
+
+def test_parse_and_embedding():
+    root = parse_cpp("int main(){ return 0; }")
+    assert root.type == "translation_unit"
+    emb = node_embedding(root)
+    assert emb["type"] == "translation_unit"
+
+
+def test_insert_and_delete_roundtrip():
+    editor = ASTEditor("int main(){ return 0; }")
+    insert = Insert(parent_path=[0, 2], index=1, code="int x = 0;")
+    editor.apply(insert)
+    body = editor.root.children[0].children[2]
+    assert body.children[1].type == "declaration"
+
+    delete = Delete(target_path=[0, 2, 1])
+    editor.apply(delete)
+    body = editor.root.children[0].children[2]
+    assert len(body.children) == 3
+
+
+def test_invalid_delete_path():
+    editor = ASTEditor("int main(){ return 0; }")
+    with pytest.raises(ValueError):
+        editor.apply(Delete(target_path=[1]))


### PR DESCRIPTION
## Summary
- introduce Tree-sitter powered C++ AST editor with insert/replace/delete actions and validation
- expand project checklist for AST-edit phase
- add tests covering AST parsing and edit round-trips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0366d44cc8331a718940189f3b3a9