### PR TITLE
feat: add run update and log endpoints

### DIFF
--- a/docs/hrmCoder_gui_quickstart.md
+++ b/docs/hrmCoder_gui_quickstart.md
@@ -17,6 +17,12 @@ curl http://localhost:8000/runs
 # Start a training run
 curl -X POST http://localhost:8000/train -H 'Content-Type: application/json' -d '{}'
 
+# Update the run status
+curl -X PATCH http://localhost:8000/runs/1 -H 'Content-Type: application/json' -d '{"status":"done"}'
+
+# Append a log line
+curl -X POST http://localhost:8000/runs/1/logs -H 'Content-Type: application/json' -d '{"message":"hello"}'
+
 # List artifacts for a run
 curl http://localhost:8000/runs/1/artifacts
 

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 from .run_registry import registry, Run
 
@@ -77,6 +78,37 @@ def list_artifacts(run_id: int) -> Dict[str, List[str]]:
         raise HTTPException(status_code=404, detail="artifact not found")
     files = [str(p.relative_to(path)) for p in path.rglob("*") if p.is_file()]
     return {"files": files}
+
+
+class RunUpdate(BaseModel):
+    """Payload for run status updates."""
+
+    status: str | None = None
+
+
+@app.patch("/runs/{run_id}", response_model=Run)
+def update_run(run_id: int, payload: RunUpdate):
+    """Update mutable fields of a run such as status."""
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    if payload.status is not None:
+        registry.update_status(run_id, payload.status)
+    return registry.get_run(run_id)
+
+
+class LogMessage(BaseModel):
+    message: str
+
+
+@app.post("/runs/{run_id}/logs")
+def post_log(run_id: int, msg: LogMessage) -> Dict[str, str]:
+    """Append a log line to a run."""
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    registry.append_log(run_id, msg.message)
+    return {"status": "ok"}
 
 
 @app.websocket("/logs/ws/{run_id}")

--- a/hrm_coder/tests/test_api.py
+++ b/hrm_coder/tests/test_api.py
@@ -33,3 +33,12 @@ def test_run_lifecycle():
     fetched = client.get(f"/runs/{run['id']}").json()
     assert fetched["id"] == run["id"]
 
+    # Update status
+    updated = client.patch(f"/runs/{run['id']}", json={"status": "done"}).json()
+    assert updated["status"] == "done"
+
+    # Append a log line
+    client.post(f"/runs/{run['id']}/logs", json={"message": "finished"})
+    logs = client.get(f"/runs/{run['id']}").json()["logs"]
+    assert "finished" in logs
+

--- a/hrm_coder/tests/test_websocket.py
+++ b/hrm_coder/tests/test_websocket.py
@@ -1,7 +1,6 @@
 from fastapi.testclient import TestClient
 
 from .. import app
-from ..run_registry import registry
 
 
 def test_websocket_log_stream():
@@ -11,5 +10,5 @@ def test_websocket_log_stream():
     with client.websocket_connect(f'/logs/ws/{run_id}') as ws:
         first = ws.receive_text()
         assert 'training started' in first
-        registry.append_log(run_id, 'next line')
+        client.post(f'/runs/{run_id}/logs', json={'message': 'next line'})
         assert ws.receive_text() == 'next line'


### PR DESCRIPTION
## Summary
- add PATCH /runs/{id} endpoint for run status updates
- add POST /runs/{id}/logs endpoint for log ingestion
- document new endpoints in GUI quickstart

## Testing
- `pytest hrm_coder/tests/test_api.py hrm_coder/tests/test_artifacts.py hrm_coder/tests/test_websocket.py -q`
- `pytest -q` *(fails: CompileResult unpacking TypeError in tests/test_error_taxonomy.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a05798de60833181efb8f13633ed34