### PR TITLE
feat: add linking options for C++ runner

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -100,6 +100,6 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
     [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
     [~] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
-    [ ] Configure static versus dynamic linking inside jail with rpath handling and ccache
+    [~] Configure static versus dynamic linking inside jail with rpath handling and ccache
     [ ] Create C++ security test suite for resource abuse and restricted syscalls
     [ ] Integrate C++ metrics and outcomes into common evaluator and reports

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -8,16 +8,20 @@ against multiple input/output pairs with basic resource limits.
 """
 from __future__ import annotations
 
+import os
 import resource
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
 
 
 DEFAULT_FLAGS: List[str] = ["-std=c++17", "-O2", "-pipe"]
-SANITIZER_FLAGS: List[str] = ["-fsanitize=address,undefined", "-fno-omit-frame-pointer"]
+SANITIZER_FLAGS: List[str] = [
+    "-fsanitize=address,undefined",
+    "-fno-omit-frame-pointer",
+]
 
 
 def compile_cpp_sources(
@@ -184,8 +188,25 @@ def run_binary(
     input_data: str = "",
     timeout: float = 2.0,
     memory_limit: Optional[int] = None,
+    env: Optional[Mapping[str, str]] = None,
 ) -> Tuple[int, str, str]:
-    """Execute a compiled binary with optional resource limits."""
+    """Execute a compiled ``binary`` with optional limits and environment.
+
+    Parameters
+    ----------
+    binary:
+        Path to the executable to run.
+    input_data:
+        Data fed to ``stdin`` of the process.
+    timeout:
+        Maximum wall-clock time in seconds before termination.
+    memory_limit:
+        Optional address-space limit in bytes.
+    env:
+        Extra environment variables to inject. Values override the current
+        process environment which enables dynamic library lookup via
+        ``LD_LIBRARY_PATH`` when rpath isn't provided.
+    """
 
     def preexec() -> None:
         _set_limits(memory_limit)
@@ -197,6 +218,7 @@ def run_binary(
         text=True,
         timeout=timeout,
         preexec_fn=preexec,
+        env={**os.environ, **env} if env is not None else None,
     )
     return proc.returncode, proc.stdout, proc.stderr
 
@@ -215,6 +237,7 @@ def run_codeforces_tests(
     libraries: Optional[Iterable[str]] = None,
     rpath: Optional[Iterable[Path]] = None,
     use_ccache: bool = False,
+    env: Optional[Mapping[str, str]] = None,
 ) -> dict:
     """Compile ``sources`` and run them against all tests in ``tests_dir``.
 
@@ -236,7 +259,11 @@ def run_codeforces_tests(
     )
     results = []
     if not success or binary is None:
-        return {"compile_stdout": out, "compile_stderr": err, "results": results}
+        return {
+            "compile_stdout": out,
+            "compile_stderr": err,
+            "results": results,
+        }
 
     for input_file in sorted(Path(tests_dir).glob("*.in")):
         test_name = input_file.stem
@@ -249,6 +276,7 @@ def run_codeforces_tests(
                 input_data=input_data,
                 timeout=timeout,
                 memory_limit=memory_limit,
+                env=env,
             )
         except subprocess.TimeoutExpired:
             code, stdout, stderr = -1, "", "TIMEOUT"

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import re
+import subprocess
+
 from runners.cpp_runner import (
     compile_cpp_sources,
     compile_shared_library,
@@ -33,7 +36,9 @@ int main() { std::cout << add(1, 2); }
 def test_shared_library_link(tmp_path: Path) -> None:
     """Build a shared library and link it into a main program."""
     lib_src = tmp_path / "double.cpp"
-    lib_src.write_text('extern "C" int times_two(int x){return 2*x;}\n')
+    lib_src.write_text(
+        'extern "C" int times_two(int x){return 2*x;}\n'
+    )
 
     lib_path = tmp_path / "libdouble.so"
     success, out, err, so = compile_shared_library([lib_src], output=lib_path)
@@ -61,3 +66,70 @@ int main(){std::cout<<times_two(5);}
     code, stdout, stderr = run_binary(binary)
     assert code == 0
     assert stdout.strip() == "10"
+
+
+def test_shared_library_env_link(tmp_path: Path) -> None:
+    """Link a shared library and supply its path via ``LD_LIBRARY_PATH``."""
+    lib_src = tmp_path / "double.cpp"
+    lib_src.write_text(
+        'extern "C" int times_two(int x){return 2*x;}\n'
+    )
+
+    lib_path = tmp_path / "libdouble.so"
+    success, out, err, so = compile_shared_library([lib_src], output=lib_path)
+    assert success, f"lib compile failed: {out}\n{err}"
+    assert so is not None
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+extern "C" int times_two(int);
+int main(){std::cout<<times_two(5);}
+"""
+    )
+
+    success, out, err, binary = compile_cpp_sources(
+        [main],
+        library_dirs=[tmp_path],
+        libraries=["double"],
+    )
+    assert success, f"compile failed: {out}\n{err}"
+    assert binary is not None
+
+    code, stdout, stderr = run_binary(
+        binary, env={"LD_LIBRARY_PATH": str(tmp_path)}
+    )
+    assert code == 0
+    assert stdout.strip() == "10"
+
+
+def test_static_build(tmp_path: Path) -> None:
+    """Request a static binary and verify it's not dynamically linked."""
+    src = tmp_path / "main.cpp"
+    src.write_text("int main(){return 0;}")
+
+    success, out, err, binary = compile_cpp_sources(
+        [src], static=True, sanitize=False
+    )
+    assert success, f"compile failed: {out}\n{err}"
+    assert binary is not None
+
+    ldd = subprocess.run(["ldd", str(binary)], capture_output=True, text=True)
+    assert "not a dynamic executable" in (ldd.stdout + ldd.stderr)
+
+
+def test_ccache_hit(tmp_path: Path) -> None:
+    """Ensure that invoking ``use_ccache`` results in cache hits."""
+    src = tmp_path / "foo.cpp"
+    src.write_text("int add(int a,int b){return a+b;}")
+    obj = tmp_path / "foo.o"
+
+    subprocess.run(["ccache", "-z"], check=True)
+    compile_cpp_sources([src], output=obj, flags=["-c"], use_ccache=True)
+    compile_cpp_sources([src], output=obj, flags=["-c"], use_ccache=True)
+    stats = subprocess.run(
+        ["ccache", "-s", "-v"], capture_output=True, text=True
+    )
+    m = re.search(r"Hits:\s+(\d+)", stats.stdout)
+    assert m and int(m.group(1)) >= 1


### PR DESCRIPTION
## Summary
- extend C++ runner with environment-aware execution and linking options to support static builds, rpath and ccache
- document Phase 10 progress for linking configuration
- add regression tests for shared libraries via LD_LIBRARY_PATH, static binaries, and ccache hits

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py docs/hrmCoder_checklist.md`
- `PYTHONPATH=. pytest tests/test_cpp_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a042d8a254833190711d4a3f8e2c0d