### PR TITLE
feat: extend isolate runner with filesystem controls

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -51,7 +51,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [ ] Phase 4: Sandbox Executor
     [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
-    [ ] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
+    [~] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
     [ ] Implement caching layer keyed by prompt+code+tests+limits hash
     [ ] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
     [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)

--- a/runners/isolate.py
+++ b/runners/isolate.py
@@ -1,6 +1,10 @@
+"""Lightweight wrapper for the ``isolate`` sandbox tool."""
+
+from __future__ import annotations
+
 import shutil
 import subprocess
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 
 class SandboxError(RuntimeError):
@@ -10,14 +14,19 @@ class SandboxError(RuntimeError):
 class IsolateRunner:
     """Adapter for the ``isolate`` sandbox tool.
 
-    This minimal wrapper constructs and runs ``isolate`` commands with
-    resource limits. It does not depend on the actual presence of the
-    ``isolate`` binary until :meth:`run` is invoked, enabling unit tests
-    to validate command construction without the binary installed.
+    The runner exposes a small subset of the ``isolate`` command line in a
+    Pythonic interface.  It performs the standard ``--init`` → ``--run`` →
+    ``--cleanup`` sequence for each invocation and allows callers to mount
+    additional read-only directories or specify an explicit working
+    directory inside the sandbox.  The implementation intentionally
+    constructs command lines without executing them, permitting unit tests
+    to exercise the wrapper even when the ``isolate`` binary is not
+    installed.
     """
 
-    def __init__(self, isolate_path: str = "isolate") -> None:
+    def __init__(self, isolate_path: str = "isolate", box_id: int = 0) -> None:
         self.isolate_path = isolate_path
+        self.box_id = box_id
 
     def build_command(
         self,
@@ -28,8 +37,12 @@ class IsolateRunner:
         memory: int = 256 * 1024,
         processes: int = 1,
         network: bool = False,
+        workdir: Optional[str] = None,
+        readonly_dirs: Optional[Iterable[str]] = None,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
     ) -> List[str]:
-        """Build an ``isolate`` invocation.
+        """Build an ``isolate --run`` invocation.
 
         Parameters
         ----------
@@ -45,10 +58,20 @@ class IsolateRunner:
             Maximum number of allowed processes.
         network:
             Allow network access if ``True``.
+        workdir:
+            Path inside the sandbox to use as the working directory.  When
+            provided the same path on the host is mounted read-write.
+        readonly_dirs:
+            Optional collection of host directories to bind read-only
+            inside the sandbox at the same absolute paths.
+        stdout, stderr:
+            Optional filenames (inside the sandbox) to capture the
+            respective streams.
         """
         isolate_cmd = [
             self.isolate_path,
             "--cg",
+            f"--box-id={self.box_id}",
             f"--time={time_limit}",
             f"--wall={wall_time}",
             f"--mem={memory}",
@@ -56,7 +79,17 @@ class IsolateRunner:
         ]
         if not network:
             isolate_cmd.append("--net=none")
-        isolate_cmd.append("--")
+        if workdir is not None:
+            isolate_cmd.append(f"--dir={workdir}=rw")
+            isolate_cmd.append(f"--chdir={workdir}")
+        if readonly_dirs is not None:
+            for path in readonly_dirs:
+                isolate_cmd.append(f"--dir={path}=ro")
+        if stdout is not None:
+            isolate_cmd.append(f"--stdout={stdout}")
+        if stderr is not None:
+            isolate_cmd.append(f"--stderr={stderr}")
+        isolate_cmd.extend(["--run", "--"])
         isolate_cmd.extend(command)
         return isolate_cmd
 
@@ -69,29 +102,62 @@ class IsolateRunner:
         memory: int = 256 * 1024,
         processes: int = 1,
         network: bool = False,
+        workdir: Optional[str] = None,
+        readonly_dirs: Optional[Iterable[str]] = None,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
         stdin: Optional[bytes] = None,
     ) -> subprocess.CompletedProcess:
-        """Execute a command within ``isolate``.
+        """Execute ``command`` within ``isolate``.
 
-        Returns the :class:`subprocess.CompletedProcess` object produced
-        by :func:`subprocess.run`.
+        The method performs the standard ``init`` → ``run`` → ``cleanup``
+        lifecycle for a single command invocation.  In case initialization
+        fails a :class:`SandboxError` is raised.  Execution errors of the
+        sandboxed command itself are reflected in the returned
+        :class:`subprocess.CompletedProcess` object and are not raised as
+        exceptions.
         """
         if shutil.which(self.isolate_path) is None:
             raise SandboxError(
                 f"isolate executable not found: {self.isolate_path}"
             )
-        cmd = self.build_command(
-            command,
-            time_limit=time_limit,
-            wall_time=wall_time,
-            memory=memory,
-            processes=processes,
-            network=network,
-        )
-        return subprocess.run(
-            cmd,
-            input=stdin,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+
+        init_cmd = [
+            self.isolate_path,
+            f"--box-id={self.box_id}",
+            "--init",
+        ]
+        init_proc = subprocess.run(init_cmd, capture_output=True, text=True)
+        if init_proc.returncode != 0:
+            raise SandboxError("isolate initialization failed")
+        try:
+            cmd = self.build_command(
+                command,
+                time_limit=time_limit,
+                wall_time=wall_time,
+                memory=memory,
+                processes=processes,
+                network=network,
+                workdir=workdir,
+                readonly_dirs=readonly_dirs,
+                stdout=stdout,
+                stderr=stderr,
+            )
+            proc = subprocess.run(
+                cmd,
+                input=stdin,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            subprocess.run(
+                [
+                    self.isolate_path,
+                    f"--box-id={self.box_id}",
+                    "--cleanup",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        return proc

--- a/tests/test_isolate.py
+++ b/tests/test_isolate.py
@@ -7,7 +7,7 @@ from runners.isolate import IsolateRunner
 
 
 def test_build_command_has_no_network_by_default():
-    runner = IsolateRunner(isolate_path="isolate")
+    runner = IsolateRunner(isolate_path="isolate", box_id=0)
     cmd = runner.build_command(
         ["/bin/echo", "hello"],
         time_limit=1,
@@ -16,7 +16,26 @@ def test_build_command_has_no_network_by_default():
         processes=1,
     )
     assert cmd[0] == "isolate"
+    assert f"--box-id={runner.box_id}" in cmd
     assert "--net=none" in cmd
-    assert "--" in cmd
+    assert "--run" in cmd
+    run_idx = cmd.index("--run")
+    assert cmd[run_idx + 1] == "--"
     assert cmd[-2:] == ["/bin/echo", "hello"]
+
+
+def test_build_command_with_filesystem_options():
+    runner = IsolateRunner(isolate_path="isolate", box_id=1)
+    cmd = runner.build_command(
+        ["/bin/true"],
+        workdir="/tmp/work",
+        readonly_dirs=["/data"],
+        stdout="out.txt",
+        stderr="err.txt",
+    )
+    assert "--dir=/tmp/work=rw" in cmd
+    assert "--chdir=/tmp/work" in cmd
+    assert "--dir=/data=ro" in cmd
+    assert "--stdout=out.txt" in cmd
+    assert "--stderr=err.txt" in cmd
 


### PR DESCRIPTION
## Summary
- expand IsolateRunner to perform init-run-cleanup lifecycle and support working directories, read-only mounts, and custom stdio files
- mark filesystem policy work as in progress in the Phase 4 checklist
- cover new options with tests

## Testing
- `apt-get install -y libgtest-dev`
- `pytest tests/test_isolate.py tests/test_gtest_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a03d6593bc8331b088497f2e230d52