### PR TITLE
Add acceptance metrics config

### DIFF
--- a/hrm_coder/acceptance.py
+++ b/hrm_coder/acceptance.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Acceptance checks for Phase 0.
+
+Phase 0 of the HRM Coder project defines basic success criteria for C++
+experiments.  This module provides a small utility to evaluate whether a
+set of metrics meets those criteria.  It is intentionally lightweight and
+will be expanded in later phases.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class AcceptanceCriteria:
+    """Thresholds used to judge run acceptance.
+
+    Attributes
+    ----------
+    pass_at_1:
+        Minimum required pass@1 value.
+    pass_at_10:
+        Minimum required pass@10 value.
+    max_timeout_rate:
+        Maximum tolerated fraction of timeouts.
+    max_sanitizer_failures:
+        Maximum number of sanitizer failures allowed.
+    """
+
+    pass_at_1: float = 0.0
+    pass_at_10: float = 0.0
+    max_timeout_rate: float = 1.0
+    max_sanitizer_failures: int = 0
+
+
+def evaluate_acceptance(
+    metrics: Dict[str, float], criteria: AcceptanceCriteria
+) -> Dict[str, bool]:
+    """Evaluate ``metrics`` against ``criteria``.
+
+    Parameters
+    ----------
+    metrics:
+        Mapping of metric name to value.  Expected keys are ``"pass@1"``,
+        ``"pass@10"``, ``"timeout_rate"`` and ``"sanitizer_failures"``.
+    criteria:
+        :class:`AcceptanceCriteria` describing the thresholds.
+
+    Returns
+    -------
+    Dict[str, bool]
+        Mapping of check name to a boolean result.  Includes an
+        ``"overall"`` key indicating whether all checks passed.
+    """
+
+    results = {
+        "pass@1": metrics.get("pass@1", 0.0) >= criteria.pass_at_1,
+        "pass@10": metrics.get("pass@10", 0.0) >= criteria.pass_at_10,
+        "timeout_rate": metrics.get("timeout_rate", 1.0)
+        <= criteria.max_timeout_rate,
+        "sanitizer_failures": metrics.get("sanitizer_failures", 0)
+        <= criteria.max_sanitizer_failures,
+    }
+    results["overall"] = all(results.values())
+    return results
+
+
+__all__ = ["AcceptanceCriteria", "evaluate_acceptance"]

--- a/hrm_coder/conf/acceptance/default.yaml
+++ b/hrm_coder/conf/acceptance/default.yaml
@@ -1,0 +1,4 @@
+pass_at_1: 0.5
+pass_at_10: 0.7
+max_timeout_rate: 0.05
+max_sanitizer_failures: 0

--- a/hrm_coder/conf/config.yaml
+++ b/hrm_coder/conf/config.yaml
@@ -2,4 +2,5 @@ defaults:
   - dataset: humaneval_cpp
   - model: small
   - runner: default
+  - acceptance: default
   - _self_

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -37,11 +37,26 @@ class RunnerConfig:
 
 
 @dataclass
+class AcceptanceConfig:
+    """Acceptance metric thresholds for Phase 0.
+
+    These values represent the minimum quality bar for C++ experiments.
+    Later phases may expand this structure with additional metrics.
+    """
+
+    pass_at_1: float = 0.5
+    pass_at_10: float = 0.7
+    max_timeout_rate: float = 0.05
+    max_sanitizer_failures: int = 0
+
+
+@dataclass
 class AppConfig:
     """Top-level application configuration."""
     model: ModelConfig = field(default_factory=ModelConfig)
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     runner: RunnerConfig = field(default_factory=RunnerConfig)
+    acceptance: AcceptanceConfig = field(default_factory=AcceptanceConfig)
 
 
 def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
@@ -63,6 +78,7 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
         model=ModelConfig(**cfg_dict["model"]),
         dataset=DatasetConfig(**cfg_dict["dataset"]),
         runner=RunnerConfig(**cfg_dict["runner"]),
+        acceptance=AcceptanceConfig(**cfg_dict["acceptance"]),
     )
 
 
@@ -71,5 +87,6 @@ __all__ = [
     "DatasetConfig",
     "ModelConfig",
     "RunnerConfig",
+    "AcceptanceConfig",
     "load_config",
 ]

--- a/hrm_coder/tests/test_acceptance.py
+++ b/hrm_coder/tests/test_acceptance.py
@@ -1,0 +1,27 @@
+from hrm_coder.acceptance import AcceptanceCriteria, evaluate_acceptance
+
+
+def test_evaluate_acceptance_passes():
+    criteria = AcceptanceCriteria(pass_at_1=0.5, pass_at_10=0.7, max_timeout_rate=0.1)
+    metrics = {
+        "pass@1": 0.6,
+        "pass@10": 0.8,
+        "timeout_rate": 0.05,
+        "sanitizer_failures": 0,
+    }
+    result = evaluate_acceptance(metrics, criteria)
+    assert result["overall"]
+    assert all(result[k] for k in ["pass@1", "pass@10", "timeout_rate", "sanitizer_failures"])
+
+
+def test_evaluate_acceptance_failure():
+    criteria = AcceptanceCriteria(pass_at_1=0.5, pass_at_10=0.7, max_timeout_rate=0.1)
+    metrics = {
+        "pass@1": 0.4,
+        "pass@10": 0.8,
+        "timeout_rate": 0.05,
+        "sanitizer_failures": 0,
+    }
+    result = evaluate_acceptance(metrics, criteria)
+    assert not result["overall"]
+    assert not result["pass@1"]

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -7,12 +7,16 @@ def test_load_config_defaults():
     assert cfg.dataset.name == "humaneval-cpp"
     assert cfg.runner.compiler == "g++"
     assert cfg.runner.timeout == 5
+    assert cfg.acceptance.pass_at_1 == 0.5
+    assert cfg.acceptance.max_timeout_rate == 0.05
 
 
 def test_load_config_override():
     cfg = load_config([
         "model.learning_rate=0.01",
         "runner.timeout=10",
+        "acceptance.pass_at_1=0.9",
     ])
     assert cfg.model.learning_rate == 0.01
     assert cfg.runner.timeout == 10
+    assert cfg.acceptance.pass_at_1 == 0.9


### PR DESCRIPTION
## Summary
- add `AcceptanceCriteria` utility to evaluate Phase 0 success metrics
- wire new acceptance thresholds into Hydra config
- test configuration loading and acceptance evaluation

## Testing
- `pytest -q` *(fails: TypeError: cannot unpack non-iterable CompileResult object in tests/test_error_taxonomy.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a057938bf48331bd1c42ce178e165d