### PR TITLE
Add sandbox and caching support for C++ Codeforces runner

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from .error_taxonomy import classify_compile, classify_runtime
+from .isolate import IsolateRunner, SandboxError
+from .sandbox_cache import SandboxCache
 from utils.diagnostics import compiler_diagnostics
 
 
@@ -223,8 +225,13 @@ def run_binary(
     timeout: float = 2.0,
     memory_limit: Optional[int] = None,
     env: Optional[Mapping[str, str]] = None,
+    sandbox: Optional[IsolateRunner] = None,
 ) -> Tuple[int, str, str]:
     """Execute a compiled ``binary`` with optional limits and environment.
+
+    When ``sandbox`` is provided the binary is executed inside that sandbox
+    runner.  Otherwise :func:`subprocess.run` is used directly with a simple
+    address-space limit.
 
     Parameters
     ----------
@@ -235,12 +242,28 @@ def run_binary(
     timeout:
         Maximum wall-clock time in seconds before termination.
     memory_limit:
-        Optional address-space limit in bytes.
+        Optional address-space limit in bytes.  When a sandbox is supplied the
+        value is converted to kilobytes for the adapter.
     env:
-        Extra environment variables to inject. Values override the current
-        process environment which enables dynamic library lookup via
-        ``LD_LIBRARY_PATH`` when rpath isn't provided.
+        Extra environment variables to inject when executing directly.
+    sandbox:
+        Optional :class:`~runners.isolate.IsolateRunner` used to enforce
+        resource limits and disable networking.
     """
+
+    if sandbox is not None:
+        memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
+        try:
+            proc = sandbox.run(
+                [str(binary)],
+                time_limit=int(timeout),
+                wall_time=int(timeout),
+                memory=memory_kb,
+                stdin=input_data,
+            )
+        except SandboxError as exc:
+            return -1, "", str(exc)
+        return proc.returncode, proc.stdout, proc.stderr
 
     def preexec() -> None:
         _set_limits(memory_limit)
@@ -272,6 +295,8 @@ def run_codeforces_tests(
     rpath: Optional[Iterable[Path]] = None,
     use_ccache: bool = False,
     env: Optional[Mapping[str, str]] = None,
+    sandbox: Optional[IsolateRunner] = None,
+    cache: Optional[SandboxCache] = None,
 ) -> dict:
     """Compile ``sources`` and run them against all tests in ``tests_dir``.
 
@@ -279,6 +304,20 @@ def run_codeforces_tests(
     Results include compilation diagnostics and a list of per-test outcomes
     with error classifications.
     """
+
+    key: Optional[str] = None
+    if cache is not None:
+        parts = [Path(s).read_bytes() for s in sources]
+        for f in sorted(Path(tests_dir).glob("*")):
+            if f.is_file():
+                parts.append(f.read_bytes())
+        parts.append(str(timeout).encode())
+        if memory_limit is not None:
+            parts.append(str(memory_limit).encode())
+        key = cache.hash_parts(parts)
+        cached = cache.load(key)
+        if cached is not None:
+            return cached
 
     compile_res = compile_cpp_sources(
         sources,
@@ -291,16 +330,22 @@ def run_codeforces_tests(
         rpath=rpath,
         use_ccache=use_ccache,
     )
-    compile_status = classify_compile(success, err)
+    compile_status = classify_compile(
+        compile_res.success, compile_res.stderr
+    )
     results = []
     if not compile_res.success or compile_res.binary is None:
-        return {
+        data = {
             "compile_stdout": compile_res.stdout,
             "compile_stderr": compile_res.stderr,
             "compile_warnings": compile_res.warnings,
             "compile_errors": compile_res.errors,
+            "compile_status": compile_status,
             "results": results,
         }
+        if cache is not None and key is not None:
+            cache.store(key, data)
+        return data
 
     for input_file in sorted(Path(tests_dir).glob("*.in")):
         test_name = input_file.stem
@@ -314,6 +359,7 @@ def run_codeforces_tests(
                 timeout=timeout,
                 memory_limit=memory_limit,
                 env=env,
+                sandbox=sandbox,
             )
             timed_out = False
         except subprocess.TimeoutExpired:
@@ -331,10 +377,14 @@ def run_codeforces_tests(
             }
         )
 
-    return {
+    data = {
         "compile_stdout": compile_res.stdout,
         "compile_stderr": compile_res.stderr,
         "compile_warnings": compile_res.warnings,
         "compile_errors": compile_res.errors,
+        "compile_status": compile_status,
         "results": results,
     }
+    if cache is not None and key is not None:
+        cache.store(key, data)
+    return data

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -6,13 +6,18 @@ import re
 import subprocess
 import sys
 
+import pytest
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
+import runners.cpp_runner as cpp_runner
 from runners.cpp_runner import (
     compile_cpp_sources,
     compile_shared_library,
     run_binary,
+    run_codeforces_tests,
 )
+from runners.sandbox_cache import SandboxCache
 
 
 def test_compile_multi_file(tmp_path: Path) -> None:
@@ -147,3 +152,49 @@ def test_warning_count(tmp_path: Path) -> None:
     ], flags=["-std=c++17", "-Wall"], sanitize=False)
     assert res.success
     assert res.warnings >= 1
