### PR TITLE
Add AtCoder ABC dataset builder and tests

### DIFF
--- a/dataset/build_atcoder_abc_dataset.py
+++ b/dataset/build_atcoder_abc_dataset.py
@@ -1,0 +1,114 @@
+"""Builder for the AtCoder ABC subset dataset.
+
+This builder consumes a JSONL file where each line encodes one
+AtCoder-style problem. The expected fields mirror those used by the
+Codeforces builder to keep a consistent layout:
+
+- ``task_id``: unique identifier for the problem
+- ``prompt``: textual description or starter code
+- ``tests``: list of input/output pairs, e.g.,
+  ``{"input": "1\n", "output": "1\n"}``
+- ``time_limit_ms``: optional time limit in milliseconds (default 2000)
+- ``memory_limit_kb``: optional memory limit in kilobytes (default 102400)
+
+Each task is written to ``output_dir/<split>/<task_id>/`` with the
+following files:
+
+- ``prompt.txt`` -- problem text
+- ``tests/`` -- directory containing numbered ``*.in``/``*.out`` pairs
+- ``meta.json`` -- metadata with time and memory limits
+
+The dataset is split deterministically into train/val/test subsets using
+:func:`dataset.split_manager.split_list`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import List
+
+from .split_manager import split_list
+
+
+@dataclass
+class IOPair:
+    """Simple container for an input/output example."""
+    input: str
+    output: str
+
+
+@dataclass
+class AtCoderTask:
+    task_id: str
+    prompt: str
+    tests: List[IOPair]
+    time_limit_ms: int = 2000
+    memory_limit_kb: int = 102400
+
+
+def load_tasks(path: Path) -> List[AtCoderTask]:
+    """Load tasks from a JSONL file at *path*."""
+    tasks: List[AtCoderTask] = []
+    with path.open() as fh:
+        for line in fh:
+            raw = json.loads(line)
+            tests = [IOPair(**t) for t in raw["tests"]]
+            tasks.append(
+                AtCoderTask(
+                    task_id=raw["task_id"],
+                    prompt=raw["prompt"],
+                    tests=tests,
+                    time_limit_ms=raw.get("time_limit_ms", 2000),
+                    memory_limit_kb=raw.get("memory_limit_kb", 102400),
+                )
+            )
+    return tasks
+
+
+def write_task(task: AtCoderTask, dest: Path) -> None:
+    """Write a single task directory to *dest*."""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "prompt.txt").write_text(task.prompt)
+
+    tests_dir = dest / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    for idx, io in enumerate(task.tests):
+        (tests_dir / f"{idx}.in").write_text(io.input)
+        (tests_dir / f"{idx}.out").write_text(io.output)
+
+    meta = {
+        "time_limit_ms": task.time_limit_ms,
+        "memory_limit_kb": task.memory_limit_kb,
+    }
+    (dest / "meta.json").write_text(json.dumps(meta))
+
+
+def build_dataset(raw_path: str, output_dir: str, seed: int = 0) -> None:
+    """Entry point to process the raw dataset into a split directory."""
+    tasks = load_tasks(Path(raw_path))
+    splits = split_list(tasks, seed)
+
+    out_dir = Path(output_dir)
+    for split_name, subset in splits.items():
+        for task in subset:
+            write_task(task, out_dir / split_name / task.task_id)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build AtCoder ABC dataset")
+    parser.add_argument("raw_path", help="Path to raw JSONL dataset")
+    parser.add_argument(
+        "output_dir", help="Output directory for processed dataset"
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for deterministic splits",
+    )
+    args = parser.parse_args()
+
+    build_dataset(args.raw_path, args.output_dir, args.seed)

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -42,7 +42,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [ ] Phase 3: Deterministic Dataset Pipeline (C++)
     [~] Implement HumanEval-CPP builder with harness generator and reference solutions
     [~] Implement Codeforces-Intro builder (I/O testcases, constraints, per-problem time limits)
-    [ ] Implement AtCoder ABC subset builder with normalized input/output cases
+    [~] Implement AtCoder ABC subset builder with normalized input/output cases
     [X] Write determinism validator to re-run and hash equality of artifacts
     [ ] Integrate DVC pipelines and data/versions.yml locking
     [ ] Add dataset schema contracts and unit tests for loaders

--- a/tests/test_build_atcoder_abc_dataset.py
+++ b/tests/test_build_atcoder_abc_dataset.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from dataset.build_atcoder_abc_dataset import build_dataset  # noqa: E402
+from dataset.determinism import validate_build_determinism  # noqa: E402
+
+
+def _write_sample_dataset(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "abc001",
+            "prompt": "Echo input",
+            "tests": [{"input": "42\n", "output": "42\n"}],
+            "time_limit_ms": 2000,
+            "memory_limit_kb": 65536,
+        },
+        {
+            "task_id": "abc002",
+            "prompt": "Add numbers",
+            "tests": [{"input": "1 2\n", "output": "3\n"}],
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_atcoder_abc_build_is_deterministic(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+
+    assert validate_build_determinism(build_dataset, str(raw), seed=123)


### PR DESCRIPTION
## Summary
- implement AtCoder ABC dataset builder with deterministic splitting and task export
- cover builder with determinism unit test
- mark AtCoder builder progress in checklist

## Testing
- `pre-commit run --files dataset/build_atcoder_abc_dataset.py tests/test_build_atcoder_abc_dataset.py docs/hrmCoder_checklist.md`
- `pytest tests/test_build_atcoder_abc_dataset.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a042c74bcc8331a2f13ea133277090