### PR TITLE
feat: add runner config

### DIFF
--- a/hrm_coder/conf/config.yaml
+++ b/hrm_coder/conf/config.yaml
@@ -1,4 +1,5 @@
 defaults:
   - dataset: humaneval_cpp
   - model: small
+  - runner: default
   - _self_

--- a/hrm_coder/conf/runner/default.yaml
+++ b/hrm_coder/conf/runner/default.yaml
@@ -1,0 +1,3 @@
+compiler: g++
+sandbox: nsjail
+timeout: 5

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -23,10 +23,25 @@ class DatasetConfig:
 
 
 @dataclass
+class RunnerConfig:
+    """Configuration for the sandbox runner.
+
+    These defaults are intentionally lightweight but provide a
+    foundation for Phase 1 deterministic execution. They will be
+    expanded in later phases to cover additional runner options.
+    """
+
+    compiler: str = "g++"
+    sandbox: str = "nsjail"
+    timeout: int = 5
+
+
+@dataclass
 class AppConfig:
     """Top-level application configuration."""
     model: ModelConfig = field(default_factory=ModelConfig)
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
+    runner: RunnerConfig = field(default_factory=RunnerConfig)
 
 
 def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
@@ -47,7 +62,14 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
     return AppConfig(
         model=ModelConfig(**cfg_dict["model"]),
         dataset=DatasetConfig(**cfg_dict["dataset"]),
+        runner=RunnerConfig(**cfg_dict["runner"]),
     )
 
 
-__all__ = ["AppConfig", "DatasetConfig", "ModelConfig", "load_config"]
+__all__ = [
+    "AppConfig",
+    "DatasetConfig",
+    "ModelConfig",
+    "RunnerConfig",
+    "load_config",
+]

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -5,8 +5,14 @@ def test_load_config_defaults():
     cfg = load_config()
     assert cfg.model.name == "small"
     assert cfg.dataset.name == "humaneval-cpp"
+    assert cfg.runner.compiler == "g++"
+    assert cfg.runner.timeout == 5
 
 
 def test_load_config_override():
-    cfg = load_config(["model.learning_rate=0.01"])
+    cfg = load_config([
+        "model.learning_rate=0.01",
+        "runner.timeout=10",
+    ])
     assert cfg.model.learning_rate == 0.01
+    assert cfg.runner.timeout == 10


### PR DESCRIPTION
## Summary
- add `RunnerConfig` to Hydra schema for Phase 1 runner settings
- include default runner config and hook into AppConfig
- extend tests for runner overrides

## Testing
- `pre-commit run --files hrm_coder/config.py hrm_coder/conf/config.yaml hrm_coder/conf/runner/default.yaml hrm_coder/tests/test_config.py`
- `pytest hrm_coder/tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0522b39b88331805fc81b618bc7bc