+
+
+class SpyRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, cmd, **kwargs):
+        self.calls += 1
+        return subprocess.run(
+            cmd,
+            input=kwargs.get("stdin"),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+def test_run_codeforces_tests_cache(tmp_path: Path, monkeypatch):
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        "#include <iostream>\nint main(){int a,b; if(!(std::cin>>a>>b)) return 0; std::cout<<a+b;}"
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("1 2\n")
+    (tests_dir / "a.out").write_text("3\n")
+
+    cache = SandboxCache(tmp_path / "cache")
+    spy = SpyRunner()
+
+    calls = {"compile": 0}
+
+    original_compile = cpp_runner.compile_cpp_sources
+
+    def wrapped_compile(*args, **kwargs):
+        calls["compile"] += 1
+        return original_compile(*args, **kwargs)
+
+    monkeypatch.setattr(cpp_runner, "compile_cpp_sources", wrapped_compile)
+
+    first = run_codeforces_tests([src], tests_dir, sandbox=spy, cache=cache)
+    assert calls["compile"] == 1
+    second = run_codeforces_tests([src], tests_dir, sandbox=spy, cache=cache)
+    assert calls["compile"] == 1
+    assert spy.calls == 1
+    assert first == second

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -14,15 +14,15 @@ def test_classify_compile_errors(tmp_path: Path) -> None:
         "#include <nonexistent_header.h>\n"
         "int main(){}"
     )
-    success, _, err, _ = compile_cpp(src, sanitize=False)
-    assert not success
-    assert classify_compile(success, err) == "compile_error"
+    res = compile_cpp(src, sanitize=False)
+    assert not res.success
+    assert classify_compile(res.success, res.stderr) == "compile_error"
 
     src2 = tmp_path / "link.cpp"
     src2.write_text("extern int foo(); int main(){return foo();}")
-    success2, out2, err2, _ = compile_cpp(src2, sanitize=False)
-    assert not success2
-    assert classify_compile(success2, err2) == "link_error"
+    res2 = compile_cpp(src2, sanitize=False)
+    assert not res2.success
+    assert classify_compile(res2.success, res2.stderr) == "link_error"
 
 
 def test_classify_runtime_conditions(tmp_path: Path) -> None:
@@ -30,18 +30,18 @@ def test_classify_runtime_conditions(tmp_path: Path) -> None:
     # Runtime error due to non-zero exit code
     src = tmp_path / "runtime.cpp"
     src.write_text("int main(){return 1;}")
-    success, _, err, binary = compile_cpp(src, sanitize=False)
-    assert success and binary is not None
-    code, out, err = run_binary(binary)
+    res = compile_cpp(src, sanitize=False)
+    assert res.success and res.binary is not None
+    code, out, err = run_binary(res.binary)
     assert classify_runtime(code, err) == "runtime_error"
 
     # Timeout
     src_t = tmp_path / "loop.cpp"
     src_t.write_text("int main(){while(true){} }")
-    success_t, _, _, binary_t = compile_cpp(src_t, sanitize=False)
-    assert success_t and binary_t is not None
+    res_t = compile_cpp(src_t, sanitize=False)
+    assert res_t.success and res_t.binary is not None
     try:
-        run_binary(binary_t, timeout=0.1)
+        run_binary(res_t.binary, timeout=0.1)
         timed_out = False
         code, _, err_t = 0, "", ""
     except subprocess.TimeoutExpired:
@@ -55,7 +55,7 @@ def test_classify_runtime_conditions(tmp_path: Path) -> None:
         "#include <iostream>\nint main(){int *p=new int[1];delete[] p;"
         "std::cout<<p[0];}"
     )
-    success_s, _, _, binary_s = compile_cpp(src_s)
-    assert success_s and binary_s is not None
-    code_s, _, err_s = run_binary(binary_s)
+    res_s = compile_cpp(src_s)
+    assert res_s.success and res_s.binary is not None
+    code_s, _, err_s = run_binary(res_s.binary)
     assert classify_runtime(code_s, err_s) == "sanitizer_error"


### PR DESCRIPTION
## Summary
- support running compiled binaries inside an optional sandbox
- cache Codeforces-style test executions and return stored results on cache hit
- add unit tests for caching and adjust error taxonomy tests for CompileResult API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0579df090833181cae5d36234e28d