### PR TITLE
Add Phase 6 training demo

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -72,7 +72,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Integrate REINFORCE with value baseline and entropy regularization
     [X] Implement curriculum toggles for visible versus hidden tests
     [X] Add checkpointing, resume logic, and deterministic dataloaders
-    [?] Create 5-task smoke run pipeline for CI runtime budgets
+    [X] Create 5-task smoke run pipeline for CI runtime budgets
 
 ** [ ] Phase 7: Evaluation Harness and Reporting
     [X] Implement pass\@k computation with fixed seeds and sampling policies

--- a/hrm_coder/tests/test_train_script.py
+++ b/hrm_coder/tests/test_train_script.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+
+
+def test_train_module_runs():
+    """Ensure the training entry point executes end-to-end."""
+    result = subprocess.run(
+        [sys.executable, "-m", "hrm_coder.train"], capture_output=True, text=True, check=True
+    )
+    assert "avg_loss=" in result.stdout
+    assert "reinforce:" in result.stdout

--- a/hrm_coder/train.py
+++ b/hrm_coder/train.py
@@ -1,28 +1,46 @@
 from __future__ import annotations
 
-"""Phase 1 training stub for HRM Coder.
+"""Minimal training entry point for Phase 6 integration.
 
-This module demonstrates how training scripts will load Hydra
-configuration and pin the runtime environment for determinism.
-Actual training logic will be implemented in later phases.
+The script exercises both supervised fine-tuning and a tiny
+reinforcement-learning loop using :class:`hrm.training_loop.HRMTrainer`.
+It intentionally operates on a synthetic five-sample dataset so that
+CI can run it within tight runtime budgets.
 """
 
 from dataclasses import asdict
 import argparse
 from pprint import pformat
 
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from hrm.training_loop import HRMTrainer, HRMTrainingConfig
+
 from .config import load_config
 from .env import pin_environment
 
 
-def main() -> None:
-    """Entry point for the training stub.
+class TinyModel(nn.Module):
+    """Simple linear policy/value model used for smoke training."""
 
-    Parameters
-    ----------
-    None
-    """
+    def __init__(self, vocab_size: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(vocab_size, vocab_size)
+        self.value = nn.Linear(vocab_size, 1)
+
+    def forward(self, x: torch.Tensor):  # type: ignore[override]
+        logits = self.linear(x)
+        value = self.value(x).squeeze(-1)
+        return logits, value
+
+
+def main() -> None:
+    """Run a tiny end-to-end training demo."""
+
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=0, help="PRNG seed")
     parser.add_argument(
         "overrides",
         nargs="*",
@@ -31,11 +49,43 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = load_config(args.overrides)
-    pin_environment()
+    pin_environment(args.seed)
+    torch.manual_seed(args.seed)
 
     print("Loaded configuration:")
     print(pformat(asdict(cfg)))
-    print("Training loop not yet implemented – Phase 1 placeholder")
+
+    # Build a toy dataset consisting of five one-hot samples.
+    vocab = 8
+    inputs = torch.eye(vocab)[:5]
+    targets = torch.arange(5) % vocab
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=1, shuffle=True)
+
+    # Initialise model and trainer.
+    model = TinyModel(vocab)
+    opt = torch.optim.SGD(model.parameters(), lr=cfg.model.learning_rate)
+    trainer = HRMTrainer(model, opt, HRMTrainingConfig())
+
+    # --- Supervised fine-tuning ---------------------------------------
+    avg_loss = trainer.sft_epoch(loader)
+    print(f"avg_loss={avg_loss:.4f}")
+
+    # --- Reinforcement learning ---------------------------------------
+    def reward_fn_factory(target: torch.Tensor):
+        def reward_fn(actions: torch.Tensor) -> torch.Tensor:
+            return torch.where(actions == target, torch.tensor(1.0), torch.tensor(0.0))
+
+        return reward_fn
+
+    rl_stats = {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "reward": 0.0}
+    for inp, target in dataset:
+        stats = trainer.reinforce_step(inp.unsqueeze(0), reward_fn_factory(target))
+        for k, v in stats.items():
+            rl_stats[k] += v
+    for k in rl_stats:
+        rl_stats[k] /= len(dataset)
+    print("reinforce:", " ".join(f"{k}={v:.4f}" for k, v in rl_stats.items()))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- implement miniature HRM training run with both SFT and REINFORCE paths
- add test for training entry point and update Phase 6 checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06631d1d88331a9652b4dd58efd79