### PR TITLE
Add dataset catalog scaffold for Phase 0

### DIFF
--- a/docs/dataset_catalog.json
+++ b/docs/dataset_catalog.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Codeforces-Intro",
+    "license": "TBD",
+    "path": "dataset/raw-data/codeforces_intro",
+    "sha256": "TBD"
+  },
+  {
+    "name": "AtCoder-ABC",
+    "license": "TBD",
+    "path": "dataset/raw-data/atcoder_abc",
+    "sha256": "TBD"
+  },
+  {
+    "name": "Kattis-micro",
+    "license": "TBD",
+    "path": "dataset/raw-data/kattis_micro",
+    "sha256": "TBD"
+  },
+  {
+    "name": "HumanEval-CPP",
+    "license": "MIT",
+    "path": "dataset/raw-data/humaneval_cpp.jsonl",
+    "sha256": "TBD"
+  }
+]

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -15,7 +15,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Inventory HRM repo APIs and identify injection points for C++ token/AST decoders
     [ ] Setup project operation within isolate/gVisor runner images
     [ ] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
-    [ ] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes
+    [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
     [ ] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
     [ ] Draft sandbox Threat Model and initial security requirements for native binaries
     [ ] Write ADRs for sandbox choice, experiment tracker, and GUI stack

--- a/scripts/dataset_catalog.py
+++ b/scripts/dataset_catalog.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate dataset catalog with license and SHA256 hashes.
+
+This script enumerates key datasets and records their licensing
+information and content hashes when available. The resulting catalog is
+written to ``docs/dataset_catalog.json`` to support Phase 0 tracking.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+DATASETS = [
+    {"name": "Codeforces-Intro", "path": Path("dataset/raw-data/codeforces_intro"), "license": "TBD"},
+    {"name": "AtCoder-ABC", "path": Path("dataset/raw-data/atcoder_abc"), "license": "TBD"},
+    {"name": "Kattis-micro", "path": Path("dataset/raw-data/kattis_micro"), "license": "TBD"},
+    {"name": "HumanEval-CPP", "path": Path("dataset/raw-data/humaneval_cpp.jsonl"), "license": "MIT"},
+]
+
+
+def sha256_of_path(path: Path) -> str | None:
+    """Return the SHA256 hash of ``path`` or ``None`` if it does not exist."""
+    if not path.exists():
+        return None
+    hash_obj = hashlib.sha256()
+    if path.is_file():
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(8192), b""):
+                hash_obj.update(chunk)
+    else:
+        for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+            hash_obj.update(file_path.relative_to(path).as_posix().encode())
+            with file_path.open("rb") as fh:
+                for chunk in iter(lambda: fh.read(8192), b""):
+                    hash_obj.update(chunk)
+    return hash_obj.hexdigest()
+
+
+def build_catalog() -> List[Dict[str, Any]]:
+    catalog: List[Dict[str, Any]] = []
+    for ds in DATASETS:
+        path = ds["path"]
+        digest = sha256_of_path(path)
+        catalog.append(
+            {
+                "name": ds["name"],
+                "license": ds["license"],
+                "path": str(path),
+                "sha256": digest or "TBD",
+            }
+        )
+    return catalog
+
+
+def main() -> None:
+    catalog = build_catalog()
+    out_path = Path("docs/dataset_catalog.json")
+    out_path.write_text(json.dumps(catalog, indent=2) + "\n")
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- script to generate dataset catalog with dataset names, licenses, and hashes
- placeholder dataset_catalog.json for Phase 0 tracking
- mark dataset catalog task in checklist as in progress

## Testing
- `pre-commit run --files scripts/dataset_catalog.py docs/hrmCoder_checklist.md docs/dataset_catalog.json`


------
https://chatgpt.com/codex/tasks/task_e_68a03d5a051883319c26753b8696910f