### PR TITLE
Add run version stamping for CI/CD

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -84,7 +84,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
     [ ] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [ ] Create nightly full evaluation job with retention and tagging
-    [ ] Implement version stamping (git SHA, Docker digest, seeds) in runs
+    [~] Implement version stamping (git SHA, Docker digest, seeds) in runs
     [ ] Configure GitHub Pages publish for latest report artifacts
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 from itertools import count
 import asyncio
+from .version import VersionInfo, collect_version_info
 
 
 class Run(BaseModel):
@@ -12,6 +13,7 @@ class Run(BaseModel):
     status: str = "pending"
     logs: List[str] = Field(default_factory=list)
     artifact: Optional[str] = None
+    version: VersionInfo
 
 
 class RunRegistry:
@@ -25,7 +27,14 @@ class RunRegistry:
 
     def create_run(self, config: Optional[Dict[str, str]] = None) -> Run:
         run_id = next(self._id_counter)
-        run = Run(id=run_id, config=config or {})
+        seed_value = None
+        if config and "seed" in config:
+            try:
+                seed_value = int(config["seed"])
+            except (TypeError, ValueError):
+                seed_value = None
+        version = collect_version_info(seed=seed_value)
+        run = Run(id=run_id, config=config or {}, version=version)
         self._runs[run_id] = run
         self._log_queues[run_id] = asyncio.Queue()
         return run

--- a/hrm_coder/tests/test_run_registry.py
+++ b/hrm_coder/tests/test_run_registry.py
@@ -1,0 +1,7 @@
+from hrm_coder.run_registry import registry
+
+
+def test_run_records_version_info():
+    run = registry.create_run({"seed": "7"})
+    assert run.version.git_sha
+    assert run.version.seed == 7

--- a/hrm_coder/version.py
+++ b/hrm_coder/version.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utilities for capturing reproducibility metadata."""
+
+import os
+import subprocess
+from pydantic import BaseModel
+from typing import Optional
+
+
+class VersionInfo(BaseModel):
+    """Record identifying a run's code and environment versions."""
+
+    git_sha: str
+    docker_digest: str
+    seed: Optional[int] = None
+
+
+def collect_version_info(seed: Optional[int] = None) -> VersionInfo:
+    """Gather versioning information for the current run.
+
+    Parameters
+    ----------
+    seed: Optional[int]
+        The random seed associated with the run, if any.
+
+    Returns
+    -------
+    VersionInfo
+        Populated version information.
+    """
+    try:
+        git_sha = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], text=True)
+            .strip()
+        )
+    except Exception:
+        git_sha = "unknown"
+
+    docker_digest = os.getenv("DOCKER_DIGEST", "unknown")
+
+    return VersionInfo(git_sha=git_sha, docker_digest=docker_digest, seed=seed)


### PR DESCRIPTION
## Summary
- track git SHA, docker digest and seed in new `VersionInfo`
- capture version info when runs are created and expose through registry
- document phase 8 progress in HRM coder checklist
- test run registry version stamping

## Testing
- `pre-commit run --files hrm_coder/run_registry.py hrm_coder/version.py docs/hrmCoder_checklist.md hrm_coder/tests/test_run_registry.py`
- `pytest hrm_coder/tests/test_api.py hrm_coder/tests/test_run_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03d6eaa3c8331a8cab9b6cb3aaf7b