### PR TITLE
Add evaluation baseline comparison and artifact upload helpers

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -77,8 +77,8 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement determinism checker to re-run top-k with shuffled ordering
     [X] Implement flaky-test detector and flagging in results
     [X] Build HTML and Markdown report generator with tables and plots
-    [ ] Implement baseline comparator against recorded C++ code-LM prompts
-    [~] Implement artifact bundler and uploader for reports and raw JSON
+    [~] Implement baseline comparator against recorded C++ code-LM prompts
+    [X] Implement artifact bundler and uploader for reports and raw JSON
 
 ** [ ] Phase 8: CI/CD and Automation
     [~] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,38 @@
+import json
+import pathlib
+import sys
+import zipfile
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.eval_harness import compare_to_baseline, bundle_and_upload
+
+
+def test_compare_to_baseline(tmp_path):
+    baseline_metrics = {"pass@1": 0.5, "pass@10": 0.8}
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(baseline_metrics))
+
+    current_metrics = {"pass@1": 0.6, "pass@10": 0.7}
+    comparison = compare_to_baseline(current_metrics, str(baseline_file))
+
+    assert comparison["pass@1"]["baseline"] == pytest.approx(0.5)
+    assert comparison["pass@1"]["delta"] == pytest.approx(0.1)
+    assert comparison["pass@10"]["delta"] == pytest.approx(-0.1)
+
+
+def test_bundle_and_upload(tmp_path):
+    file_a = tmp_path / "a.txt"
+    file_b = tmp_path / "b.txt"
+    file_a.write_text("hello")
+    file_b.write_text("world")
+
+    bundle_path = tmp_path / "bundle.zip"
+    dest_dir = tmp_path / "upload"
+    uploaded_path = bundle_and_upload([str(file_a), str(file_b)], str(bundle_path), str(dest_dir))
+
+    assert zipfile.is_zipfile(uploaded_path)
+    with zipfile.ZipFile(uploaded_path) as zf:
+        assert sorted(zf.namelist()) == ["a.txt", "b.txt"]

--- a/utils/eval_harness.py
+++ b/utils/eval_harness.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 import math
+import shutil
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List
 import zipfile
@@ -120,3 +121,44 @@ def bundle_artifacts(paths: Iterable[str], bundle_path: str) -> None:
             p = Path(p)
             if p.exists():
                 zf.write(p, p.name)
+
+
+def upload_bundle(bundle_path: str, dest_dir: str) -> str:
+    """Upload a bundle to ``dest_dir`` by copying it.
+
+    This simple uploader is intended for local file systems and is sufficient
+    for tests and CI environments. Returns the destination path of the copied
+    bundle.
+    """
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    target = dest / Path(bundle_path).name
+    shutil.copy2(bundle_path, target)
+    return str(target)
+
+
+def bundle_and_upload(paths: Iterable[str], bundle_path: str, dest_dir: str) -> str:
+    """Bundle ``paths`` into ``bundle_path`` and upload to ``dest_dir``.
+
+    Returns the path to the uploaded bundle.
+    """
+    bundle_artifacts(paths, bundle_path)
+    return upload_bundle(bundle_path, dest_dir)
+
+
+def compare_to_baseline(current: Dict[str, float], baseline_path: str) -> Dict[str, Dict[str, float]]:
+    """Compare ``current`` metrics to a JSON baseline.
+
+    The ``baseline_path`` should point to a JSON file containing a mapping of
+    metric names to numeric values. The returned dictionary maps metric names to
+    dictionaries with ``baseline``, ``current`` and ``delta`` fields. Missing
+    baseline values yield ``None`` deltas.
+    """
+    p = Path(baseline_path)
+    baseline = json.loads(p.read_text()) if p.exists() else {}
+    comparison: Dict[str, Dict[str, float]] = {}
+    for key, cur_val in current.items():
+        base_val = baseline.get(key)
+        delta = cur_val - base_val if base_val is not None else None
+        comparison[key] = {"baseline": base_val, "current": cur_val, "delta": delta}
+    return comparison


### PR DESCRIPTION
## Summary
- add helper functions to bundle and upload evaluation artifacts and compare metrics to a JSON baseline
- update Phase 7 checklist to note progress on artifact bundling and baseline comparator

## Testing
- `pytest tests/test_eval_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03d6c506c83319c5f44847f9490d3