### PR TITLE
Add run detail view with log streaming

### DIFF
--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 from pathlib import Path
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
@@ -28,6 +28,14 @@ app.mount("/artifacts", StaticFiles(directory=ARTIFACT_DIR), name="artifacts")
 @app.get("/runs", response_model=list[Run])
 def get_runs(offset: int = 0, limit: int = 10):
     return registry.list_runs(offset, limit)
+
+
+@app.get("/runs/{run_id}", response_model=Run)
+def get_run(run_id: int):
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return run
 
 
 @app.post("/train", response_model=Run)

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -34,6 +34,10 @@ class RunRegistry:
         runs = list(self._runs.values())
         return runs[offset : offset + limit]
 
+    def get_run(self, run_id: int) -> Optional[Run]:
+        """Return run by id if it exists."""
+        return self._runs.get(run_id)
+
     def update_status(self, run_id: int, status: str) -> None:
         if run_id in self._runs:
             self._runs[run_id].status = status

--- a/hrm_coder/static/jobs.html
+++ b/hrm_coder/static/jobs.html
@@ -24,7 +24,7 @@
       tbody.innerHTML = '';
       for (const r of runs) {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${r.id}</td><td>${r.status}</td><td>${r.artifact ? `<a href="${r.artifact}">link</a>` : ''}</td>`;
+        tr.innerHTML = `<td><a href="run.html?id=${r.id}">${r.id}</a></td><td>${r.status}</td><td>${r.artifact ? `<a href="${r.artifact}">link</a>` : ''}</td>`;
         tbody.appendChild(tr);
       }
     }

--- a/hrm_coder/static/run.html
+++ b/hrm_coder/static/run.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Run Detail</title>
+</head>
+<body>
+  <h1>Run <span id="run_id"></span></h1>
+  <div>Status: <span id="status"></span></div>
+  <div>Artifact: <span id="artifact"></span></div>
+  <pre id="logs"></pre>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const runId = params.get('id');
+    document.getElementById('run_id').textContent = runId;
+
+    async function loadRun() {
+      const resp = await fetch(`/runs/${runId}`);
+      if (!resp.ok) return;
+      const run = await resp.json();
+      document.getElementById('status').textContent = run.status;
+      if (run.artifact) {
+        const a = document.createElement('a');
+        a.href = run.artifact;
+        a.textContent = 'link';
+        document.getElementById('artifact').appendChild(a);
+      }
+    }
+    loadRun();
+
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${proto}//${location.host}/logs/ws/${runId}`);
+    ws.onmessage = (ev) => {
+      const pre = document.getElementById('logs');
+      pre.textContent += ev.data + '\n';
+    };
+  </script>
+</body>
+</html>

--- a/hrm_coder/tests/test_api.py
+++ b/hrm_coder/tests/test_api.py
@@ -29,3 +29,7 @@ def test_run_lifecycle():
     assert len(runs) == 1
     assert runs[0]["id"] == run["id"]
 
+    # Fetch single run
+    fetched = client.get(f"/runs/{run['id']}").json()
+    assert fetched["id"] == run["id"]
+


### PR DESCRIPTION
## Summary
- Expose a new `/runs/{run_id}` API endpoint and registry helper to fetch individual run metadata
- Link job listings to a new run detail page that streams logs in real-time
- Test the run endpoint in the run lifecycle test

## Testing
- `pytest hrm_coder/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a03d5ff4a48331897668e5be345b4a