### PR TITLE
Add multi-file C++ compilation helper

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -8,15 +8,101 @@ against multiple input/output pairs with basic resource limits.
 """
 from __future__ import annotations
 
+import resource
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
-import resource
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 
 DEFAULT_FLAGS: List[str] = ["-std=c++17", "-O2", "-pipe"]
 SANITIZER_FLAGS: List[str] = ["-fsanitize=address,undefined", "-fno-omit-frame-pointer"]
+
+
+def compile_cpp_sources(
+    sources: Sequence[Path],
+    output: Optional[Path] = None,
+    *,
+    compiler: str = "g++",
+    flags: Optional[Iterable[str]] = None,
+    sanitize: bool = True,
+    static: bool = False,
+    library_dirs: Optional[Iterable[Path]] = None,
+    libraries: Optional[Iterable[str]] = None,
+    rpath: Optional[Iterable[Path]] = None,
+    use_ccache: bool = False,
+) -> Tuple[bool, str, str, Optional[Path]]:
+    """Compile one or more C++ ``sources`` into a single binary.
+
+    This helper expands the simple single-file ``compile_cpp`` function to
+    support the Phase 10 roadmap goals of linking multi-file projects and
+    honoring optional dynamic linking settings.  A subset of features such as
+    rpath handling and optional static builds are exposed for experimentation
+    with more complex judges.
+
+    Parameters
+    ----------
+    sources:
+        Iterable of paths to C++ source files to be compiled and linked
+        together.
+    output:
+        Optional path to the produced binary.  A temporary file is created
+        when omitted.
+    compiler:
+        Which compiler to invoke, e.g. ``g++`` or ``clang++``.
+    flags:
+        Additional compiler flags.
+    sanitize:
+        Whether to include address and undefined behaviour sanitizers.
+    static:
+        Request a static build by passing ``-static`` when True.
+    library_dirs:
+        Extra directories to search for libraries during linking (``-L``).
+    libraries:
+        Additional libraries to link against (``-l``).
+    rpath:
+        Runtime search paths to embed into the binary via ``-Wl,-rpath``.
+    use_ccache:
+        Prepend ``ccache`` to the compile command when available to speed up
+        iterative builds.
+    """
+
+    if flags is None:
+        flags = list(DEFAULT_FLAGS)
+    else:
+        flags = list(flags)
+    if sanitize:
+        flags = list(flags) + SANITIZER_FLAGS
+    if static:
+        flags.append("-static")
+
+    if output is None:
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        output_path = Path(tmp.name)
+        tmp.close()
+    else:
+        output_path = Path(output)
+
+    cmd: List[str] = [compiler]
+    if use_ccache and shutil.which("ccache") is not None:
+        cmd = ["ccache", compiler]
+
+    cmd += [str(s) for s in sources] + ["-o", str(output_path)] + list(flags)
+
+    if library_dirs is not None:
+        for d in library_dirs:
+            cmd.extend(["-L", str(d)])
+    if libraries is not None:
+        for lib in libraries:
+            cmd.extend(["-l", lib])
+    if rpath is not None:
+        for p in rpath:
+            cmd.append(f"-Wl,-rpath,{p}")
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    success = proc.returncode == 0
+    return success, proc.stdout, proc.stderr, output_path if success else None
 
 
 def compile_cpp(
@@ -27,46 +113,20 @@ def compile_cpp(
     flags: Optional[Iterable[str]] = None,
     sanitize: bool = True,
 ) -> Tuple[bool, str, str, Optional[Path]]:
-    """Compile a C++ source file.
+    """Compile a single C++ ``source`` file.
 
-    Parameters
-    ----------
-    source:
-        Path to the C++ source file.
-    output:
-        Optional path to the output binary.  If omitted, a temporary file is
-        created.
-    compiler:
-        Which compiler binary to invoke (``g++`` or ``clang++``).
-    flags:
-        Additional compiler flags.
-    sanitize:
-        Whether to enable address and undefined behaviour sanitizers.
-
-    Returns
-    -------
-    success, stdout, stderr, binary_path
-        Tuple indicating compile success, compiler stdout/stderr, and the path
-        to the produced binary if compilation succeeded.
+    This is a thin wrapper around :func:`compile_cpp_sources` for backwards
+    compatibility.  The implementation simply delegates to the more general
+    multi-file helper with a one-element source list.
     """
-    if flags is None:
-        flags = DEFAULT_FLAGS
-    else:
-        flags = list(flags)
-    if sanitize:
-        flags = list(flags) + SANITIZER_FLAGS
 
-    if output is None:
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        output_path = Path(tmp.name)
-        tmp.close()
-    else:
-        output_path = Path(output)
-
-    cmd = [compiler, str(source), "-o", str(output_path)] + list(flags)
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    success = proc.returncode == 0
-    return success, proc.stdout, proc.stderr, output_path if success else None
+    return compile_cpp_sources(
+        [source],
+        output,
+        compiler=compiler,
+        flags=flags,
+        sanitize=sanitize,
+    )
 
 
 def _set_limits(memory_limit: Optional[int]) -> None:

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from runners.cpp_runner import compile_cpp_sources, run_binary
+
+
+def test_compile_multi_file(tmp_path: Path) -> None:
+    """Compile and run a simple two-file C++ project."""
+    main = tmp_path / "main.cpp"
+    helper = tmp_path / "helper.cpp"
+
+    main.write_text(
+        """
+#include <iostream>
+extern int add(int a, int b);
+int main() { std::cout << add(1, 2); }
+"""
+    )
+    helper.write_text("int add(int a, int b) { return a + b; }\n")
+
+    success, out, err, binary = compile_cpp_sources([main, helper])
+    assert success, f"compile failed: {out}\n{err}"
+    assert binary is not None
+
+    code, stdout, stderr = run_binary(binary)
+    assert code == 0
+    assert stdout.strip() == "3"


### PR DESCRIPTION
## Summary
- extend `cpp_runner` with `compile_cpp_sources` supporting multi-file builds, optional static linking, rpath, and ccache
- cover new helper with a test that compiles a two-file C++ project

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a03670b9e883319b817aa9598f336d