### PR TITLE
feat: add smoke training pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: data build_runner train eval report
+.PHONY: data build_runner train eval report smoke
 
 # Placeholder targets for Phase 1 scaffold
 
@@ -12,7 +12,10 @@ train:
 	python train.py
 
 eval:
-	python evaluate.py
+        python evaluate.py
 
 report:
-	@echo "Report generation not implemented yet"
+        @echo "Report generation not implemented yet"
+
+smoke:
+        python scripts/smoke_train.py

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -70,7 +70,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Integrate REINFORCE with value baseline and entropy regularization
     [X] Implement curriculum toggles for visible versus hidden tests
     [X] Add checkpointing, resume logic, and deterministic dataloaders
-    [~] Create 5-task smoke run pipeline for CI runtime budgets
+    [?] Create 5-task smoke run pipeline for CI runtime budgets
 
 ** [ ] Phase 7: Evaluation Harness and Reporting
     [X] Implement pass\@k computation with fixed seeds and sampling policies

--- a/scripts/smoke_train.py
+++ b/scripts/smoke_train.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
 """Minimal 5-task smoke training run for Phase 6.
 
-This script exercises the HRMTrainer's supervised fine-tuning path on a
-small synthetic dataset.  It is intended for CI smoke tests and runs in
-under a second on CPU.
+This script exercises the HRMTrainer's supervised fine-tuning **and**
+reinforcement-learning paths on a small synthetic dataset.  It is
+intended for CI smoke tests and runs in under a second on CPU.
 """
+
+import pathlib
+import sys
 
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
-from hrm.training_loop import HRMTrainer, HRMTrainingConfig
+# Ensure repository root is on the import path when executed directly.
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from hrm.training_loop import HRMTrainer, HRMTrainingConfig  # noqa: E402
 
 
 class TinyModel(nn.Module):
@@ -39,8 +45,37 @@ def main() -> None:
     opt = torch.optim.SGD(model.parameters(), lr=0.1)
     trainer = HRMTrainer(model, opt, HRMTrainingConfig())
 
+    # --- Supervised fine-tuning epoch ---------------------------------
     avg_loss = trainer.sft_epoch(loader)
     print(f"avg_loss={avg_loss:.4f}")
+
+    # --- Reinforcement learning epoch ---------------------------------
+    def reward_fn_factory(target: torch.Tensor):
+        def reward_fn(actions: torch.Tensor) -> torch.Tensor:
+            return torch.where(
+                actions == target, torch.tensor(1.0), torch.tensor(0.0)
+            )
+
+        return reward_fn
+
+    rl_stats = {
+        "policy_loss": 0.0,
+        "value_loss": 0.0,
+        "entropy": 0.0,
+        "reward": 0.0,
+    }
+    for inp, target in dataset:
+        stats = trainer.reinforce_step(
+            inp.unsqueeze(0), reward_fn_factory(target)
+        )
+        for k, v in stats.items():
+            rl_stats[k] += v
+    for k in rl_stats:
+        rl_stats[k] /= len(dataset)
+    print(
+        "reinforce:",
+        " ".join(f"{k}={v:.4f}" for k, v in rl_stats.items()),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand smoke training script with reinforcement learning epoch and path fixes
- add `smoke` Makefile target to run the script
- mark smoke pipeline task as awaiting review in Phase 6 checklist

## Testing
- `pre-commit run --files scripts/smoke_train.py Makefile docs/hrmCoder_checklist.md`
- `python scripts/smoke_train.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a052364b90833188a7f30f3a7a73d6