### PR TITLE
feat: add baseline comparison helpers

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -77,7 +77,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement determinism checker to re-run top-k with shuffled ordering
     [X] Implement flaky-test detector and flagging in results
     [X] Build HTML and Markdown report generator with tables and plots
-    [~] Implement baseline comparator against recorded C++ code-LM prompts
+    [X] Implement baseline comparator against recorded C++ code-LM prompts
     [X] Implement artifact bundler and uploader for reports and raw JSON
 
 ** [ ] Phase 8: CI/CD and Automation

--- a/hrm_coder/evaluation.py
+++ b/hrm_coder/evaluation.py
@@ -9,8 +9,10 @@ high-level plan laid out in the documentation.
 """
 
 from dataclasses import dataclass
-from typing import Dict, Sequence, Iterable, List
+import json
 import math
+from pathlib import Path
+from typing import Dict, Sequence, Iterable, List, Optional
 
 
 @dataclass
@@ -116,5 +118,80 @@ def html_report(metrics: Dict[int, float], flaky: Sequence[str]) -> str:
         "<table><tr><th>k</th><th>pass@k</th></tr>"
         f"{rows}</table>"
         f"{flaky_html}"
+    )
+
+
+def compare_to_baseline(
+    current: Dict[str, float], baseline_path: str
+) -> Dict[str, Dict[str, Optional[float]]]:
+    """Compare ``current`` metrics to a JSON baseline.
+
+    Parameters
+    ----------
+    current:
+        Mapping of metric name to value for the current run.
+    baseline_path:
+        Path to a JSON file containing the baseline metrics with the
+        same keys as ``current``.
+
+    Returns
+    -------
+    Dict[str, Dict[str, Optional[float]]]
+        Mapping metric name → {"baseline", "current", "delta"}.
+        ``delta`` is ``None`` when the metric is missing from the baseline.
+    """
+
+    p = Path(baseline_path)
+    baseline = json.loads(p.read_text()) if p.exists() else {}
+    comparison: Dict[str, Dict[str, Optional[float]]] = {}
+    for key, cur_val in current.items():
+        base_val = baseline.get(key)
+        delta = cur_val - base_val if base_val is not None else None
+        comparison[key] = {
+            "baseline": base_val,
+            "current": cur_val,
+            "delta": delta,
+        }
+    return comparison
+
+
+def comparison_markdown_report(
+    comparison: Dict[str, Dict[str, Optional[float]]]
+) -> str:
+    """Render a baseline comparison as a Markdown table."""
+
+    lines = [
+        "# Baseline Comparison",
+        "",
+        "| metric | baseline | current | delta |",
+        "|---|---|---|---|",
+    ]
+    def fmt(val: Optional[float]) -> str:
+        return f"{val:.3f}" if isinstance(val, float) else str(val)
+
+    for metric, vals in comparison.items():
+        lines.append(
+            f"| {metric} | {fmt(vals['baseline'])} | {fmt(vals['current'])} | {fmt(vals['delta'])} |"
+        )
+    return "\n".join(lines)
+
+
+def comparison_html_report(
+    comparison: Dict[str, Dict[str, Optional[float]]]
+) -> str:
+    """Render a baseline comparison as HTML."""
+
+    def fmt(val: Optional[float]) -> str:
+        return f"{val:.3f}" if isinstance(val, float) else str(val)
+
+    rows = "".join(
+        f"<tr><td>{metric}</td><td>{fmt(vals['baseline'])}</td><td>{fmt(vals['current'])}</td>"
+        f"<td>{fmt(vals['delta'])}</td></tr>"
+        for metric, vals in comparison.items()
+    )
+    return (
+        "<h1>Baseline Comparison</h1>"
+        "<table><tr><th>metric</th><th>baseline</th><th>current</th><th>delta</th></tr>"
+        f"{rows}</table>"
     )
 

--- a/hrm_coder/tests/test_evaluation.py
+++ b/hrm_coder/tests/test_evaluation.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from hrm_coder.evaluation import (
@@ -7,6 +8,9 @@ from hrm_coder.evaluation import (
     flaky_tasks,
     markdown_report,
     html_report,
+    compare_to_baseline,
+    comparison_markdown_report,
+    comparison_html_report,
 )
 
 def test_pass_at_k_and_aggregate():
@@ -38,3 +42,20 @@ def test_report_generation():
     report_html = html_report(metrics, [])
     assert '<td>1</td><td>0.500</td>' in report_html
     assert 'No flaky tasks' in report_html
+
+
+def test_baseline_comparison(tmp_path):
+    baseline = {"pass@1": 0.4}
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(baseline))
+
+    current = {"pass@1": 0.6}
+    comparison = compare_to_baseline(current, str(baseline_file))
+
+    assert comparison["pass@1"]["delta"] == pytest.approx(0.2)
+
+    report_md = comparison_markdown_report(comparison)
+    assert "| pass@1 | 0.400 | 0.600 | 0.200 |" in report_md
+
+    report_html = comparison_html_report(comparison)
+    assert "<td>0.600</td>" in report_html


### PR DESCRIPTION
## Summary
- add utilities to compare evaluation metrics against a JSON baseline
- render baseline deltas as Markdown or HTML tables
- mark Phase 7 checklist item for baseline comparator as complete

## Testing
- `pytest hrm_coder/tests/test_evaluation.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0523863ac8331b88daa6144a9ab1b