### PR TITLE
feat: enhance gui and artifacts

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -33,10 +33,10 @@ Save new code files in: C:\repos\hrm-coder
 ** [~] Phase 2: GUI Stub and Backend Skeleton
     [X] Scaffold FastAPI app with /runs, /train, /eval, /logs/ws endpoints
     [X] Implement mock run registry with in-memory store and pagination
-    [ ] Build Run Console page with config pickers and action buttons
-    [ ] Build Jobs list page with sortable metrics and artifact links
-    [ ] Implement artifact static server for JUnit XML and lcov/llvm-cov HTML
-    [ ] Add WebSocket log streamer with tail-follow behavior
+    [X] Build Run Console page with config pickers and action buttons
+    [X] Build Jobs list page with sortable metrics and artifact links
+    [~] Implement artifact static server for JUnit XML and lcov/llvm-cov HTML
+    [X] Add WebSocket log streamer with tail-follow behavior
     [X] Provide GUI quickstart docs and sample configs
 
 ** [ ] Phase 3: Deterministic Dataset Pipeline (C++)

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -41,7 +41,7 @@ def get_run(run_id: int):
 @app.post("/train", response_model=Run)
 def start_train(config: Dict[str, str] | None = None):
     run = registry.create_run(config)
-    run.artifact = f"/artifacts/run_{run.id}/"
+    _init_artifact(run.id)
     registry.append_log(run.id, "training started")
     registry.update_status(run.id, "training")
     return run
@@ -50,10 +50,20 @@ def start_train(config: Dict[str, str] | None = None):
 @app.post("/eval", response_model=Run)
 def start_eval(config: Dict[str, str] | None = None):
     run = registry.create_run(config)
-    run.artifact = f"/artifacts/run_{run.id}/"
+    _init_artifact(run.id)
     registry.append_log(run.id, "evaluation started")
     registry.update_status(run.id, "evaluating")
     return run
+
+
+def _init_artifact(run_id: int) -> None:
+    """Create an artifact directory with a placeholder file."""
+    path = ARTIFACT_DIR / f"run_{run_id}"
+    path.mkdir(parents=True, exist_ok=True)
+    placeholder = path / "README.txt"
+    if not placeholder.exists():
+        placeholder.write_text("artifacts for run %d" % run_id)
+    registry.get_run(run_id).artifact = f"/artifacts/run_{run_id}/"
 
 
 @app.websocket("/logs/ws/{run_id}")

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -59,7 +59,8 @@ class RunRegistry:
             self._log_queues[run_id].put_nowait(message)
 
     def get_logs(self, run_id: int) -> List[str]:
-        return self._runs.get(run_id, Run(id=run_id)).logs
+        run = self._runs.get(run_id)
+        return run.logs if run else []
 
     def get_log_queue(self, run_id: int) -> "asyncio.Queue[str]":
         return self._log_queues.setdefault(run_id, asyncio.Queue())

--- a/hrm_coder/static/configs.json
+++ b/hrm_coder/static/configs.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "default",
+    "config": {"foo": "bar"}
+  },
+  {
+    "name": "fast",
+    "config": {"foo": "baz", "mode": "fast"}
+  }
+]

--- a/hrm_coder/static/run.html
+++ b/hrm_coder/static/run.html
@@ -33,6 +33,7 @@
     ws.onmessage = (ev) => {
       const pre = document.getElementById('logs');
       pre.textContent += ev.data + '\n';
+      pre.scrollTop = pre.scrollHeight;
     };
   </script>
 </body>

--- a/hrm_coder/static/run_console.html
+++ b/hrm_coder/static/run_console.html
@@ -6,14 +6,39 @@
 </head>
 <body>
   <h1>Run Console</h1>
+  <label for="picker">Config:</label>
+  <select id="picker"></select><br/>
   <label>Config JSON:</label>
-  <textarea id="config" rows="4" cols="40">{"foo":"bar"}</textarea><br/>
+  <textarea id="config" rows="4" cols="40"></textarea><br/>
   <button onclick="startRun('train')">Start Train</button>
   <button onclick="startRun('eval')">Start Eval</button>
   <pre id="result"></pre>
   <script>
+    const picker = document.getElementById('picker');
+    const cfgBox = document.getElementById('config');
+    async function loadConfigs() {
+      const resp = await fetch('/static/configs.json');
+      const items = await resp.json();
+      picker.innerHTML = '';
+      for (const item of items) {
+        const opt = document.createElement('option');
+        opt.value = item.name;
+        opt.textContent = item.name;
+        opt.dataset.cfg = JSON.stringify(item.config, null, 2);
+        picker.appendChild(opt);
+      }
+      if (items.length) {
+        cfgBox.value = JSON.stringify(items[0].config);
+      }
+    }
+    picker.addEventListener('change', () => {
+      const opt = picker.selectedOptions[0];
+      cfgBox.value = opt.dataset.cfg || '';
+    });
+    loadConfigs();
+
     async function startRun(kind) {
-      let cfgText = document.getElementById('config').value;
+      let cfgText = cfgBox.value;
       let cfg;
       try {
         cfg = JSON.parse(cfgText);


### PR DESCRIPTION
## Summary
- add GUI config picker and tail-follow log streaming
- scaffold artifact directories with placeholder files
- document Phase 2 checklist progress

## Testing
- `pytest hrm_coder/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a042c46294833181e83bc6be6d3eb2