### PR TITLE
Add smoke evaluation workflow and script

### DIFF
--- a/.github/workflows/smoke-eval.yml
+++ b/.github/workflows/smoke-eval.yml
@@ -1,0 +1,45 @@
+name: Smoke Evaluation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  smoke-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt coverage
+
+      - name: Run smoke evaluation
+        run: |
+          python -m coverage run scripts/smoke_eval.py
+
+      - name: Generate coverage reports
+        run: |
+          python -m coverage html
+          python -m coverage xml
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-eval-coverage
+          path: htmlcov
+
+      - name: Upload evaluation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-eval-artifacts
+          path: |
+            artifacts/metrics.json
+            artifacts/report.md
+            artifacts/report.html

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -82,7 +82,7 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 8: CI/CD and Automation
     [X] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
-    [~] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
+    [?] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [ ] Create nightly full evaluation job with retention and tagging
     [X] Implement version stamping (git SHA, Docker digest, seeds) in runs
     [ ] Configure GitHub Pages publish for latest report artifacts

--- a/scripts/smoke_eval.py
+++ b/scripts/smoke_eval.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Minimal smoke evaluation run for Phase 8.
+
+This script exercises the evaluation utilities on a tiny synthetic set of
+results. It writes Markdown and HTML reports to an ``artifacts`` directory so
+CI can upload them as build artifacts.
+"""
+
+from __future__ import annotations
+
+import sys
+import json
+from pathlib import Path
+
+# Ensure project root on sys.path so `hrm_coder` is importable when run as a script
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from hrm_coder.evaluation import (
+    aggregate_pass_at_k,
+    flaky_tasks,
+    html_report,
+    markdown_report,
+)
+
+
+def main() -> None:
+    # Synthetic results for three tasks with three attempts each.
+    results = {
+        "task1": [True, False, True],
+        "task2": [False, False, False],
+        "task3": [True, True, True],
+    }
+    ks = [1, 2]
+    metrics = aggregate_pass_at_k(results, ks)
+
+    # Two deterministic runs to feed into flaky detection.
+    runs = [
+        {"task1": True, "task2": False, "task3": True},
+        {"task1": True, "task2": False, "task3": True},
+    ]
+    flaky = flaky_tasks(runs)
+
+    artifacts = Path("artifacts")
+    artifacts.mkdir(exist_ok=True)
+    artifacts.joinpath("metrics.json").write_text(json.dumps(metrics, indent=2))
+    artifacts.joinpath("report.md").write_text(markdown_report(metrics, flaky))
+    artifacts.joinpath("report.html").write_text(html_report(metrics, flaky))
+
+    print(json.dumps(metrics))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add smoke evaluation script creating metrics and reports
- run smoke evaluation with coverage in new GitHub Actions job
- update phase 8 checklist to mark smoke evaluation job for review

## Testing
- `pytest`
- `python scripts/smoke_eval.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0523b1590833184aa727d00c4df06