### PR TITLE
Add coverage artifact step and version stamping tests

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install clang tools
-        run: sudo apt-get update && sudo apt-get install -y clang-format clang-tidy cmake build-essential
+        run: sudo apt-get update && sudo apt-get install -y clang-format clang-tidy cmake build-essential lcov
 
       - name: C++ lint
         run: |
@@ -25,12 +25,32 @@ jobs:
           fi
 
       - name: Build and test
+        id: build-test
         run: |
           if [ -f CMakeLists.txt ]; then
             mkdir build && cd build
-            cmake ..
+            cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage" ..
             make
             ctest --output-on-failure
+            cd ..
           else
             echo "No C++ tests found."
           fi
+
+      - name: Collect coverage
+        if: ${{ steps.build-test.outcome == 'success' }}
+        run: |
+          if [ -d build ]; then
+            lcov --capture --directory build --output-file coverage.info
+            lcov --remove coverage.info '/usr/*' --output-file coverage.info
+            genhtml coverage.info --output-directory coverage_html
+          else
+            echo "No coverage generated."
+          fi
+
+      - name: Upload coverage
+        if: ${{ steps.build-test.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-coverage
+          path: coverage_html

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -81,10 +81,10 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement artifact bundler and uploader for reports and raw JSON
 
 ** [ ] Phase 8: CI/CD and Automation
-    [~] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
-    [ ] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
+    [X] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
+    [~] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [ ] Create nightly full evaluation job with retention and tagging
-    [~] Implement version stamping (git SHA, Docker digest, seeds) in runs
+    [X] Implement version stamping (git SHA, Docker digest, seeds) in runs
     [ ] Configure GitHub Pages publish for latest report artifacts
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -41,7 +41,7 @@ class RunRegistry:
 
     def list_runs(self, offset: int = 0, limit: int = 10) -> List[Run]:
         runs = list(self._runs.values())
-        return runs[offset : offset + limit]
+        return runs[offset:offset + limit]
 
     def get_run(self, run_id: int) -> Optional[Run]:
         """Return run by id if it exists."""
@@ -59,7 +59,8 @@ class RunRegistry:
             self._log_queues[run_id].put_nowait(message)
 
     def get_logs(self, run_id: int) -> List[str]:
-        return self._runs.get(run_id, Run(id=run_id)).logs
+        run = self._runs.get(run_id)
+        return run.logs if run else []
 
     def get_log_queue(self, run_id: int) -> "asyncio.Queue[str]":
         return self._log_queues.setdefault(run_id, asyncio.Queue())

--- a/hrm_coder/tests/test_run_registry.py
+++ b/hrm_coder/tests/test_run_registry.py
@@ -5,3 +5,9 @@ def test_run_records_version_info():
     run = registry.create_run({"seed": "7"})
     assert run.version.git_sha
     assert run.version.seed == 7
+
+
+def test_run_records_docker_digest(monkeypatch):
+    monkeypatch.setenv("DOCKER_DIGEST", "sha256:testdigest")
+    run = registry.create_run()
+    assert run.version.docker_digest == "sha256:testdigest"


### PR DESCRIPTION
## Summary
- collect and upload lcov coverage in C++ CI workflow
- record docker digest in run registry tests and fix log retrieval
- update progress checklist for CI/CD automation

## Testing
- `pre-commit run --files .github/workflows/cpp-ci.yml docs/hrmCoder_checklist.md hrm_coder/tests/test_run_registry.py hrm_coder/run_registry.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a042d21b888331b1563fe557ff7cbe