### PR TITLE
feat: add reward drift check and logging tests

### DIFF
--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -1,17 +1,20 @@
 import pathlib
 import sys
+import logging
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from utils.reward import RewardAggregator
-from utils.diagnostics import clang_tidy_score, cppcheck_score
+from utils.reward import RewardAggregator  # noqa: E402
+from utils.diagnostics import clang_tidy_score, cppcheck_score  # noqa: E402
 
 
 def test_reward_aggregator_basic():
-    agg = RewardAggregator(weights={'compile': 0.1, 'tests': 0.7, 'coverage': 0.2},
-                           max_edit_penalty=0.05,
-                           max_time_penalty=0.05,
-                           max_memory_penalty=0.05)
+    agg = RewardAggregator(
+        weights={'compile': 0.1, 'tests': 0.7, 'coverage': 0.2},
+        max_edit_penalty=0.05,
+        max_time_penalty=0.05,
+        max_memory_penalty=0.05,
+    )
 
     # Perfect run within limits
     r1 = agg.compute(
@@ -226,3 +229,56 @@ def test_all_green_bonus_and_compile_gate():
         memory_used=0.0,
     )
     assert gated == 0.0
+
+
+def test_log_histogram_warns_on_out_of_range(caplog):
+    agg = RewardAggregator(weights={'compile': 1.0}, max_edit_penalty=2.0)
+    agg.compute(
+        compile_success=False,
+        tests_passed=0,
+        tests_total=0,
+        coverage=0.0,
+        edit_cost=10.0,
+        time_used=0.0,
+        memory_used=0.0,
+    )
+    with caplog.at_level(logging.WARNING):
+        agg.log_histogram()
+    assert any(
+        "reward out of expected [-1,1] range" in r.message
+        for r in caplog.records
+    )
+
+
+def test_drift_check_detects_mean_shift(caplog):
+    agg = RewardAggregator(weights={'compile': 1.0}, max_edit_penalty=2.0)
+    # Populate history with positive rewards within range
+    for _ in range(5):
+        agg.compute(
+            compile_success=True,
+            tests_passed=1,
+            tests_total=1,
+            coverage=0.0,
+            edit_cost=0.0,
+            time_used=0.0,
+            memory_used=0.0,
+        )
+    with caplog.at_level(logging.WARNING):
+        assert not agg.check_drift((0.0, 1.0))
+
+    # Add negative rewards to shift mean below range
+    for _ in range(5):
+        agg.compute(
+            compile_success=False,
+            tests_passed=0,
+            tests_total=0,
+            coverage=0.0,
+            edit_cost=10.0,
+            time_used=0.0,
+            memory_used=0.0,
+        )
+    with caplog.at_level(logging.WARNING):
+        assert agg.check_drift((0.0, 1.0))
+    assert any(
+        "outside expected range" in r.message for r in caplog.records
+    )

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -20,8 +20,10 @@ class RewardAggregator:
         ``compile``, ``tests``, ``coverage``, ``coverage_delta``,
         ``lint``, ``static`` and ``sanitizer``.
     max_edit_penalty: maximum penalty applied for edit cost.
-    max_time_penalty: maximum penalty applied when runtime exceeds the limit.
-    max_memory_penalty: maximum penalty applied when memory use exceeds the limit.
+    max_time_penalty: maximum penalty applied when runtime exceeds the
+        limit.
+    max_memory_penalty: maximum penalty applied when memory use exceeds
+        the limit.
     all_green_bonus: additional reward added when all tests pass.
     """
 
@@ -61,7 +63,8 @@ class RewardAggregator:
         time_used: wall-clock seconds consumed.
         memory_used: peak memory usage in megabytes.
         lint_score: normalized score from clang-tidy/clang diagnostics.
-        static_score: normalized score from static analysis tools (e.g. cppcheck).
+        static_score: normalized score from static analysis tools
+            (e.g. cppcheck).
         sanitizer_clean: whether Address/UndefinedBehavior sanitizers reported
             no issues. ``None`` skips this signal.
         prev_coverage: previous coverage value used to compute coverage delta.
@@ -94,8 +97,12 @@ class RewardAggregator:
         reward += self.weights.get("tests", 0.0) * test_score
         reward += self.weights.get("coverage", 0.0) * coverage_score
         reward += self.weights.get("coverage_delta", 0.0) * cov_delta
-        reward += self.weights.get("lint", 0.0) * max(0.0, min(lint_score, 1.0))
-        reward += self.weights.get("static", 0.0) * max(0.0, min(static_score, 1.0))
+        reward += self.weights.get("lint", 0.0) * max(
+            0.0, min(lint_score, 1.0)
+        )
+        reward += self.weights.get("static", 0.0) * max(
+            0.0, min(static_score, 1.0)
+        )
         if sanitizer_clean is not None:
             san_score = 1.0 if sanitizer_clean else -1.0
             reward += self.weights.get("sanitizer", 0.0) * san_score
@@ -112,7 +119,10 @@ class RewardAggregator:
 
         if memory_limit and memory_used > memory_limit:
             over = (memory_used - memory_limit) / memory_limit
-            reward -= min(over * self.max_memory_penalty, self.max_memory_penalty)
+            reward -= min(
+                over * self.max_memory_penalty,
+                self.max_memory_penalty,
+            )
 
         # Record history for histogram logging
         self.history.append(reward)
@@ -203,3 +213,53 @@ class RewardAggregator:
         if any(r < -1.0 or r > 1.0 for r in self.history):
             logger.warning("reward out of expected [-1,1] range")
         logger.debug("reward histogram: %s", hist)
+
+    def check_drift(
+        self,
+        expected_range: tuple[float, float],
+        window: int = 50,
+        logger: logging.Logger | None = None,
+    ) -> bool:
+        """Return ``True`` if the mean reward drifts outside
+        ``expected_range``.
+
+        Parameters
+        ----------
+        expected_range:
+            Tuple specifying inclusive lower and upper bounds for the
+            expected mean reward.
+        window:
+            Number of most recent rewards to consider.  Defaults to 50,
+            or the available history if shorter.
+        logger:
+            Optional :class:`logging.Logger` used for warnings.
+            When ``None`` a module-level logger is used.
+
+        Returns
+        -------
+        bool
+            ``True`` when drift is detected, otherwise ``False``.
+        """
+
+        if not self.history:
+            return False
+
+        logger = logger or logging.getLogger(__name__)
+        lo, hi = expected_range
+        sample = self.history[-window:]
+        mean = sum(sample) / len(sample)
+        if mean < lo or mean > hi:
+            logger.warning(
+                "mean reward %.3f outside expected range [%s, %s]",
+                mean,
+                lo,
+                hi,
+            )
+            return True
+        logger.debug(
+            "mean reward %.3f within expected range [%s, %s]",
+            mean,
+            lo,
+            hi,
+        )
+        return False


### PR DESCRIPTION
## Summary
- add `check_drift` to RewardAggregator for basic reward stability monitoring
- test histogram warning and drift detection logic

## Testing
- `pre-commit run --files utils/reward.py tests/test_reward.py`
- `pytest tests/test_reward.py tests/test_training_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a057a0a6bc8331b478425352affdec