### PR TITLE
Integrate compiler diagnostics into reward scoring

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -60,6 +60,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [ ] Phase 5: Reward Shaping and Safety Gates
     [X] Implement reward aggregator with weighted compile/link status, tests, and coverage signals
     [X] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
+    [X] Incorporate compiler warning/error counts into reward diagnostics score
     [X] Integrate static analysis (cppcheck) scoring and normalization
     [X] Implement coverage delta computation using gcov/lcov or llvm-cov
     [X] Implement edit-cost, time, and memory penalty functions with clamps

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,6 +8,7 @@ from utils.diagnostics import (
     cppcheck_score,
     coverage_delta,
     compiler_diagnostics,
+    diagnostics_score,
 )
 
 
@@ -33,3 +34,8 @@ def test_compiler_diagnostics():
     warnings, errors = compiler_diagnostics(stdout, stderr)
     assert warnings == 1
     assert errors == 1
+
+
+def test_diagnostics_score():
+    assert diagnostics_score(0, 0) == 1.0
+    assert diagnostics_score(2, 1) == 0.7

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -126,6 +126,69 @@ def test_compute_from_outputs_matches_manual_scores():
     assert abs(r1 - r2) < 1e-6
 
 
+def test_compile_diagnostics_penalty():
+    agg = RewardAggregator(
+        weights={"compile": 0.1, "diagnostics": 0.3},
+        max_edit_penalty=0.0,
+        max_time_penalty=0.0,
+        max_memory_penalty=0.0,
+    )
+
+    clean = agg.compute(
+        compile_success=True,
+        tests_passed=0,
+        tests_total=0,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        warnings=0,
+        errors=0,
+    )
+
+    noisy = agg.compute(
+        compile_success=True,
+        tests_passed=0,
+        tests_total=0,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        warnings=2,
+        errors=1,
+    )
+
+    assert noisy < clean
+
+    r = agg.compute_from_outputs(
+        compile_success=True,
+        tests_passed=0,
+        tests_total=0,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        clang_output="",
+        cppcheck_output="",
+        compiler_stdout="a.cpp:1:1: warning: w\n",
+        compiler_stderr="a.cpp:2:2: error: e\n",
+    )
+
+    manual = agg.compute(
+        compile_success=True,
+        tests_passed=0,
+        tests_total=0,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        warnings=1,
+        errors=1,
+    )
+
+    assert abs(r - manual) < 1e-6
+
+
 def test_sanitizer_bonus_and_penalty():
     agg = RewardAggregator(
         weights={'compile': 0.1, 'tests': 0.2, 'sanitizer': 0.1},

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -6,6 +6,7 @@ from .diagnostics import (  # noqa: F401
     clang_tidy_score,
     cppcheck_score,
     compiler_diagnostics,
+    diagnostics_score,
     coverage_delta,
 )
 

--- a/utils/diagnostics.py
+++ b/utils/diagnostics.py
@@ -36,6 +36,17 @@ def compiler_diagnostics(stdout: str, stderr: str) -> tuple[int, int]:
     return warnings, errors
 
 
+def diagnostics_score(warnings: int, errors: int) -> float:
+    """Return a normalized score from warning and error counts.
+
+    Each compiler warning reduces the score by ``0.05`` and each error by
+    ``0.2``.  The result is clipped to the ``[0, 1]`` interval.
+    """
+
+    penalty = 0.05 * warnings + 0.2 * errors
+    return max(0.0, 1.0 - penalty)
+
+
 def sanitizer_clean(output: str) -> bool:
     """Return True when no sanitizer issues are detected.
 

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -5,7 +5,9 @@ import logging
 from .diagnostics import (
     clang_tidy_score,
     cppcheck_score,
+    compiler_diagnostics,
     coverage_delta,
+    diagnostics_score,
     sanitizer_clean,
 )
 
@@ -45,6 +47,8 @@ class RewardAggregator:
         memory_used: float,
         lint_score: float = 1.0,
         static_score: float = 1.0,
+        warnings: int = 0,
+        errors: int = 0,
         sanitizer_clean: bool | None = None,
         prev_coverage: float | None = None,
         time_limit: float | None = None,
@@ -65,6 +69,8 @@ class RewardAggregator:
         lint_score: normalized score from clang-tidy/clang diagnostics.
         static_score: normalized score from static analysis tools
             (e.g. cppcheck).
+        warnings: count of compiler warnings.
+        errors: count of compiler errors.
         sanitizer_clean: whether Address/UndefinedBehavior sanitizers reported
             no issues. ``None`` skips this signal.
         prev_coverage: previous coverage value used to compute coverage delta.
@@ -78,6 +84,7 @@ class RewardAggregator:
         if compile_success:
             test_score = tests_passed / tests_total if tests_total else 0.0
             coverage_score = max(0.0, min(coverage, 1.0))
+            diag_score = diagnostics_score(warnings, errors)
             prev_cov = (
                 max(0.0, min(prev_coverage, 1.0))
                 if prev_coverage is not None
@@ -92,11 +99,13 @@ class RewardAggregator:
             test_score = 0.0
             coverage_score = 0.0
             cov_delta = 0.0
+            diag_score = 0.0
 
         reward += self.weights.get("compile", 0.0) * compile_score
         reward += self.weights.get("tests", 0.0) * test_score
         reward += self.weights.get("coverage", 0.0) * coverage_score
         reward += self.weights.get("coverage_delta", 0.0) * cov_delta
+        reward += self.weights.get("diagnostics", 0.0) * diag_score
         reward += self.weights.get("lint", 0.0) * max(
             0.0, min(lint_score, 1.0)
         )
@@ -138,6 +147,8 @@ class RewardAggregator:
         time_used: float,
         memory_used: float,
         clang_output: str = "",
+        compiler_stdout: str = "",
+        compiler_stderr: str = "",
         cppcheck_output: str = "",
         sanitizer_output: str | None = None,
         prev_coverage: float | None = None,
@@ -153,7 +164,11 @@ class RewardAggregator:
         Parameters
         ----------
         clang_output:
-            Raw stderr/stdout from clang-tidy/clang++.
+            Raw stderr/stdout from clang-tidy.
+        compiler_stdout:
+            Stdout from the compiler invocation.
+        compiler_stderr:
+            Stderr from the compiler invocation.
         cppcheck_output:
             Raw output from cppcheck.
         sanitizer_output:
@@ -168,6 +183,7 @@ class RewardAggregator:
         """
 
         lint = clang_tidy_score(clang_output)
+        warnings, errors = compiler_diagnostics(compiler_stdout, compiler_stderr)
         static = cppcheck_score(cppcheck_output)
         san = (
             sanitizer_clean(sanitizer_output)
@@ -184,6 +200,8 @@ class RewardAggregator:
             memory_used=memory_used,
             lint_score=lint,
             static_score=static,
+            warnings=warnings,
+            errors=errors,
             sanitizer_clean=san,
             prev_coverage=prev_coverage,
             time_limit=time_limit,


### PR DESCRIPTION
## Summary
- score compiler warnings and errors via new `diagnostics_score` helper
- incorporate diagnostics weighting into `RewardAggregator` and parse compiler output
- document Phase 5 progress on diagnostics scoring

## Testing
- `pytest tests/test_diagnostics.py tests/test_reward.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a066303de48331bfabc1e3973bfb75