### PR TITLE
Add AST encoder interface and tokenizer tests

### DIFF
--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -10,6 +10,13 @@ on code tasks.
 
 from .code_tokenizer import CppTokenizer
 from .code_encoder import CodeEncoder
+from .ast_encoder import ASTEncoder
 from .training_loop import HRMTrainer, HRMTrainingConfig
 
-__all__ = ["CppTokenizer", "CodeEncoder", "HRMTrainer", "HRMTrainingConfig"]
+__all__ = [
+    "CppTokenizer",
+    "CodeEncoder",
+    "ASTEncoder",
+    "HRMTrainer",
+    "HRMTrainingConfig",
+]

--- a/hrm/ast_encoder.py
+++ b/hrm/ast_encoder.py
@@ -1,0 +1,27 @@
+"""Draft interface for an AST-based code encoder."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Protocol
+
+
+class ASTEncoder(Protocol):
+    """Protocol describing an AST-based encoder interface.
+
+    The concrete implementation will convert source code into an abstract
+    syntax tree (AST) representation and provide utilities to encode the
+    tree into model-ready tensors.  Only the method signatures are defined
+    here to unblock Phase 6 development while a full implementation is
+    designed.
+    """
+
+    def encode(self, code: str) -> List[int]:  # pragma: no cover - interface
+        """Encode *code* into a sequence of token ids."""
+        raise NotImplementedError
+
+    def decode(self, ids: Iterable[int]) -> str:  # pragma: no cover - interface
+        """Reconstruct code from *ids* representing an AST traversal."""
+        raise NotImplementedError
+
+
+__all__ = ["ASTEncoder"]

--- a/tests/test_code_tokenizer.py
+++ b/tests/test_code_tokenizer.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from hrm import CppTokenizer, CodeEncoder
+
+
+def test_tokenizer_removes_comments_and_splits_tokens():
+    code = """
+    // comment line
+    int main() {
+        /* block comment */
+        std::string s = "hi";
+        return 0; // trailing
+    }
+    """
+    toks = CppTokenizer().tokenize(code)
+    assert "comment" not in toks
+    assert toks == [
+        "int",
+        "main",
+        "(",
+        ")",
+        "{",
+        "std",
+        ":",
+        ":",
+        "string",
+        "s",
+        "=",
+        '"hi"',
+        ";",
+        "return",
+        "0",
+        ";",
+        "}",
+    ]
+
+
+def test_code_encoder_round_trip():
+    samples = ["int x = 1;", "int y = x + 2;"]
+    encoder = CodeEncoder()
+    encoder.build_vocab(samples)
+    ids = encoder.encode("int y = x + 2;")
+    decoded = encoder.decode(ids)
+    assert decoded.split() == CppTokenizer().tokenize("int y = x + 2;")


### PR DESCRIPTION
## Summary
- add initial `ASTEncoder` protocol to outline AST-based encoding
- export `ASTEncoder` from `hrm` package
- test `CppTokenizer` and `CodeEncoder` round trip behaviour

## Testing
- `pre-commit run --files tests/test_code_tokenizer.py hrm/ast_encoder.py hrm/__init__.py`
- `pytest tests/test_code_tokenizer.py tests/test_training_loop.py`

------
https://chatgpt.com/codex/tasks/task_e_68a03d6986b08331bc0c2924b93e6d53