### PR TITLE
Add deterministic smoke training run for phase 6

### DIFF
--- a/scripts/smoke_train.py
+++ b/scripts/smoke_train.py
@@ -4,8 +4,13 @@
 This script exercises the HRMTrainer's supervised fine-tuning **and**
 reinforcement-learning paths on a small synthetic dataset.  It is
 intended for CI smoke tests and runs in under a second on CPU.
+
+The script now pins the environment for deterministic behaviour and
+allows overriding the random seed via a command-line flag.  This helps
+establish a reproducible 5-task smoke pipeline for Phase 6.
 """
 
+import argparse
 import pathlib
 import sys
 
@@ -17,6 +22,7 @@ from torch.utils.data import DataLoader, TensorDataset
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from hrm.training_loop import HRMTrainer, HRMTrainingConfig  # noqa: E402
+from hrm_coder.env import pin_environment  # noqa: E402
 
 
 class TinyModel(nn.Module):
@@ -33,8 +39,14 @@ class TinyModel(nn.Module):
         return logits, value
 
 
-def main() -> None:
-    torch.manual_seed(0)
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", type=int, default=0, help="PRNG seed")
+    args = parser.parse_args(argv)
+
+    pin_environment(args.seed)
+
+    torch.manual_seed(args.seed)
     vocab = 8
     inputs = torch.eye(vocab)[:5]
     targets = torch.arange(5) % vocab

--- a/tests/test_smoke_train.py
+++ b/tests/test_smoke_train.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_smoke_train_script_runs():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "smoke_train.py"
+    result = subprocess.run(
+        [sys.executable, str(script)], capture_output=True, text=True, check=True
+    )
+    assert "avg_loss=" in result.stdout
+    assert "reinforce:" in result.stdout


### PR DESCRIPTION
## Summary
- make smoke_train script deterministic with seed flag and environment pinning
- add test to run 5-task smoke training pipeline

## Testing
- `pytest tests/test_smoke_train.py tests/test_training_loop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a057a2826883319b1b79b446db1194