### PR TITLE
Add Hydra config scaffold and expand pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,12 @@ repos:
     hooks:
       - id: cpplint
         files: \.(cpp|hpp|cc|cxx|c|h)$
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: 336fdd7c3cab698ead0b1c95157b9e74d3906b62
+    hooks:
+      - id: clang-tidy
+        files: \.(cpp|hpp|cc|cxx|c|h)$
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -26,8 +26,8 @@ Save new code files in: C:\repos\hrm-coder
     [~] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
     [~] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
     [~] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
-    [ ] Define Hydra config schema and default configs under conf/
-    [~] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
+    [~] Define Hydra config schema and default configs under conf/
+    [?] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [X] Implement environment pinning and seed/tz/locale normalization module
 
 ** [~] Phase 2: GUI Stub and Backend Skeleton

--- a/hrm_coder/conf/config.yaml
+++ b/hrm_coder/conf/config.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - dataset: humaneval_cpp
+  - model: small
+  - _self_

--- a/hrm_coder/conf/dataset/humaneval_cpp.yaml
+++ b/hrm_coder/conf/dataset/humaneval_cpp.yaml
@@ -1,0 +1,1 @@
+name: humaneval-cpp

--- a/hrm_coder/conf/model/small.yaml
+++ b/hrm_coder/conf/model/small.yaml
@@ -1,0 +1,2 @@
+name: small
+learning_rate: 0.001

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -1,0 +1,53 @@
+"""Hydra configuration loader for HRM Coder."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for the model/training setup."""
+    name: str = "small"
+    learning_rate: float = 1e-3
+
+
+@dataclass
+class DatasetConfig:
+    """Configuration for dataset selection."""
+    name: str = "humaneval-cpp"
+
+
+@dataclass
+class AppConfig:
+    """Top-level application configuration."""
+    model: ModelConfig = field(default_factory=ModelConfig)
+    dataset: DatasetConfig = field(default_factory=DatasetConfig)
+
+
+def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
+    """Load the Hydra configuration from the ``conf`` directory.
+
+    Parameters
+    ----------
+    overrides:
+        Optional sequence of Hydra override strings.
+    """
+    config_dir = Path(__file__).parent / "conf"
+    with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
+        cfg = compose(
+            config_name="config",
+            overrides=list(overrides) if overrides else [],
+        )
+    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+    return AppConfig(
+        model=ModelConfig(**cfg_dict["model"]),
+        dataset=DatasetConfig(**cfg_dict["dataset"]),
+    )
+
+
+__all__ = ["AppConfig", "DatasetConfig", "ModelConfig", "load_config"]

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -1,0 +1,12 @@
+from hrm_coder.config import load_config
+
+
+def test_load_config_defaults():
+    cfg = load_config()
+    assert cfg.model.name == "small"
+    assert cfg.dataset.name == "humaneval-cpp"
+
+
+def test_load_config_override():
+    cfg = load_config(["model.learning_rate=0.01"])
+    assert cfg.model.learning_rate == 0.01


### PR DESCRIPTION
## Summary
- add Hydra-based configuration schema with defaults and loader
- test configuration overrides
- include clang-tidy and flake8 in pre-commit hooks and update checklist

## Testing
- `pre-commit run --files .pre-commit-config.yaml hrm_coder/config.py hrm_coder/conf/config.yaml hrm_coder/conf/dataset/humaneval_cpp.yaml hrm_coder/conf/model/small.yaml hrm_coder/tests/test_config.py docs/hrmCoder_checklist.md`
- `pytest hrm_coder/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a03d5dbfc48331ad37efdd0a502594