### PR TITLE
feat(gui): list artifacts for runs

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -35,7 +35,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement mock run registry with in-memory store and pagination
     [X] Build Run Console page with config pickers and action buttons
     [X] Build Jobs list page with sortable metrics and artifact links
-    [~] Implement artifact static server for JUnit XML and lcov/llvm-cov HTML
+    [X] Implement artifact static server for JUnit XML and lcov/llvm-cov HTML
     [X] Add WebSocket log streamer with tail-follow behavior
     [X] Provide GUI quickstart docs and sample configs
 

--- a/docs/hrmCoder_gui_quickstart.md
+++ b/docs/hrmCoder_gui_quickstart.md
@@ -16,4 +16,10 @@ curl http://localhost:8000/runs
 
 # Start a training run
 curl -X POST http://localhost:8000/train -H 'Content-Type: application/json' -d '{}'
+
+# List artifacts for a run
+curl http://localhost:8000/runs/1/artifacts
+
+# Fetch an artifact file
+curl http://localhost:8000/artifacts/run_1/result.xml
 ```

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 from pathlib import Path
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -64,6 +64,19 @@ def _init_artifact(run_id: int) -> None:
     if not placeholder.exists():
         placeholder.write_text("artifacts for run %d" % run_id)
     registry.get_run(run_id).artifact = f"/artifacts/run_{run_id}/"
+
+
+@app.get("/runs/{run_id}/artifacts")
+def list_artifacts(run_id: int) -> Dict[str, List[str]]:
+    """Return a list of artifact files for a run."""
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    path = ARTIFACT_DIR / f"run_{run_id}"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="artifact not found")
+    files = [str(p.relative_to(path)) for p in path.rglob("*") if p.is_file()]
+    return {"files": files}
 
 
 @app.websocket("/logs/ws/{run_id}")

--- a/hrm_coder/tests/test_artifacts.py
+++ b/hrm_coder/tests/test_artifacts.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from .. import app
+
+
+def test_artifact_static_server(tmp_path):
+    client = TestClient(app)
+    run = client.post('/train', json={}).json()
+    run_id = run['id']
+    artifact_path = Path('hrm_coder/artifacts') / f'run_{run_id}'
+    (artifact_path / 'result.xml').write_text('<testsuite/>')
+    resp = client.get(f"/artifacts/run_{run_id}/result.xml")
+    assert resp.status_code == 200
+    assert '<testsuite/>' in resp.text
+
+
+def test_artifact_listing(tmp_path):
+    client = TestClient(app)
+    run = client.post('/train', json={}).json()
+    run_id = run['id']
+    artifact_path = Path('hrm_coder/artifacts') / f'run_{run_id}'
+    (artifact_path / 'junit.xml').write_text('<junit/>')
+    (artifact_path / 'coverage').mkdir(exist_ok=True)
+    (artifact_path / 'coverage' / 'index.html').write_text('cov')
+    resp = client.get(f"/runs/{run_id}/artifacts")
+    files = resp.json()['files']
+    assert 'junit.xml' in files
+    assert 'coverage/index.html' in files

--- a/hrm_coder/tests/test_websocket.py
+++ b/hrm_coder/tests/test_websocket.py
@@ -1,17 +1,7 @@
-from pathlib import Path
 from fastapi.testclient import TestClient
 
 from .. import app
 from ..run_registry import registry
-
-
-def test_artifact_static_server(tmp_path):
-    client = TestClient(app)
-    artifact_dir = Path('hrm_coder/artifacts')
-    (artifact_dir / 'sample.txt').write_text('hello')
-    resp = client.get('/artifacts/sample.txt')
-    assert resp.status_code == 200
-    assert resp.text == 'hello'
 
 
 def test_websocket_log_stream():


### PR DESCRIPTION
## Summary
- expose `/runs/{id}/artifacts` endpoint to enumerate run artifacts
- document artifact listing and fetching in GUI quickstart
- mark artifact static server task as complete and add tests

## Testing
- `pre-commit run --files hrm_coder/api.py hrm_coder/tests/test_artifacts.py hrm_coder/tests/test_websocket.py docs/hrmCoder_gui_quickstart.md docs/hrmCoder_checklist.md`
- `pytest hrm_coder/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0522d49688331a11dc0a1eb132647