### PR TITLE
feat: add humaneval dataset loader with schema validation

### DIFF
--- a/dataset/humaneval_cpp_loader.py
+++ b/dataset/humaneval_cpp_loader.py
@@ -1,0 +1,79 @@
+"""Loader for HumanEval-CPP dataset with schema validation.
+
+This module reads a processed HumanEval-CPP dataset directory and
+returns structured objects for each task.  It validates that the
+expected files are present in every task directory and uses
+``pydantic`` models to enforce the schema.  The loader is intended for
+Phase 3 where dataset schemas require explicit contracts and unit
+ tests.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class HumanEvalCPPRecord(BaseModel):
+    """Represents a single HumanEval-CPP task."""
+
+    task_id: str
+    prompt: str
+    test: str
+    reference_solution: Optional[str]
+    split: str
+
+
+def _load_task(task_dir: Path, split: str) -> HumanEvalCPPRecord:
+    """Load a single task located at *task_dir*.
+
+    Parameters
+    ----------
+    task_dir:
+        Path to the task directory containing ``prompt.cpp`` and
+        ``tests.cpp`` files.  ``reference.cpp`` is optional.
+    split:
+        Name of the dataset split (``train``, ``val`` or ``test``).
+    """
+    prompt_path = task_dir / "prompt.cpp"
+    tests_path = task_dir / "tests.cpp"
+    if not prompt_path.exists() or not tests_path.exists():
+        missing = []
+        if not prompt_path.exists():
+            missing.append("prompt.cpp")
+        if not tests_path.exists():
+            missing.append("tests.cpp")
+        raise FileNotFoundError(
+            f"Missing required files in {task_dir}: {', '.join(missing)}"
+        )
+
+    reference_path = task_dir / "reference.cpp"
+    reference = reference_path.read_text() if reference_path.exists() else None
+
+    return HumanEvalCPPRecord(
+        task_id=task_dir.name,
+        prompt=prompt_path.read_text(),
+        test=tests_path.read_text(),
+        reference_solution=reference,
+        split=split,
+    )
+
+
+def load_dataset(root: str | Path) -> Dict[str, List[HumanEvalCPPRecord]]:
+    """Load all tasks from a processed HumanEval-CPP dataset.
+
+    The function expects the directory layout produced by
+    ``build_humaneval_cpp_dataset.py`` and returns a mapping of split
+    name to a list of ``HumanEvalCPPRecord`` objects.
+    """
+    root_path = Path(root)
+    splits: Dict[str, List[HumanEvalCPPRecord]] = {"train": [], "val": [], "test": []}
+    for split in splits:
+        split_dir = root_path / split
+        if not split_dir.exists():
+            continue
+        for task_dir in sorted(p for p in split_dir.iterdir() if p.is_dir()):
+            record = _load_task(task_dir, split)
+            splits[split].append(record)
+    return splits

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -45,7 +45,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement AtCoder ABC subset builder with normalized input/output cases
     [X] Write determinism validator to re-run and hash equality of artifacts
     [ ] Integrate DVC pipelines and data/versions.yml locking
-    [ ] Add dataset schema contracts and unit tests for loaders
+    [~] Add dataset schema contracts and unit tests for loaders
     [~] Implement dataset split manager for train/val/test with fixed seeds
 
 ** [ ] Phase 4: Sandbox Executor

--- a/tests/test_humaneval_cpp_loader.py
+++ b/tests/test_humaneval_cpp_loader.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import json
+import pytest
+
+from dataset.build_humaneval_cpp_dataset import build_dataset
+from dataset.humaneval_cpp_loader import HumanEvalCPPRecord, load_dataset
+
+
+def _write_sample_dataset(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "task1",
+            "prompt": "int add(int a,int b){return a+b;}\n",
+            "test": "#include <cassert>\nint main(){assert(add(1,2)==3);}\n",
+            "reference_solution": "int add(int a,int b){return a+b;}\n",
+        },
+        {
+            "task_id": "task2",
+            "prompt": "int sub(int a,int b){return a-b;}\n",
+            "test": "#include <cassert>\nint main(){assert(sub(3,1)==2);}\n",
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_loader_round_trip(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    splits = load_dataset(out_dir)
+    assert set(splits.keys()) == {"train", "val", "test"}
+    all_tasks = [t for tasks in splits.values() for t in tasks]
+    assert len(all_tasks) == 2
+    first = next(t for t in all_tasks if t.task_id == "task1")
+    assert isinstance(first, HumanEvalCPPRecord)
+    assert "add" in first.prompt
+
+
+def test_loader_missing_files(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    # remove tests.cpp from one task to trigger error
+    task_dir = next((out_dir / "train").iterdir())
+    (task_dir / "tests.cpp").unlink()
+    with pytest.raises(FileNotFoundError):
+        load_dataset(out_dir)


### PR DESCRIPTION
## Summary
- add `HumanEvalCPPRecord` data model and loader with file existence checks
- cover loader with round-trip and error tests
- update Phase 3 checklist to track dataset schema contract work

## Testing
- `python -m pytest tests/test_humaneval_cpp_loader.py tests/test_dataset_determinism.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0522f89c88331bd0a700415f50ee4