### PR TITLE
feat: parse diagnostics for rewards

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -58,9 +58,9 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 5: Reward Shaping and Safety Gates
     [X] Implement reward aggregator with weighted compile/link status, tests, and coverage signals
-    [~] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
-    [~] Integrate static analysis (cppcheck) scoring and normalization
-    [~] Implement coverage delta computation using gcov/lcov or llvm-cov
+    [X] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
+    [X] Integrate static analysis (cppcheck) scoring and normalization
+    [X] Implement coverage delta computation using gcov/lcov or llvm-cov
     [X] Implement edit-cost, time, and memory penalty functions with clamps
     [X] Add reward histogram logging to tracker with sanity checks
 

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from utils.reward import RewardAggregator
+from utils.diagnostics import clang_tidy_score, cppcheck_score
 
 
 def test_reward_aggregator_basic():
@@ -73,3 +74,50 @@ def test_reward_with_lint_static_and_coverage_delta():
     )
 
     assert abs(r - 0.615) < 1e-6
+
+
+def test_compute_from_outputs_matches_manual_scores():
+    agg = RewardAggregator(
+        weights={
+            'compile': 0.1,
+            'tests': 0.3,
+            'coverage': 0.2,
+            'coverage_delta': 0.2,
+            'lint': 0.1,
+            'static': 0.1,
+        },
+        max_edit_penalty=0.0,
+        max_time_penalty=0.0,
+        max_memory_penalty=0.0,
+    )
+
+    clang_output = "foo.cpp:1:1: warning: thing [misc]"
+    cppcheck_output = "[warning] variable unused"
+
+    r1 = agg.compute_from_outputs(
+        compile_success=True,
+        tests_passed=2,
+        tests_total=4,
+        coverage=0.5,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        clang_output=clang_output,
+        cppcheck_output=cppcheck_output,
+        prev_coverage=0.3,
+    )
+
+    r2 = agg.compute(
+        compile_success=True,
+        tests_passed=2,
+        tests_total=4,
+        coverage=0.5,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        lint_score=clang_tidy_score(clang_output),
+        static_score=cppcheck_score(cppcheck_output),
+        prev_coverage=0.3,
+    )
+
+    assert abs(r1 - r2) < 1e-6

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from typing import Dict, List
 import logging
 
+from .diagnostics import clang_tidy_score, cppcheck_score, coverage_delta
+
 
 @dataclass
 class RewardAggregator:
@@ -61,13 +63,17 @@ class RewardAggregator:
         compile_score = 1.0 if compile_success else 0.0
         test_score = tests_passed / tests_total if tests_total else 0.0
         coverage_score = max(0.0, min(coverage, 1.0))
-        prev_cov = max(0.0, min(prev_coverage, 1.0)) if prev_coverage is not None else None
-        coverage_delta = max(0.0, coverage_score - prev_cov) if prev_cov is not None else 0.0
+        prev_cov = (
+            max(0.0, min(prev_coverage, 1.0))
+            if prev_coverage is not None
+            else None
+        )
+        cov_delta = coverage_delta(prev_cov, coverage_score) if prev_cov is not None else 0.0
 
         reward += self.weights.get("compile", 0.0) * compile_score
         reward += self.weights.get("tests", 0.0) * test_score
         reward += self.weights.get("coverage", 0.0) * coverage_score
-        reward += self.weights.get("coverage_delta", 0.0) * coverage_delta
+        reward += self.weights.get("coverage_delta", 0.0) * cov_delta
         reward += self.weights.get("lint", 0.0) * max(0.0, min(lint_score, 1.0))
         reward += self.weights.get("static", 0.0) * max(0.0, min(static_score, 1.0))
 
@@ -85,6 +91,44 @@ class RewardAggregator:
         # Record history for histogram logging
         self.history.append(reward)
         return reward
+
+    def compute_from_outputs(
+        self,
+        compile_success: bool,
+        tests_passed: int,
+        tests_total: int,
+        coverage: float,
+        edit_cost: float,
+        time_used: float,
+        memory_used: float,
+        clang_output: str = "",
+        cppcheck_output: str = "",
+        prev_coverage: float | None = None,
+        time_limit: float | None = None,
+        memory_limit: float | None = None,
+    ) -> float:
+        """Compute reward using raw diagnostics output strings.
+
+        Convenience wrapper that parses ``clang_output`` and ``cppcheck_output``
+        into normalized scores before delegating to :meth:`compute`.
+        """
+
+        lint = clang_tidy_score(clang_output)
+        static = cppcheck_score(cppcheck_output)
+        return self.compute(
+            compile_success=compile_success,
+            tests_passed=tests_passed,
+            tests_total=tests_total,
+            coverage=coverage,
+            edit_cost=edit_cost,
+            time_used=time_used,
+            memory_used=memory_used,
+            lint_score=lint,
+            static_score=static,
+            prev_coverage=prev_coverage,
+            time_limit=time_limit,
+            memory_limit=memory_limit,
+        )
 
     def histogram(self, bins: int = 10) -> List[int]:
         """Return a simple histogram of historical rewards."""
@@ -109,4 +153,3 @@ class RewardAggregator:
         if any(r < -1.0 or r > 1.0 for r in self.history):
             logger.warning("reward out of expected [-1,1] range")
         logger.debug("reward histogram: %s", hist)
-        


### PR DESCRIPTION
## Summary
- add helper to compute rewards directly from clang-tidy and cppcheck outputs
- reuse shared coverage delta utility in RewardAggregator
- document Phase 5 checklist completion

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md tests/test_reward.py utils/reward.py`
- `pytest` *(fails: TypeError: __init__() takes exactly 1 argument (2 given))*
- `pytest tests/test_reward.py tests/test_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03d674ab48331bff2ec00595333bf