### PR TITLE
feat: support shared C++ library builds for Phase 10

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -105,6 +105,50 @@ def compile_cpp_sources(
     return success, proc.stdout, proc.stderr, output_path if success else None
 
 
+def compile_shared_library(
+    sources: Sequence[Path],
+    output: Optional[Path] = None,
+    *,
+    compiler: str = "g++",
+    flags: Optional[Iterable[str]] = None,
+    sanitize: bool = True,
+    use_ccache: bool = False,
+) -> Tuple[bool, str, str, Optional[Path]]:
+    """Compile ``sources`` into a shared library.
+
+    This helper produces a ``.so`` suitable for linking against binaries
+    compiled with :func:`compile_cpp_sources`.  It mirrors that function's
+    support for optional sanitizers and ``ccache`` to encourage deterministic
+    yet repeatable builds.
+    """
+
+    if flags is None:
+        flags = list(DEFAULT_FLAGS)
+    else:
+        flags = list(flags)
+    if sanitize:
+        flags = list(flags) + SANITIZER_FLAGS
+
+    flags = ["-shared", "-fPIC"] + list(flags)
+
+    if output is None:
+        tmp = tempfile.NamedTemporaryFile(suffix=".so", delete=False)
+        output_path = Path(tmp.name)
+        tmp.close()
+    else:
+        output_path = Path(output)
+
+    cmd: List[str] = [compiler]
+    if use_ccache and shutil.which("ccache") is not None:
+        cmd = ["ccache", compiler]
+
+    cmd += [str(s) for s in sources] + ["-o", str(output_path)] + list(flags)
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    success = proc.returncode == 0
+    return success, proc.stdout, proc.stderr, output_path if success else None
+
+
 def compile_cpp(
     source: Path,
     output: Optional[Path] = None,
@@ -158,7 +202,7 @@ def run_binary(
 
 
 def run_codeforces_tests(
-    source: Path,
+    sources: Sequence[Path],
     tests_dir: Path,
     *,
     compiler: str = "g++",
@@ -166,16 +210,29 @@ def run_codeforces_tests(
     sanitize: bool = True,
     timeout: float = 2.0,
     memory_limit: Optional[int] = None,
+    static: bool = False,
+    library_dirs: Optional[Iterable[Path]] = None,
+    libraries: Optional[Iterable[str]] = None,
+    rpath: Optional[Iterable[Path]] = None,
+    use_ccache: bool = False,
 ) -> dict:
-    """Compile ``source`` and run it against all tests in ``tests_dir``.
+    """Compile ``sources`` and run them against all tests in ``tests_dir``.
 
     The directory is expected to contain pairs of ``*.in`` and ``*.out`` files.
     Results are returned as a mapping with compile diagnostics and a list of
     per-test outcomes.
     """
 
-    success, out, err, binary = compile_cpp(
-        source, compiler=compiler, flags=flags, sanitize=sanitize
+    success, out, err, binary = compile_cpp_sources(
+        sources,
+        compiler=compiler,
+        flags=flags,
+        sanitize=sanitize,
+        static=static,
+        library_dirs=library_dirs,
+        libraries=libraries,
+        rpath=rpath,
+        use_ccache=use_ccache,
     )
     results = []
     if not success or binary is None:

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from runners.cpp_runner import compile_cpp_sources, run_binary
+from runners.cpp_runner import (
+    compile_cpp_sources,
+    compile_shared_library,
+    run_binary,
+)
 
 
 def test_compile_multi_file(tmp_path: Path) -> None:
@@ -24,3 +28,36 @@ int main() { std::cout << add(1, 2); }
     code, stdout, stderr = run_binary(binary)
     assert code == 0
     assert stdout.strip() == "3"
+
+
+def test_shared_library_link(tmp_path: Path) -> None:
+    """Build a shared library and link it into a main program."""
+    lib_src = tmp_path / "double.cpp"
+    lib_src.write_text('extern "C" int times_two(int x){return 2*x;}\n')
+
+    lib_path = tmp_path / "libdouble.so"
+    success, out, err, so = compile_shared_library([lib_src], output=lib_path)
+    assert success, f"lib compile failed: {out}\n{err}"
+    assert so is not None
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+extern "C" int times_two(int);
+int main(){std::cout<<times_two(5);}
+"""
+    )
+
+    success, out, err, binary = compile_cpp_sources(
+        [main],
+        library_dirs=[tmp_path],
+        libraries=["double"],
+        rpath=[tmp_path],
+    )
+    assert success, f"compile failed: {out}\n{err}"
+    assert binary is not None
+
+    code, stdout, stderr = run_binary(binary)
+    assert code == 0
+    assert stdout.strip() == "10"


### PR DESCRIPTION
## Summary
- add shared library compilation helper for C++ runner
- allow Codeforces test helper to compile multiple sources with libraries, rpath and ccache
- test dynamic library linking

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py`
- `PYTHONPATH=. pytest tests/test_cpp_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03d74566483318eb1083d19e0dd63