### PR TITLE
Add Hydra-based train and eval CLI stubs for Phase 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
+
 .PHONY: data build_runner train eval report smoke
 
 # Placeholder targets for Phase 1 scaffold
 
 data:
-	@echo "Data pipeline not implemented yet"
+        @echo "Data pipeline not implemented yet"
 
 build_runner:
-	docker build -f runner.Dockerfile -t hrm-runner .
+        docker build -f runner.Dockerfile -t hrm-runner .
 
 train:
-	python train.py
+        python -m hrm_coder.train $(ARGS)
 
 eval:
-        python evaluate.py
+        python -m hrm_coder.eval_cli $(ARGS)
 
 report:
         @echo "Report generation not implemented yet"

--- a/hrm_coder/eval_cli.py
+++ b/hrm_coder/eval_cli.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Phase 1 evaluation stub for HRM Coder.
+
+Loads configuration and pins the environment in preparation for
+future evaluation routines.
+"""
+
+import argparse
+from dataclasses import asdict
+from pprint import pformat
+
+from .config import load_config
+from .env import pin_environment
+
+
+def main() -> None:
+    """Entry point for the evaluation stub."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "overrides", nargs="*", help="Hydra-style overrides for evaluation"
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.overrides)
+    pin_environment()
+
+    print("Loaded configuration:")
+    print(pformat(asdict(cfg)))
+    print("Evaluation loop not yet implemented – Phase 1 placeholder")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/hrm_coder/train.py
+++ b/hrm_coder/train.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Phase 1 training stub for HRM Coder.
+
+This module demonstrates how training scripts will load Hydra
+configuration and pin the runtime environment for determinism.
+Actual training logic will be implemented in later phases.
+"""
+
+from dataclasses import asdict
+import argparse
+from pprint import pformat
+
+from .config import load_config
+from .env import pin_environment
+
+
+def main() -> None:
+    """Entry point for the training stub.
+
+    Parameters
+    ----------
+    None
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        help="Hydra-style overrides, e.g. model.learning_rate=1e-4",
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.overrides)
+    pin_environment()
+
+    print("Loaded configuration:")
+    print(pformat(asdict(cfg)))
+    print("Training loop not yet implemented – Phase 1 placeholder")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add Hydra-powered training stub that pins environment for deterministic runs
- add evaluation stub and update Makefile train/eval targets

## Testing
- `pre-commit run --files Makefile hrm_coder/train.py hrm_coder/eval_cli.py`
- `pytest` (fails: TypeError in tests/test_error_taxonomy.py)


------
https://chatgpt.com/codex/tasks/task_e_68a05796dc2c8331972ddc9b5943e339