### PR TITLE
Add Codeforces dataset loader with schema validation

### DIFF
--- a/dataset/codeforces_intro_loader.py
+++ b/dataset/codeforces_intro_loader.py
@@ -1,0 +1,99 @@
+"""Loader for the Codeforces-Intro dataset with schema validation.
+
+This module reads a processed Codeforces-Intro dataset directory and
+returns structured objects for each task. It validates the presence of
+required files and uses ``pydantic`` models to enforce the schema. The
+layout mirrors the one produced by ``build_codeforces_intro_dataset.py``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+
+class IOPair(BaseModel):
+    """Container for a single input/output example."""
+
+    input: str
+    output: str
+
+
+class CodeforcesRecord(BaseModel):
+    """Represents one Codeforces-Intro task."""
+
+    task_id: str
+    prompt: str
+    tests: List[IOPair]
+    time_limit_ms: int
+    memory_limit_kb: int
+    split: str
+
+
+def _load_task(task_dir: Path, split: str) -> CodeforcesRecord:
+    """Load a single task located at *task_dir*.
+
+    Parameters
+    ----------
+    task_dir:
+        Directory containing ``prompt.txt``, ``tests`` subdirectory and
+        ``meta.json``.
+    split:
+        Name of the dataset split (``train``, ``val`` or ``test``).
+    """
+    prompt_path = task_dir / "prompt.txt"
+    tests_dir = task_dir / "tests"
+    meta_path = task_dir / "meta.json"
+    missing = [
+        p.name for p in [prompt_path, tests_dir, meta_path] if not p.exists()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"Missing required paths in {task_dir}: {', '.join(missing)}"
+        )
+
+    prompt = prompt_path.read_text()
+    meta = json.loads(meta_path.read_text())
+
+    tests: List[IOPair] = []
+    for in_file in sorted(tests_dir.glob("*.in")):
+        out_file = in_file.with_suffix(".out")
+        if not out_file.exists():
+            raise FileNotFoundError(
+                f"Missing expected output file {out_file}"
+            )
+        tests.append(
+            IOPair(
+                input=in_file.read_text(),
+                output=out_file.read_text(),
+            )
+        )
+
+    return CodeforcesRecord(
+        task_id=task_dir.name,
+        prompt=prompt,
+        tests=tests,
+        time_limit_ms=meta.get("time_limit_ms", 2000),
+        memory_limit_kb=meta.get("memory_limit_kb", 256000),
+        split=split,
+    )
+
+
+def load_dataset(root: str | Path) -> Dict[str, List[CodeforcesRecord]]:
+    """Load all tasks from a processed Codeforces-Intro dataset."""
+    root_path = Path(root)
+    splits: Dict[str, List[CodeforcesRecord]] = {
+        "train": [],
+        "val": [],
+        "test": [],
+    }
+    for split in splits:
+        split_dir = root_path / split
+        if not split_dir.exists():
+            continue
+        for task_dir in sorted(p for p in split_dir.iterdir() if p.is_dir()):
+            record = _load_task(task_dir, split)
+            splits[split].append(record)
+    return splits

--- a/tests/test_codeforces_intro_loader.py
+++ b/tests/test_codeforces_intro_loader.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dataset.build_codeforces_intro_dataset import build_dataset
+from dataset.codeforces_intro_loader import CodeforcesRecord, load_dataset
+
+
+def _write_sample_dataset(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "cf1",
+            "prompt": "Sum two numbers",
+            "tests": [{"input": "1 2\n", "output": "3\n"}],
+            "time_limit_ms": 1000,
+            "memory_limit_kb": 65536,
+        },
+        {
+            "task_id": "cf2",
+            "prompt": "Subtract numbers",
+            "tests": [{"input": "3 1\n", "output": "2\n"}],
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_loader_round_trip(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    splits = load_dataset(out_dir)
+    assert set(splits.keys()) == {"train", "val", "test"}
+    all_tasks = [t for tasks in splits.values() for t in tasks]
+    assert len(all_tasks) == 2
+    first = next(t for t in all_tasks if t.task_id == "cf1")
+    assert isinstance(first, CodeforcesRecord)
+    assert first.tests[0].output.strip() == "3"
+
+
+def test_loader_missing_meta(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    # remove meta.json from one task to trigger error
+    task_dir = next((out_dir / "train").iterdir())
+    (task_dir / "meta.json").unlink()
+    with pytest.raises(FileNotFoundError):
+        load_dataset(out_dir)


### PR DESCRIPTION
## Summary
- implement pydantic-backed loader for Codeforces-Intro dataset
- add unit tests exercising loader round-trip and error handling

## Testing
- `pre-commit run --files dataset/codeforces_intro_loader.py tests/test_codeforces_intro_loader.py --hook-stage manual`
- `PYTHONPATH=. pytest tests/test_codeforces_intro_loader.py tests/test_build_codeforces_intro_dataset.py tests/test_dataset_determinism.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0579bb0dc8331a9f0e6f0d085dd52