### PR TITLE
feat: add basic C++ AST encoder

### DIFF
--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -10,6 +10,14 @@ on code tasks.
 
 from .code_tokenizer import CppTokenizer
 from .code_encoder import CodeEncoder
+from .ast_encoder import ASTEncoder, NodeTypeSchema
 from .training_loop import HRMTrainer, HRMTrainingConfig
 
-__all__ = ["CppTokenizer", "CodeEncoder", "HRMTrainer", "HRMTrainingConfig"]
+__all__ = [
+    "CppTokenizer",
+    "CodeEncoder",
+    "ASTEncoder",
+    "NodeTypeSchema",
+    "HRMTrainer",
+    "HRMTrainingConfig",
+]

--- a/hrm/ast_encoder.py
+++ b/hrm/ast_encoder.py
@@ -1,0 +1,91 @@
+"""AST-based encoder for C++ source code.
+
+This module provides a minimal :class:`ASTEncoder` used in Phase 9 of the
+HRM Coder roadmap.  It converts the Tree-sitter parse tree of a C++ source
+string into a sequence of integer node-type ids.  The mapping from node type
+strings to ids is managed by :class:`NodeTypeSchema` and is populated lazily
+as new node kinds are encountered.
+
+The encoder is deliberately lightweight – it only captures node types in a
+pre-order traversal and tracks their depth.  Future iterations can extend
+this to richer embeddings (e.g. parent chains or typed edges).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+from tree_sitter import Node, Parser, Tree
+
+try:  # pragma: no cover - optional dependency may be missing
+    from tree_sitter_languages import get_parser
+except Exception as exc:  # pragma: no cover
+    get_parser = None  # type: ignore[assignment]
+    _PARSER_ERROR = exc
+
+
+class NodeTypeSchema:
+    """Maps Tree-sitter node type strings to integer ids."""
+
+    def __init__(self) -> None:
+        self._type_to_id: Dict[str, int] = {}
+
+    def id_for(self, node_type: str) -> int:
+        """Return the id for ``node_type`` creating a new entry if needed."""
+
+        if node_type not in self._type_to_id:
+            self._type_to_id[node_type] = len(self._type_to_id)
+        return self._type_to_id[node_type]
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._type_to_id)
+
+
+@dataclass
+class ASTEncoder:
+    """Encode C++ source code as a sequence of node-type ids."""
+
+    schema: NodeTypeSchema = field(default_factory=NodeTypeSchema)
+    parser: Parser | None = field(init=False, default=None)
+    _init_error: Exception | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        if get_parser is None:
+            self._init_error = _PARSER_ERROR
+        else:
+            try:
+                self.parser = get_parser("cpp")
+            except Exception as exc:  # pragma: no cover
+                self._init_error = exc
+
+    def _traverse(self, node: Node, out: List[int]) -> None:
+        out.append(self.schema.id_for(node.type))
+        for child in node.children:
+            self._traverse(child, out)
+
+    def encode(self, code: str) -> List[int]:
+        """Return the node-type ids for ``code`` in a pre-order traversal."""
+
+        if self.parser is None:
+            raise RuntimeError("Tree-sitter C++ parser unavailable") from self._init_error
+        tree: Tree = self.parser.parse(code.encode("utf8"))
+        ids: List[int] = []
+        self._traverse(tree.root_node, ids)
+        return ids
+
+    def encode_with_depth(self, code: str) -> List[Tuple[int, int]]:
+        """Return ``(node_type_id, depth)`` pairs for ``code``."""
+
+        if self.parser is None:
+            raise RuntimeError("Tree-sitter C++ parser unavailable") from self._init_error
+        tree: Tree = self.parser.parse(code.encode("utf8"))
+        result: List[Tuple[int, int]] = []
+
+        def walk(n: Node, depth: int) -> None:
+            result.append((self.schema.id_for(n.type), depth))
+            for child in n.children:
+                walk(child, depth + 1)
+
+        walk(tree.root_node, 0)
+        return result

--- a/tests/test_ast_edit.py
+++ b/tests/test_ast_edit.py
@@ -10,15 +10,19 @@ from utils.ast_edit import CppAst
 
 CPP_SNIPPET = """int add(int a, int b) { return a + b; }"""
 
-_HAS_CHILD = hasattr(CppAst().parse("int x; ").root_node, "child")
 
-
-@pytest.mark.skipif(not _HAS_CHILD, reason="tree-sitter Node.child not available")
-def test_parse_and_basic_edits():
+def _parser_available() -> bool:
     try:
         ast = CppAst()
-    except Exception as e:  # pragma: no cover - environment missing parser
-        pytest.skip(f"Tree-sitter parser unavailable: {e}")
+        ast.parse("int x; ")
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+def test_parse_and_basic_edits():
+    ast = CppAst()
     tree = ast.parse(CPP_SNIPPET)
     assert tree.root_node.type == "translation_unit"
 
@@ -36,4 +40,3 @@ def test_parse_and_basic_edits():
     comment_node = ast.parse(inserted.code).root_node.child(0)
     deleted = ast.delete(inserted.code, comment_node)
     assert ast.is_valid(deleted.code)
-

--- a/tests/test_ast_encoder.py
+++ b/tests/test_ast_encoder.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from hrm.ast_encoder import ASTEncoder
+
+CPP_SNIPPET = """int add(int a, int b) { return a + b; }"""
+
+
+def _parser_available() -> bool:
+    try:
+        enc = ASTEncoder()
+        enc.encode("int x;")
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+def test_encode_produces_node_ids():
+    enc = ASTEncoder()
+    ids = enc.encode(CPP_SNIPPET)
+    assert ids[0] == enc.schema.id_for("translation_unit")
+    assert len(ids) > 3
+
+
+@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+def test_encode_with_depth():
+    enc = ASTEncoder()
+    pairs = enc.encode_with_depth(CPP_SNIPPET)
+    # root node at depth 0
+    assert pairs[0] == (enc.schema.id_for("translation_unit"), 0)
+    # ensure there is a node deeper than root
+    assert any(depth > 0 for _, depth in pairs)

--- a/utils/ast_edit.py
+++ b/utils/ast_edit.py
@@ -22,7 +22,11 @@ from dataclasses import dataclass
 from typing import Optional
 
 from tree_sitter import Node, Tree
-from tree_sitter_languages import get_parser
+try:  # pragma: no cover - import guard
+    from tree_sitter_languages import get_parser
+except Exception as exc:  # pragma: no cover - runtime environment may lack compiled grammars
+    get_parser = None  # type: ignore[assignment]
+    _PARSER_ERROR = exc
 
 
 @dataclass
@@ -39,14 +43,35 @@ class EditResult:
 
 
 class CppAst:
-    """Thin wrapper around a Tree-sitter C++ parser."""
+    """Thin wrapper around a Tree-sitter C++ parser.
+
+    The constructor attempts to load the pre-built C++ grammar from
+    :mod:`tree_sitter_languages`.  In environments where the compiled
+    grammars are unavailable (e.g. missing wheels for the running Python
+    version) the object is still created but ``parse`` will raise a
+    :class:`RuntimeError`.  This allows callers and tests to gracefully
+    skip AST-edit features when the dependency is missing.
+    """
 
     def __init__(self) -> None:
-        self.parser = get_parser("cpp")
+        self._init_error: Exception | None = None
+        if get_parser is None:
+            self.parser = None
+            self._init_error = _PARSER_ERROR
+        else:
+            try:
+                self.parser = get_parser("cpp")
+            except Exception as exc:  # pragma: no cover - missing grammar
+                self.parser = None
+                self._init_error = exc
 
     def parse(self, code: str) -> Tree:
         """Parse ``code`` into a :class:`Tree`."""
 
+        if self.parser is None:
+            raise RuntimeError(
+                "Tree-sitter C++ parser unavailable"
+            ) from self._init_error
         return self.parser.parse(bytes(code, "utf8"))
 
     def replace(self, code: str, node: Node, replacement: str, *, reparse: bool = True) -> EditResult:
@@ -93,4 +118,3 @@ class CppAst:
             return True
         except Exception:
             return False
-


### PR DESCRIPTION
## Summary
- add lightweight ASTEncoder for C++ using tree-sitter
- handle missing tree-sitter grammars gracefully in AST utilities
- cover AST encoder and editing helpers with tests

## Testing
- `pre-commit run --files utils/ast_edit.py hrm/ast_encoder.py hrm/__init__.py tests/test_ast_edit.py tests/test_ast_encoder.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a03d70dd4883319c36118259acec25