### PR TITLE
Add sandbox-aware C++ runner helpers

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from .error_taxonomy import classify_compile, classify_runtime
+from .isolate import IsolateRunner
 from utils.diagnostics import compiler_diagnostics
 
 
@@ -223,6 +224,7 @@ def run_binary(
     timeout: float = 2.0,
     memory_limit: Optional[int] = None,
     env: Optional[Mapping[str, str]] = None,
+    sandbox: Optional[IsolateRunner] = None,
 ) -> Tuple[int, str, str]:
     """Execute a compiled ``binary`` with optional limits and environment.
 
@@ -240,7 +242,32 @@ def run_binary(
         Extra environment variables to inject. Values override the current
         process environment which enables dynamic library lookup via
         ``LD_LIBRARY_PATH`` when rpath isn't provided.
+    sandbox:
+        Optional :class:`~runners.isolate.IsolateRunner` used to execute the
+        binary in a restricted environment.  When omitted the program is run
+        directly via :func:`subprocess.run` with best-effort ``rlimit``
+        enforcement.
     """
+
+    if sandbox is not None:
+        cmd: List[str]
+        if env:
+            cmd = ["env"] + [f"{k}={v}" for k, v in env.items()]
+            cmd.append(str(binary))
+        else:
+            cmd = [str(binary)]
+        proc = sandbox.run(
+            cmd,
+            time_limit=int(timeout),
+            wall_time=int(timeout),
+            memory=(
+                (memory_limit // 1024)
+                if memory_limit is not None
+                else 256 * 1024
+            ),
+            stdin=input_data.encode(),
+        )
+        return proc.returncode, proc.stdout, proc.stderr
 
     def preexec() -> None:
         _set_limits(memory_limit)
@@ -272,12 +299,16 @@ def run_codeforces_tests(
     rpath: Optional[Iterable[Path]] = None,
     use_ccache: bool = False,
     env: Optional[Mapping[str, str]] = None,
+    sandbox: Optional[IsolateRunner] = None,
 ) -> dict:
     """Compile ``sources`` and run them against all tests in ``tests_dir``.
 
     The directory is expected to contain pairs of ``*.in`` and ``*.out`` files.
     Results include compilation diagnostics and a list of per-test outcomes
-    with error classifications.
+    with error classifications.  The ``sandbox`` parameter allows executing
+    each test run inside an :class:`~runners.isolate.IsolateRunner` to enforce
+    hard resource limits and disable networking, aligning with Phase 10's
+    extended judge goals.
     """
 
     compile_res = compile_cpp_sources(
@@ -291,7 +322,7 @@ def run_codeforces_tests(
         rpath=rpath,
         use_ccache=use_ccache,
     )
-    compile_status = classify_compile(success, err)
+    compile_status = classify_compile(compile_res.success, compile_res.stderr)
     results = []
     if not compile_res.success or compile_res.binary is None:
         return {
@@ -299,6 +330,7 @@ def run_codeforces_tests(
             "compile_stderr": compile_res.stderr,
             "compile_warnings": compile_res.warnings,
             "compile_errors": compile_res.errors,
+            "compile_status": compile_status,
             "results": results,
         }
 
@@ -314,6 +346,7 @@ def run_codeforces_tests(
                 timeout=timeout,
                 memory_limit=memory_limit,
                 env=env,
+                sandbox=sandbox,
             )
             timed_out = False
         except subprocess.TimeoutExpired:
@@ -336,5 +369,6 @@ def run_codeforces_tests(
         "compile_stderr": compile_res.stderr,
         "compile_warnings": compile_res.warnings,
         "compile_errors": compile_res.errors,
+        "compile_status": compile_status,
         "results": results,
     }

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,17 +1,17 @@
 from pathlib import Path
-
-from pathlib import Path
 import pathlib
 import re
 import subprocess
 import sys
+from typing import List, Optional, Tuple
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from runners.cpp_runner import (
+from runners.cpp_runner import (  # noqa: E402
     compile_cpp_sources,
     compile_shared_library,
     run_binary,
+    run_codeforces_tests,
 )
 
 
@@ -47,7 +47,9 @@ def test_shared_library_link(tmp_path: Path) -> None:
 
     lib_path = tmp_path / "libdouble.so"
     lib_res = compile_shared_library([lib_src], output=lib_path)
-    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.success, (
+        f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    )
     assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
@@ -65,7 +67,9 @@ int main(){std::cout<<times_two(5);}
         libraries=["double"],
         rpath=[tmp_path],
     )
-    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.success, (
+        f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    )
     assert main_res.binary is not None
 
     code, stdout, stderr = run_binary(main_res.binary)
@@ -82,7 +86,9 @@ def test_shared_library_env_link(tmp_path: Path) -> None:
 
     lib_path = tmp_path / "libdouble.so"
     lib_res = compile_shared_library([lib_src], output=lib_path)
-    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.success, (
+        f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    )
     assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
@@ -99,7 +105,9 @@ int main(){std::cout<<times_two(5);}
         library_dirs=[tmp_path],
         libraries=["double"],
     )
-    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.success, (
+        f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    )
     assert main_res.binary is not None
 
     code, stdout, stderr = run_binary(
@@ -118,7 +126,9 @@ def test_static_build(tmp_path: Path) -> None:
     assert res.success, f"compile failed: {res.stdout}\n{res.stderr}"
     assert res.binary is not None
 
-    ldd = subprocess.run(["ldd", str(res.binary)], capture_output=True, text=True)
+    ldd = subprocess.run(
+        ["ldd", str(res.binary)], capture_output=True, text=True
+    )
     assert "not a dynamic executable" in (ldd.stdout + ldd.stderr)
 
 
@@ -147,3 +157,59 @@ def test_warning_count(tmp_path: Path) -> None:
     ], flags=["-std=c++17", "-Wall"], sanitize=False)
     assert res.success
     assert res.warnings >= 1
+
+
+class DummySandbox:
+    """Stub sandbox that records invocations."""
+
+    def __init__(self) -> None:
+        self.last: Optional[Tuple[List[str], int, int, int, bytes]] = None
+
+    def run(
+        self,
+        cmd: List[str],
+        *,
+        time_limit: int = 5,
+        wall_time: int = 5,
+        memory: int = 256 * 1024,
+        stdin: Optional[bytes] = None,
+    ) -> subprocess.CompletedProcess:
+        self.last = (cmd, time_limit, wall_time, memory, stdin or b"")
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+
+def test_run_binary_with_sandbox() -> None:
+    sandbox = DummySandbox()
+    binary = Path("/bin/echo")
+    code, stdout, stderr = run_binary(
+        binary,
+        input_data="hi",
+        timeout=3.2,
+        memory_limit=1024 * 1024,
+        sandbox=sandbox,
+    )
+    assert code == 0
+    assert stdout == "ok"
+    assert sandbox.last is not None
+    cmd, tl, wl, mem, stdin = sandbox.last
+    assert cmd == [str(binary)]
+    assert tl == 3 and wl == 3
+    assert mem == 1024
+    assert stdin == b"hi"
+
+
+def test_run_codeforces_tests(tmp_path: Path) -> None:
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        """
+#include <iostream>
+int main(){int a,b;if(!(std::cin>>a>>b)) return 0; std::cout<<a+b;}
+"""
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "sample.in").write_text("2 3\n")
+    (tests_dir / "sample.out").write_text("5\n")
+    res = run_codeforces_tests([src], tests_dir)
+    assert res["compile_status"] == "success"
+    assert res["results"] and res["results"][0]["passed"]


### PR DESCRIPTION
## Summary
- Allow running compiled binaries inside isolate sandboxes
- Expose sandbox option and compile status in Codeforces test harness
- Cover sandbox execution and Codeforces harness with new tests

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py`
- `pytest tests/test_cpp_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a057ad98088331bad3a3499baecbe2