### PR TITLE
feat: add all-green test bonus and compile gate

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -63,6 +63,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement coverage delta computation using gcov/lcov or llvm-cov
     [X] Implement edit-cost, time, and memory penalty functions with clamps
     [X] Add reward histogram logging to tracker with sanity checks
+    [X] Add all-green test bonus to reward aggregator
 
 ** [~] Phase 6: HRM Training Loop Integration
     [X] Implement CodeEncoder interface and tokenizer utilities for C++ syntax

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -180,3 +180,49 @@ def test_sanitizer_bonus_and_penalty():
     assert abs(crash - 0.2) < 1e-6
     assert abs(clean - clean2) < 1e-6
     assert abs(crash - crash2) < 1e-6
+
+
+def test_all_green_bonus_and_compile_gate():
+    agg = RewardAggregator(
+        weights={"compile": 0.1, "tests": 0.2},
+        all_green_bonus=0.5,
+        max_edit_penalty=0.0,
+        max_time_penalty=0.0,
+        max_memory_penalty=0.0,
+    )
+
+    # All tests pass → bonus applied
+    all_green = agg.compute(
+        compile_success=True,
+        tests_passed=3,
+        tests_total=3,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+    )
+    assert abs(all_green - 0.8) < 1e-6
+
+    # Partial pass → no bonus
+    partial = agg.compute(
+        compile_success=True,
+        tests_passed=2,
+        tests_total=3,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+    )
+    assert partial < all_green
+
+    # Compile failure should gate tests/coverage contributions
+    gated = agg.compute(
+        compile_success=False,
+        tests_passed=3,
+        tests_total=3,
+        coverage=1.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+    )
+    assert gated == 0.0

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -22,12 +22,14 @@ class RewardAggregator:
     max_edit_penalty: maximum penalty applied for edit cost.
     max_time_penalty: maximum penalty applied when runtime exceeds the limit.
     max_memory_penalty: maximum penalty applied when memory use exceeds the limit.
+    all_green_bonus: additional reward added when all tests pass.
     """
 
     weights: Dict[str, float]
     max_edit_penalty: float = 0.1
     max_time_penalty: float = 0.1
     max_memory_penalty: float = 0.1
+    all_green_bonus: float = 0.0
     history: List[float] = field(default_factory=list)
 
     def compute(
@@ -51,6 +53,7 @@ class RewardAggregator:
         Parameters
         ----------
         compile_success: whether compilation (and link) succeeded.
+            When ``False`` all test and coverage signals are ignored.
         tests_passed: number of unit tests passed.
         tests_total: total number of unit tests executed.
         coverage: code coverage ratio in [0, 1].
@@ -69,14 +72,23 @@ class RewardAggregator:
         reward = 0.0
 
         compile_score = 1.0 if compile_success else 0.0
-        test_score = tests_passed / tests_total if tests_total else 0.0
-        coverage_score = max(0.0, min(coverage, 1.0))
-        prev_cov = (
-            max(0.0, min(prev_coverage, 1.0))
-            if prev_coverage is not None
-            else None
-        )
-        cov_delta = coverage_delta(prev_cov, coverage_score) if prev_cov is not None else 0.0
+        if compile_success:
+            test_score = tests_passed / tests_total if tests_total else 0.0
+            coverage_score = max(0.0, min(coverage, 1.0))
+            prev_cov = (
+                max(0.0, min(prev_coverage, 1.0))
+                if prev_coverage is not None
+                else None
+            )
+            cov_delta = (
+                coverage_delta(prev_cov, coverage_score)
+                if prev_cov is not None
+                else 0.0
+            )
+        else:
+            test_score = 0.0
+            coverage_score = 0.0
+            cov_delta = 0.0
 
         reward += self.weights.get("compile", 0.0) * compile_score
         reward += self.weights.get("tests", 0.0) * test_score
@@ -87,6 +99,9 @@ class RewardAggregator:
         if sanitizer_clean is not None:
             san_score = 1.0 if sanitizer_clean else -1.0
             reward += self.weights.get("sanitizer", 0.0) * san_score
+
+        if compile_success and tests_total and tests_passed == tests_total:
+            reward += self.all_green_bonus
 
         # Penalties
         reward -= min(edit_cost * self.max_edit_penalty, self.max_edit_penalty)


### PR DESCRIPTION
## Summary
- add all-green test bonus and compile gate to reward aggregator
- cover new reward signals with tests
- track new reward feature in phase-5 checklist

## Testing
- `pytest tests/test_reward.py -q`
- `pytest tests/test_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a052342964833184b074541aec8e75