### PR TITLE
Install nsjail and sanitizers in runner image

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -23,7 +23,7 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 1: Repo Scaffold & Deterministic Environment
     [X] Generate project layout scaffold script for hrm-coder directory tree
-    [~] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
+    [?] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
     [~] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
     [~] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
     [~] Define Hydra config schema and default configs under conf/

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -41,7 +41,7 @@ class RunRegistry:
 
     def list_runs(self, offset: int = 0, limit: int = 10) -> List[Run]:
         runs = list(self._runs.values())
-        return runs[offset : offset + limit]
+        return runs[offset:offset + limit]
 
     def get_run(self, run_id: int) -> Optional[Run]:
         """Return run by id if it exists."""
@@ -59,7 +59,20 @@ class RunRegistry:
             self._log_queues[run_id].put_nowait(message)
 
     def get_logs(self, run_id: int) -> List[str]:
-        return self._runs.get(run_id, Run(id=run_id)).logs
+        """Return existing log lines for ``run_id``.
+
+        ``dict.get`` eagerly evaluates its default argument, which caused a
+        ``Run`` to be instantiated without required fields whenever a run was
+        present in the registry. That surfaced as a validation error during
+        WebSocket connections. We avoid that by looking up the run explicitly
+        and creating a minimal placeholder only when it is truly missing.
+        """
+        run = self._runs.get(run_id)
+        if run is None:
+            run = Run(id=run_id, version=collect_version_info())
+            self._runs[run_id] = run
+            self._log_queues.setdefault(run_id, asyncio.Queue())
+        return run.logs
 
     def get_log_queue(self, run_id: int) -> "asyncio.Queue[str]":
         return self._log_queues.setdefault(run_id, asyncio.Queue())

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -18,9 +18,22 @@ RUN apt-get update && \
         python3 \
         python3-pip \
         isolate \
-    && rm -rf /var/lib/apt/lists/*
+        pkg-config \
+        libprotobuf-dev \
+        protobuf-compiler \
+        libnl-route-3-dev \
+        libcap-dev \
+        libseccomp-dev \
+        zlib1g-dev \
+        llvm \
+        libclang-rt-14-dev \
+    && rm -rf /var/lib/apt/lists/* && \
+    git clone https://github.com/google/nsjail.git /tmp/nsjail && \
+    make -C /tmp/nsjail && \
+    mv /tmp/nsjail/nsjail /usr/local/bin/nsjail && \
+    rm -rf /tmp/nsjail
 
-# TODO: Install nsjail and sanitizer tools
+# nsjail provides process isolation; llvm packages enable sanitizer builds
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- Add nsjail and sanitizer-related packages to runner Dockerfile and build nsjail from source
- Mark runner.Dockerfile task as ready for review in development checklist
- Fix run registry log retrieval to avoid Pydantic validation errors and support websocket streaming

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md runner.Dockerfile hrm_coder/run_registry.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a042c177e483318103ba585ef3780b