### PR TITLE
feat: add basic AST cursor policy

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -90,9 +90,9 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)
     [~] Integrate Tree-sitter C++ grammar and bindings
-    [ ] Implement node type schema and AST embedding encoder for C++
+    [X] Implement node type schema and AST embedding encoder for C++
     [~] Define edit action space for insert, replace, and delete operations
-    [ ] Implement cursor policy module for region selection by HRM high-level
+    [~] Implement cursor policy module for region selection by HRM high-level
     [~] Implement decoder constraint checker to avoid invalid AST states
     [ ] Add ablation job configs and comparison report against token baseline
 

--- a/tests/test_ast_cursor.py
+++ b/tests/test_ast_cursor.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils.ast_edit import CppAst
+from utils.ast_cursor import CursorPolicy, find_node_by_type
+
+CPP_SNIPPET = """int add(int a, int b) { return a + b; }"""
+
+
+def _parser_available() -> bool:
+    try:
+        ast = CppAst()
+        ast.parse("int x;")
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+def test_find_node_by_type():
+    ast = CppAst()
+    tree = ast.parse(CPP_SNIPPET)
+    func = find_node_by_type(tree, "function_definition")
+    assert func is not None
+    assert func.type == "function_definition"
+
+
+@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+def test_cursor_policy_with_custom_predicate():
+    ast = CppAst()
+    tree = ast.parse(CPP_SNIPPET)
+    # predicate that selects the return statement
+    policy = CursorPolicy(lambda n: n.type == "return_statement")
+    node = policy.select(tree)
+    assert node is not None
+    assert node.type == "return_statement"

--- a/utils/ast_cursor.py
+++ b/utils/ast_cursor.py
@@ -1,0 +1,65 @@
+"""Cursor policy helpers for Tree-sitter C++ ASTs.
+
+This module provides a very small utility used in Phase 9 of the HRM
+Coder roadmap.  A :class:`CursorPolicy` represents a strategy for selecting
+an AST node to target for an edit.  Policies are expressed as predicates
+over :class:`tree_sitter.Node` instances and the ``select`` method walks the
+parse tree in breadth‑first order returning the first node that satisfies
+the predicate.
+
+The initial implementation is intentionally simple – it supports only
+predicate based searches and returns the first match.  It can be expanded in
+later phases with scores, multi-node selections or learned policies.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from tree_sitter import Node, Tree
+
+
+Predicate = Callable[[Node], bool]
+
+
+@dataclass
+class CursorPolicy:
+    """Select nodes from a Tree-sitter :class:`Tree` using a predicate.
+
+    Parameters
+    ----------
+    predicate:
+        Function returning ``True`` for nodes that satisfy the policy.
+    """
+
+    predicate: Predicate
+
+    def select(self, tree: Tree) -> Optional[Node]:
+        """Return the first node in ``tree`` that matches ``predicate``.
+
+        The traversal uses a breadth-first search which tends to prefer
+        shallower nodes and keeps the walk deterministic.
+        """
+
+        queue = [tree.root_node]
+        while queue:
+            node = queue.pop(0)
+            if self.predicate(node):
+                return node
+            queue.extend(node.children)
+        return None
+
+
+def find_node_by_type(tree: Tree, node_type: str) -> Optional[Node]:
+    """Convenience helper to locate the first node of ``node_type``.
+
+    Parameters
+    ----------
+    tree:
+        Parsed Tree-sitter tree.
+    node_type:
+        Node type string to search for.
+    """
+
+    policy = CursorPolicy(lambda n: n.type == node_type)
+    return policy.select(tree)


### PR DESCRIPTION
## Summary
- add `CursorPolicy` and helper to select nodes from C++ ASTs
- cover cursor helper with simple tests
- update Phase 9 checklist reflecting AST encoder and cursor work

## Testing
- `pre-commit run --files utils/ast_cursor.py tests/test_ast_cursor.py docs/hrmCoder_checklist.md` *(fails: command not found)*
- `pip install httpx numpy`
- `pytest` *(fails: ValidationError in websocket log stream; gtest headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a042d557c48331909a1a4bcd4b0bce