### PR TITLE
feat: report compiler diagnostics in C++ runner

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -4,7 +4,9 @@ This module provides a minimal wrapper around the system C++ compiler and
 runtime execution.  It is intended as an early step toward the full Phase 10
 C++ runner described in the project roadmap.  The functions here support
 compilation with common optimization and sanitizer flags and running binaries
-against multiple input/output pairs with basic resource limits.
+against multiple input/output pairs with basic resource limits.  It also
+includes basic compiler diagnostics parsing to report warning and error
+counts, advancing the Phase 10 goal of richer feedback from the build step.
 """
 from __future__ import annotations
 
@@ -13,8 +15,11 @@ import resource
 import shutil
 import subprocess
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from utils.diagnostics import compiler_diagnostics
 
 
 DEFAULT_FLAGS: List[str] = ["-std=c++17", "-O2", "-pipe"]
@@ -22,6 +27,18 @@ SANITIZER_FLAGS: List[str] = [
     "-fsanitize=address,undefined",
     "-fno-omit-frame-pointer",
 ]
+
+
+@dataclass
+class CompileResult:
+    """Result of a compilation step."""
+
+    success: bool
+    stdout: str
+    stderr: str
+    binary: Optional[Path]
+    warnings: int
+    errors: int
 
 
 def compile_cpp_sources(
@@ -36,7 +53,7 @@ def compile_cpp_sources(
     libraries: Optional[Iterable[str]] = None,
     rpath: Optional[Iterable[Path]] = None,
     use_ccache: bool = False,
-) -> Tuple[bool, str, str, Optional[Path]]:
+) -> CompileResult:
     """Compile one or more C++ ``sources`` into a single binary.
 
     This helper expands the simple single-file ``compile_cpp`` function to
