### PR TITLE
feat(ast): add action space and constraint checks

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -89,11 +89,11 @@ Save new code files in: C:\repos\hrm-coder
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)
-    [~] Integrate Tree-sitter C++ grammar and bindings
+    [X] Integrate Tree-sitter C++ grammar and bindings
     [X] Implement node type schema and AST embedding encoder for C++
-    [~] Define edit action space for insert, replace, and delete operations
+    [X] Define edit action space for insert, replace, and delete operations
     [~] Implement cursor policy module for region selection by HRM high-level
-    [~] Implement decoder constraint checker to avoid invalid AST states
+    [X] Implement decoder constraint checker to avoid invalid AST states
     [ ] Add ablation job configs and comparison report against token baseline
 
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)

--- a/tests/test_ast_actions.py
+++ b/tests/test_ast_actions.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils.ast_actions import DeleteAction, InsertAction, ReplaceAction
+from utils.ast_constraints import ConstraintChecker
+from utils.ast_edit import CppAst
+
+CPP_SNIPPET = "int add(int a, int b) { return a + b; }"
+
+
+def _parser_available() -> bool:
+    try:
+        ast = CppAst()
+        ast.parse("int x;")
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+def test_actions_and_constraints():
+    ast = CppAst()
+    checker = ConstraintChecker(ast)
+    tree = ast.parse(CPP_SNIPPET)
+    func = tree.root_node.children[0]
+    body = func.child_by_field_name("body")
+    return_node = body.child(1)
+
+    replace_action = ReplaceAction(return_node, "return a - b;")
+    assert checker.is_valid_edit(CPP_SNIPPET, replace_action)
+
+    bad_action = ReplaceAction(return_node, "return ;")
+    assert not checker.is_valid_edit(CPP_SNIPPET, bad_action)
+
+    insert_action = InsertAction(0, "// comment\n")
+    assert checker.is_valid_edit(CPP_SNIPPET, insert_action)
+
+    delete_action = DeleteAction(return_node)
+    assert checker.is_valid_edit(CPP_SNIPPET, delete_action)

--- a/utils/ast_actions.py
+++ b/utils/ast_actions.py
@@ -1,0 +1,55 @@
+"""Edit action representations for C++ AST manipulations.
+
+This module defines simple dataclasses representing insert, replace and
+delete operations on C++ source code.  Each action exposes an ``apply``
+method which delegates to :class:`utils.ast_edit.CppAst` and returns an
+:class:`utils.ast_edit.EditResult`.  The actions form a minimal "action
+space" for Phase 9 of the HRM Coder roadmap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from tree_sitter import Node
+
+from utils.ast_edit import CppAst, EditResult
+
+
+class AstAction:
+    """Abstract base class for AST edit actions."""
+
+    def apply(self, ast: CppAst, code: str) -> EditResult:  # pragma: no cover - interface
+        """Apply the action using ``ast`` and return the edit result."""
+        raise NotImplementedError
+
+
+@dataclass
+class InsertAction(AstAction):
+    """Insert ``text`` at ``position`` (byte offset)."""
+
+    position: int
+    text: str
+
+    def apply(self, ast: CppAst, code: str) -> EditResult:
+        return ast.insert(code, self.position, self.text)
+
+
+@dataclass
+class ReplaceAction(AstAction):
+    """Replace the span covered by ``node`` with ``replacement``."""
+
+    node: Node
+    replacement: str
+
+    def apply(self, ast: CppAst, code: str) -> EditResult:
+        return ast.replace(code, self.node, self.replacement)
+
+
+@dataclass
+class DeleteAction(AstAction):
+    """Remove the span covered by ``node``."""
+
+    node: Node
+
+    def apply(self, ast: CppAst, code: str) -> EditResult:
+        return ast.delete(code, self.node)

--- a/utils/ast_constraints.py
+++ b/utils/ast_constraints.py
@@ -1,0 +1,35 @@
+"""Constraint checking for AST edit actions.
+
+The :class:`ConstraintChecker` applies an :class:`utils.ast_actions.AstAction`
+to source code and verifies that the resulting code parses without errors.
+It provides a lightweight guard against edits that would leave the C++ AST
+in an invalid state, helping to keep Phase 9's action space well-behaved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from utils.ast_actions import AstAction
+from utils.ast_edit import CppAst
+
+
+@dataclass
+class ConstraintChecker:
+    """Validate edits produced by :mod:`utils.ast_actions`."""
+
+    ast: CppAst
+
+    def is_valid_edit(self, code: str, action: AstAction) -> bool:
+        """Return ``True`` if applying ``action`` yields a parseable AST."""
+
+        try:
+            result = action.apply(self.ast, code)
+        except Exception:
+            return False
+        if result.tree is None:
+            try:
+                return self.ast.is_valid(result.code)
+            except Exception:
+                return False
+        return not result.tree.root_node.has_error


### PR DESCRIPTION
## Summary
- add dataclass-based AST edit actions for insert, replace, and delete
- introduce ConstraintChecker to ensure edits yield valid C++ ASTs
- track Phase 9 progress in checklist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0523d658083318e499a944dbbaf62