### PR TITLE
Add error taxonomy to sandbox executor

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -53,7 +53,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
     [~] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
     [~] Implement caching layer keyed by prompt+code+tests+limits hash
-    [ ] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
+    [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
     [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)
 
 ** [ ] Phase 5: Reward Shaping and Safety Gates

--- a/runners/__init__.py
+++ b/runners/__init__.py
@@ -3,5 +3,12 @@
 from .gvisor import GVisorRunner
 from .isolate import IsolateRunner
 from .nsjail import NSJailRunner
+from .error_taxonomy import classify_compile, classify_runtime
 
-__all__ = ["GVisorRunner", "IsolateRunner", "NSJailRunner"]
+__all__ = [
+    "GVisorRunner",
+    "IsolateRunner",
+    "NSJailRunner",
+    "classify_compile",
+    "classify_runtime",
+]

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -16,6 +16,8 @@ import tempfile
 from pathlib import Path
 from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
 
+from .error_taxonomy import classify_compile, classify_runtime
+
 
 DEFAULT_FLAGS: List[str] = ["-std=c++17", "-O2", "-pipe"]
 SANITIZER_FLAGS: List[str] = [
@@ -242,8 +244,8 @@ def run_codeforces_tests(
     """Compile ``sources`` and run them against all tests in ``tests_dir``.
 
     The directory is expected to contain pairs of ``*.in`` and ``*.out`` files.
-    Results are returned as a mapping with compile diagnostics and a list of
-    per-test outcomes.
+    Results include compilation diagnostics and a list of per-test outcomes
+    with error classifications.
     """
 
     success, out, err, binary = compile_cpp_sources(
@@ -257,11 +259,13 @@ def run_codeforces_tests(
         rpath=rpath,
         use_ccache=use_ccache,
     )
+    compile_status = classify_compile(success, err)
     results = []
     if not success or binary is None:
         return {
             "compile_stdout": out,
             "compile_stderr": err,
+            "compile_status": compile_status,
             "results": results,
         }
 
@@ -278,8 +282,11 @@ def run_codeforces_tests(
                 memory_limit=memory_limit,
                 env=env,
             )
+            timed_out = False
         except subprocess.TimeoutExpired:
             code, stdout, stderr = -1, "", "TIMEOUT"
+            timed_out = True
+        error_type = classify_runtime(code, stderr, timed_out=timed_out)
         passed = stdout.strip() == expected.strip() and code == 0
         results.append(
             {
@@ -287,7 +294,13 @@ def run_codeforces_tests(
                 "passed": passed,
                 "stdout": stdout,
                 "stderr": stderr,
+                "error_type": error_type,
             }
         )
 
-    return {"compile_stdout": out, "compile_stderr": err, "results": results}
+    return {
+        "compile_stdout": out,
+        "compile_stderr": err,
+        "compile_status": compile_status,
+        "results": results,
+    }

--- a/runners/error_taxonomy.py
+++ b/runners/error_taxonomy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Utilities for classifying compilation and execution outcomes.
+
+This module implements a small error taxonomy used by Phase 4's sandbox
+executor.  It distinguishes between compilation failures, linker issues,
+run-time errors, timeouts, sanitizer crashes, and sandbox policy
+violations.  The functions intentionally rely on simple substring
+matches so they can operate on raw ``stderr`` output without requiring
+compiler-specific knowledge.
+"""
+
+from typing import Iterable
+
+# Patterns used to detect particular error categories.  All comparisons are
+# performed on lower-cased ``stderr`` text.
+_LINK_PATTERNS: Iterable[str] = [
+    "undefined reference",
+    "ld returned",
+    "linker command failed",
+]
+
+_SANITIZER_PATTERNS: Iterable[str] = [
+    "addresssanitizer",
+    "undefinedbehaviorsanitizer",
+    "ubsan",
+    "asan",
+]
+
+_POLICY_PATTERNS: Iterable[str] = [
+    "operation not permitted",
+    "permission denied",
+    "policy violation",
+    "sandbox",
+]
+
+
+def classify_compile(success: bool, stderr: str) -> str:
+    """Classify the result of a compilation step.
+
+    Parameters
+    ----------
+    success:
+        Boolean indicating whether the compiler exited with status code ``0``.
+    stderr:
+        ``stderr`` text produced by the compiler.
+
+    Returns
+    -------
+    str
+        One of ``"success"``, ``"link_error"``, or ``"compile_error"``.
+    """
+
+    if success:
+        return "success"
+    err = stderr.lower()
+    for pat in _LINK_PATTERNS:
+        if pat in err:
+            return "link_error"
+    return "compile_error"
+
+
+def classify_runtime(
+    returncode: int,
+    stderr: str,
+    *,
+    timed_out: bool = False,
+) -> str:
+    """Classify the result of executing a binary.
+
+    Parameters
+    ----------
+    returncode:
+        Process return code from execution.
+    stderr:
+        ``stderr`` text produced by the process.
+    timed_out:
+        Whether execution exceeded the allotted wall time.
+
+    Returns
+    -------
+    str
+        One of ``"success"``, ``"timeout"``,
+        ``"sanitizer_error"``, ``"policy_violation"``, or
+        ``"runtime_error"``.
+    """
+
+    if timed_out:
+        return "timeout"
+    if returncode == 0:
+        return "success"
+
+    err = stderr.lower()
+    for pat in _SANITIZER_PATTERNS:
+        if pat in err:
+            return "sanitizer_error"
+    for pat in _POLICY_PATTERNS:
+        if pat in err or returncode == 159:
+            return "policy_violation"
+    return "runtime_error"

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from runners.cpp_runner import compile_cpp, run_binary
+from runners.error_taxonomy import classify_compile, classify_runtime
+
+
+def test_classify_compile_errors(tmp_path: Path) -> None:
+    """Detect compile-time and link-time failures."""
+    src = tmp_path / "syntax.cpp"
+    src.write_text(
+        "#include <nonexistent_header.h>\n"
+        "int main(){}"
+    )
+    success, _, err, _ = compile_cpp(src, sanitize=False)
+    assert not success
+    assert classify_compile(success, err) == "compile_error"
+
+    src2 = tmp_path / "link.cpp"
+    src2.write_text("extern int foo(); int main(){return foo();}")
+    success2, out2, err2, _ = compile_cpp(src2, sanitize=False)
+    assert not success2
+    assert classify_compile(success2, err2) == "link_error"
+
+
+def test_classify_runtime_conditions(tmp_path: Path) -> None:
+    """Classify runtime error types including timeout and sanitizers."""
+    # Runtime error due to non-zero exit code
+    src = tmp_path / "runtime.cpp"
+    src.write_text("int main(){return 1;}")
+    success, _, err, binary = compile_cpp(src, sanitize=False)
+    assert success and binary is not None
+    code, out, err = run_binary(binary)
+    assert classify_runtime(code, err) == "runtime_error"
+
+    # Timeout
+    src_t = tmp_path / "loop.cpp"
+    src_t.write_text("int main(){while(true){} }")
+    success_t, _, _, binary_t = compile_cpp(src_t, sanitize=False)
+    assert success_t and binary_t is not None
+    try:
+        run_binary(binary_t, timeout=0.1)
+        timed_out = False
+        code, _, err_t = 0, "", ""
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        code, err_t = -1, ""
+    assert classify_runtime(code, err_t, timed_out=timed_out) == "timeout"
+
+    # Sanitizer error
+    src_s = tmp_path / "asan.cpp"
+    src_s.write_text(
+        "#include <iostream>\nint main(){int *p=new int[1];delete[] p;"
+        "std::cout<<p[0];}"
+    )
+    success_s, _, _, binary_s = compile_cpp(src_s)
+    assert success_s and binary_s is not None
+    code_s, _, err_s = run_binary(binary_s)
+    assert classify_runtime(code_s, err_s) == "sanitizer_error"


### PR DESCRIPTION
## Summary
- add error taxonomy utility to classify compile, link, runtime, timeout, and policy failures
- integrate taxonomy with C++ runner and expose helpers at package level
- track phase progress in docs

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md runners/__init__.py runners/cpp_runner.py runners/error_taxonomy.py tests/test_error_taxonomy.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0523205208331b66546bd5f7b5cc4