### PR TITLE
Implement Phase 6 training helpers and smoke script

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -66,11 +66,11 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [~] Phase 6: HRM Training Loop Integration
     [X] Implement CodeEncoder interface and tokenizer utilities for C++ syntax
-    [ ] Add optional SFT training path on canonical C++ solutions
-    [~] Integrate REINFORCE with value baseline and entropy regularization
-    [~] Implement curriculum toggles for visible versus hidden tests
+    [X] Add optional SFT training path on canonical C++ solutions
+    [X] Integrate REINFORCE with value baseline and entropy regularization
+    [X] Implement curriculum toggles for visible versus hidden tests
     [X] Add checkpointing, resume logic, and deterministic dataloaders
-    [ ] Create 5-task smoke run pipeline for CI runtime budgets
+    [~] Create 5-task smoke run pipeline for CI runtime budgets
 
 ** [ ] Phase 7: Evaluation Harness and Reporting
     [X] Implement pass\@k computation with fixed seeds and sampling policies

--- a/hrm/training_loop.py
+++ b/hrm/training_loop.py
@@ -10,7 +10,7 @@ development.
 """
 
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Iterable, Optional, Tuple
 
 import torch
 from torch import nn
@@ -32,8 +32,9 @@ class HRMTrainer:
     Parameters
     ----------
     model:
-        A module returning ``(logits, value)`` when called.  ``logits`` are used
-        for policy decisions while ``value`` estimates the baseline reward.
+        A module returning ``(logits, value)`` when called.  ``logits`` are
+        used for policy decisions while ``value`` estimates the baseline
+        reward.
     optimizer:
         Optimiser used to update ``model`` parameters.
     config:
@@ -77,6 +78,17 @@ class HRMTrainer:
         self.optimizer.zero_grad(set_to_none=True)
         return float(loss.detach())
 
+    def sft_epoch(
+        self, dataloader: Iterable[Tuple[torch.Tensor, torch.Tensor]]
+    ) -> float:
+        """Run an SFT epoch over ``dataloader`` and return the average loss."""
+        total_loss = 0.0
+        count = 0
+        for inputs, targets in dataloader:
+            total_loss += self.sft_step(inputs, targets)
+            count += 1
+        return total_loss / max(1, count)
+
     # ------------------------------------------------------------------
     # Reinforcement learning (REINFORCE with baseline)
     # ------------------------------------------------------------------
@@ -87,9 +99,9 @@ class HRMTrainer:
     ) -> Dict[str, float]:
         """Run a REINFORCE update using ``reward_fn``.
 
-        The model is expected to output ``(logits, value)``.  ``reward_fn`` is a
-        callable that receives sampled actions and returns a reward tensor.  A
-        dictionary containing basic metrics is returned to aid debugging.
+        The model is expected to output ``(logits, value)``.  ``reward_fn`` is
+        a callable that receives sampled actions and returns a reward tensor.
+        A dictionary containing basic metrics is returned to aid debugging.
         """
         self.model.train()
         logits, value = self.model(inputs)
@@ -116,6 +128,26 @@ class HRMTrainer:
             "entropy": float(entropy.detach()),
             "reward": float(reward.detach().mean()),
         }
+
+    def reinforce_epoch(
+        self,
+        dataloader: Iterable[torch.Tensor],
+        reward_fn: Callable[[torch.Tensor], torch.Tensor],
+    ) -> Dict[str, float]:
+        """Run a REINFORCE epoch and return averaged statistics."""
+        agg = {
+            "policy_loss": 0.0,
+            "value_loss": 0.0,
+            "entropy": 0.0,
+            "reward": 0.0,
+        }
+        count = 0
+        for inputs in dataloader:
+            stats = self.reinforce_step(inputs, reward_fn)
+            for k, v in stats.items():
+                agg[k] += v
+            count += 1
+        return {k: v / max(1, count) for k, v in agg.items()}
 
 
 __all__ = ["HRMTrainer", "HRMTrainingConfig"]

--- a/scripts/smoke_train.py
+++ b/scripts/smoke_train.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Minimal 5-task smoke training run for Phase 6.
+
+This script exercises the HRMTrainer's supervised fine-tuning path on a
+small synthetic dataset.  It is intended for CI smoke tests and runs in
+under a second on CPU.
+"""
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from hrm.training_loop import HRMTrainer, HRMTrainingConfig
+
+
+class TinyModel(nn.Module):
+    """Simple linear model used for smoke training."""
+
+    def __init__(self, vocab_size: int = 8) -> None:
+        super().__init__()
+        self.linear = nn.Linear(vocab_size, vocab_size)
+        self.value = nn.Linear(vocab_size, 1)
+
+    def forward(self, x: torch.Tensor):  # type: ignore[override]
+        logits = self.linear(x)
+        value = self.value(x).squeeze(-1)
+        return logits, value
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    vocab = 8
+    inputs = torch.eye(vocab)[:5]
+    targets = torch.arange(5) % vocab
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=1, shuffle=True)
+
+    model = TinyModel(vocab)
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = HRMTrainer(model, opt, HRMTrainingConfig())
+
+    avg_loss = trainer.sft_epoch(loader)
+    print(f"avg_loss={avg_loss:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -3,10 +3,10 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-import torch
-from torch import nn
+import torch  # noqa: E402
+from torch import nn  # noqa: E402
 
-from hrm.training_loop import HRMTrainer, HRMTrainingConfig
+from hrm.training_loop import HRMTrainer, HRMTrainingConfig  # noqa: E402
 
 
 class DummyModel(nn.Module):
@@ -50,3 +50,20 @@ def test_curriculum_toggle():
     assert trainer.config.curriculum_stage == "visible"
     trainer.toggle_curriculum()
     assert trainer.config.curriculum_stage == "hidden"
+
+
+def test_sft_step_updates_model():
+    torch.manual_seed(0)
+    model = DummyModel()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = HRMTrainer(model, opt)
+
+    inputs = torch.eye(2)
+    targets = torch.tensor([0, 1])
+
+    before = model.linear.weight.clone()
+    loss = trainer.sft_step(inputs, targets)
+    after = model.linear.weight
+
+    assert loss > 0
+    assert not torch.allclose(before, after)


### PR DESCRIPTION
## Summary
- add epoch helpers for supervised and reinforce training
- add 5-task smoke training script
- mark Phase 6 HRM training tasks as completed

## Testing
- `pre-commit run --files hrm/training_loop.py scripts/smoke_train.py tests/test_training_loop.py docs/hrmCoder_checklist.md`
- `pytest` *(fails: missing gtest headers and pydantic validation)*
- `pytest tests/test_training_loop.py`


------
https://chatgpt.com/codex/tasks/task_e_68a042cd6a8c8331995547bae561a0a8