### PR TITLE
Add sandbox detection helper for Phase 0

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -15,6 +15,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Inventory HRM repo APIs and identify injection points for C++ token/AST decoders
     [~] Setup project operation within isolate/gVisor runner images
     [~] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
+        - Added sandbox detection utility for isolate, nsjail, and gVisor runsc runtime
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
     [ ] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
     [ ] Draft sandbox Threat Model and initial security requirements for native binaries

--- a/runners/sandbox_detector.py
+++ b/runners/sandbox_detector.py
@@ -1,0 +1,63 @@
+"""Utility functions to detect available sandbox backends.
+
+Phase 0 focuses on evaluating existing sandboxing options.  This module
+provides a small helper that inspects the current environment for the
+presence of ``isolate``, ``nsjail`` and gVisor's ``runsc`` runtime.  It
+returns structured information that can be used to decide which adapter
+is usable on a given system.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Dict, Optional
+
+
+class SandboxInfo(Dict[str, Optional[str]]):
+    """Dictionary describing a sandbox binary.
+
+    Keys
+    ----
+    available:
+        ``True`` if the binary is present on ``PATH``.
+    version:
+        Version string reported by ``--version`` (``None`` if unknown).
+    path:
+        Resolved path to the binary (``None`` if missing).
+    """
+
+
+def _probe_version(cmd: str) -> Optional[str]:
+    """Return the first line of ``cmd --version`` if it executes successfully."""
+    try:
+        proc = subprocess.run([cmd, "--version"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return None
+    if proc.returncode != 0:
+        return None
+    line = proc.stdout.strip().splitlines()
+    return line[0] if line else None
+
+
+def detect_sandboxes() -> Dict[str, SandboxInfo]:
+    """Detect availability of supported sandbox tools.
+
+    Returns a mapping from sandbox name (``isolate``, ``nsjail``, ``runsc``)
+    to :class:`SandboxInfo` entries describing presence and version
+    information.  Missing binaries are reported with ``available=False``.
+    """
+    tools = {
+        "isolate": "isolate",
+        "nsjail": "nsjail",
+        "runsc": "runsc",
+    }
+    results: Dict[str, SandboxInfo] = {}
+    for name, binary in tools.items():
+        path = shutil.which(binary)
+        info: SandboxInfo = SandboxInfo(available=False, version=None, path=None)
+        if path:
+            info["available"] = True
+            info["path"] = path
+            info["version"] = _probe_version(binary)
+        results[name] = info
+    return results

--- a/tests/test_sandbox_detector.py
+++ b/tests/test_sandbox_detector.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from runners import sandbox_detector
+
+
+def test_detect_sandboxes_all_missing(monkeypatch):
+    monkeypatch.setattr(sandbox_detector.shutil, "which", lambda cmd: None)
+    result = sandbox_detector.detect_sandboxes()
+    assert set(result.keys()) == {"isolate", "nsjail", "runsc"}
+    assert all(not info["available"] for info in result.values())
+
+
+def test_detect_sandboxes_reports_version(monkeypatch):
+    def fake_which(cmd: str):
+        return f"/usr/bin/{cmd}"
+
+    def fake_run(cmd, capture_output, text):
+        return SimpleNamespace(returncode=0, stdout=f"{cmd[0]} version 1.2\n")
+
+    monkeypatch.setattr(sandbox_detector.shutil, "which", fake_which)
+    monkeypatch.setattr(sandbox_detector.subprocess, "run", fake_run)
+    result = sandbox_detector.detect_sandboxes()
+    assert all(info["available"] for info in result.values())
+    assert all(info["version"].endswith("1.2") for info in result.values())


### PR DESCRIPTION
## Summary
- add sandbox_detector utility to probe isolate, nsjail and runsc availability
- test sandbox detection for missing binaries and version reporting
- note sandbox detection progress in Phase 0 checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a05227bcb4833193face46d7ec58a0