@@ -106,7 +123,15 @@ def compile_cpp_sources(
 
     proc = subprocess.run(cmd, capture_output=True, text=True)
     success = proc.returncode == 0
-    return success, proc.stdout, proc.stderr, output_path if success else None
+    warnings, errors = compiler_diagnostics(proc.stdout, proc.stderr)
+    return CompileResult(
+        success,
+        proc.stdout,
+        proc.stderr,
+        output_path if success else None,
+        warnings,
+        errors,
+    )
 
 
 def compile_shared_library(
@@ -117,7 +142,7 @@ def compile_shared_library(
     flags: Optional[Iterable[str]] = None,
     sanitize: bool = True,
     use_ccache: bool = False,
-) -> Tuple[bool, str, str, Optional[Path]]:
+) -> CompileResult:
     """Compile ``sources`` into a shared library.
 
     This helper produces a ``.so`` suitable for linking against binaries
@@ -150,7 +175,15 @@ def compile_shared_library(
 
     proc = subprocess.run(cmd, capture_output=True, text=True)
     success = proc.returncode == 0
-    return success, proc.stdout, proc.stderr, output_path if success else None
+    warnings, errors = compiler_diagnostics(proc.stdout, proc.stderr)
+    return CompileResult(
+        success,
+        proc.stdout,
+        proc.stderr,
+        output_path if success else None,
+        warnings,
+        errors,
+    )
 
 
 def compile_cpp(
@@ -160,7 +193,7 @@ def compile_cpp(
     compiler: str = "g++",
     flags: Optional[Iterable[str]] = None,
     sanitize: bool = True,
-) -> Tuple[bool, str, str, Optional[Path]]:
+) -> CompileResult:
     """Compile a single C++ ``source`` file.
 
     This is a thin wrapper around :func:`compile_cpp_sources` for backwards
@@ -246,7 +279,7 @@ def run_codeforces_tests(
     per-test outcomes.
     """
 
-    success, out, err, binary = compile_cpp_sources(
+    compile_res = compile_cpp_sources(
         sources,
         compiler=compiler,
         flags=flags,
@@ -258,10 +291,12 @@ def run_codeforces_tests(
         use_ccache=use_ccache,
     )
     results = []
-    if not success or binary is None:
+    if not compile_res.success or compile_res.binary is None:
         return {
-            "compile_stdout": out,
-            "compile_stderr": err,
+            "compile_stdout": compile_res.stdout,
+            "compile_stderr": compile_res.stderr,
+            "compile_warnings": compile_res.warnings,
+            "compile_errors": compile_res.errors,
             "results": results,
         }
 
@@ -272,7 +307,7 @@ def run_codeforces_tests(
         expected = expected_file.read_text() if expected_file.exists() else ""
         try:
             code, stdout, stderr = run_binary(
-                binary,
+                compile_res.binary,
                 input_data=input_data,
                 timeout=timeout,
                 memory_limit=memory_limit,
@@ -290,4 +325,10 @@ def run_codeforces_tests(
             }
         )
 
-    return {"compile_stdout": out, "compile_stderr": err, "results": results}
+    return {
+        "compile_stdout": compile_res.stdout,
+        "compile_stderr": compile_res.stderr,
+        "compile_warnings": compile_res.warnings,
+        "compile_errors": compile_res.errors,
+        "results": results,
+    }

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,7 +1,12 @@
 from pathlib import Path
 
+from pathlib import Path
+import pathlib
 import re
 import subprocess
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from runners.cpp_runner import (
     compile_cpp_sources,
@@ -24,11 +29,11 @@ int main() { std::cout << add(1, 2); }
     )
     helper.write_text("int add(int a, int b) { return a + b; }\n")
 
-    success, out, err, binary = compile_cpp_sources([main, helper])
-    assert success, f"compile failed: {out}\n{err}"
-    assert binary is not None
+    res = compile_cpp_sources([main, helper])
+    assert res.success, f"compile failed: {res.stdout}\n{res.stderr}"
+    assert res.binary is not None
 
-    code, stdout, stderr = run_binary(binary)
+    code, stdout, stderr = run_binary(res.binary)
     assert code == 0
     assert stdout.strip() == "3"
 
@@ -41,9 +46,9 @@ def test_shared_library_link(tmp_path: Path) -> None:
     )
 
     lib_path = tmp_path / "libdouble.so"
-    success, out, err, so = compile_shared_library([lib_src], output=lib_path)
-    assert success, f"lib compile failed: {out}\n{err}"
-    assert so is not None
+    lib_res = compile_shared_library([lib_src], output=lib_path)
+    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
     main.write_text(
@@ -54,16 +59,16 @@ int main(){std::cout<<times_two(5);}
 """
     )
 
-    success, out, err, binary = compile_cpp_sources(
+    main_res = compile_cpp_sources(
         [main],
         library_dirs=[tmp_path],
         libraries=["double"],
         rpath=[tmp_path],
     )
-    assert success, f"compile failed: {out}\n{err}"
-    assert binary is not None
+    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.binary is not None
 
-    code, stdout, stderr = run_binary(binary)
+    code, stdout, stderr = run_binary(main_res.binary)
     assert code == 0
     assert stdout.strip() == "10"
 
@@ -76,9 +81,9 @@ def test_shared_library_env_link(tmp_path: Path) -> None:
     )
 
     lib_path = tmp_path / "libdouble.so"
-    success, out, err, so = compile_shared_library([lib_src], output=lib_path)
-    assert success, f"lib compile failed: {out}\n{err}"
-    assert so is not None
+    lib_res = compile_shared_library([lib_src], output=lib_path)
+    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
     main.write_text(
@@ -89,16 +94,16 @@ int main(){std::cout<<times_two(5);}
 """
     )
 
-    success, out, err, binary = compile_cpp_sources(
+    main_res = compile_cpp_sources(
         [main],
         library_dirs=[tmp_path],
         libraries=["double"],
     )
-    assert success, f"compile failed: {out}\n{err}"
-    assert binary is not None
+    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.binary is not None
 
     code, stdout, stderr = run_binary(
-        binary, env={"LD_LIBRARY_PATH": str(tmp_path)}
+        main_res.binary, env={"LD_LIBRARY_PATH": str(tmp_path)}
     )
     assert code == 0
     assert stdout.strip() == "10"
@@ -109,13 +114,11 @@ def test_static_build(tmp_path: Path) -> None:
     src = tmp_path / "main.cpp"
     src.write_text("int main(){return 0;}")
 
-    success, out, err, binary = compile_cpp_sources(
-        [src], static=True, sanitize=False
-    )
-    assert success, f"compile failed: {out}\n{err}"
-    assert binary is not None
+    res = compile_cpp_sources([src], static=True, sanitize=False)
+    assert res.success, f"compile failed: {res.stdout}\n{res.stderr}"
+    assert res.binary is not None
 
-    ldd = subprocess.run(["ldd", str(binary)], capture_output=True, text=True)
+    ldd = subprocess.run(["ldd", str(res.binary)], capture_output=True, text=True)
     assert "not a dynamic executable" in (ldd.stdout + ldd.stderr)
 
 
@@ -133,3 +136,14 @@ def test_ccache_hit(tmp_path: Path) -> None:
     )
     m = re.search(r"Hits:\s+(\d+)", stats.stdout)
     assert m and int(m.group(1)) >= 1
+
+
+def test_warning_count(tmp_path: Path) -> None:
+    """Compile code with a warning and ensure it is reported."""
+    src = tmp_path / "warn.cpp"
+    src.write_text("int main(){int x; return 0;}")
+    res = compile_cpp_sources([
+        src
+    ], flags=["-std=c++17", "-Wall"], sanitize=False)
+    assert res.success
+    assert res.warnings >= 1

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,7 +3,12 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from utils.diagnostics import clang_tidy_score, cppcheck_score, coverage_delta
+from utils.diagnostics import (
+    clang_tidy_score,
+    cppcheck_score,
+    coverage_delta,
+    compiler_diagnostics,
+)
 
 
 def test_clang_tidy_score():
@@ -20,3 +25,11 @@ def test_cppcheck_score():
 def test_coverage_delta():
     assert coverage_delta(0.2, 0.5) == 0.3
     assert coverage_delta(0.6, 0.2) == 0.0
+
+
+def test_compiler_diagnostics():
+    stdout = "main.cpp:1:1: warning: stuff\n"
+    stderr = "main.cpp:2:2: error: oops\n"
+    warnings, errors = compiler_diagnostics(stdout, stderr)
+    assert warnings == 1
+    assert errors == 1

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -5,6 +5,7 @@ from .functions import load_model_class, get_model_source_path  # noqa: F401
 from .diagnostics import (  # noqa: F401
     clang_tidy_score,
     cppcheck_score,
+    compiler_diagnostics,
     coverage_delta,
 )
 

--- a/utils/diagnostics.py
+++ b/utils/diagnostics.py
@@ -27,6 +27,15 @@ def cppcheck_score(output: str) -> float:
     return max(0.0, 1.0 - 0.1 * problems)
 
 
+def compiler_diagnostics(stdout: str, stderr: str) -> tuple[int, int]:
+    """Return counts of warnings and errors from compiler output."""
+
+    text = f"{stdout}\n{stderr}"
+    warnings = len(re.findall(r": warning:", text))
+    errors = len(re.findall(r": error:", text))
+    return warnings, errors
+
+
 def sanitizer_clean(output: str) -> bool:
     """Return True when no sanitizer issues are detected.
 


### PR DESCRIPTION
## Summary
- parse compiler warnings and errors while building C++ sources
- surface diagnostic counts through Codeforces test runner
- cover compiler diagnostics with new unit tests

## Testing
- `pytest tests/test_cpp_runner.py tests/test_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a052409bfc8331b97b90fda3359735