### PR TITLE
feat: add incident rate evaluation

### DIFF
--- a/hrm_coder/evaluation.py
+++ b/hrm_coder/evaluation.py
@@ -96,13 +96,52 @@ def flaky_tasks(runs: Sequence[Dict[str, bool]]) -> List[str]:
     ]
 
 
-def markdown_report(metrics: Dict[int, float], flaky: Sequence[str]) -> str:
+def incident_rates(
+    runs: Sequence[Dict[str, str]],
+    incident_types: Sequence[str] = ("timeout", "sanitizer"),
+) -> Dict[str, float]:
+    """Compute rates of specified incident types across runs.
+
+    Parameters
+    ----------
+    runs:
+        Sequence of mappings from task identifier to a status string.
+    incident_types:
+        Iterable of status values to measure. Defaults to ``("timeout",
+        "sanitizer")``.
+    """
+
+    counts = {inc: 0 for inc in incident_types}
+    total = 0
+    for run in runs:
+        for status in run.values():
+            total += 1
+            for inc in incident_types:
+                if status == inc:
+                    counts[inc] += 1
+    return {
+        inc: (counts[inc] / total if total else 0.0)
+        for inc in incident_types
+    }
+
+
+def markdown_report(
+    metrics: Dict[int, float],
+    flaky: Sequence[str],
+    incidents: Dict[str, float] | None = None,
+) -> str:
     """Generate a Markdown report for the evaluation metrics."""
 
     lines = ["# Evaluation Report", "", "| k | pass@k |", "|---|-------|"]
     for k, value in sorted(metrics.items()):
         lines.append(f"| {k} | {value:.3f} |")
     lines.append("")
+    if incidents:
+        lines.append("## Incident Rates")
+        lines.extend(
+            f"- {name}: {rate:.3f}" for name, rate in incidents.items()
+        )
+        lines.append("")
     if flaky:
         lines.append("## Flaky Tasks")
         lines.extend(f"- {task}" for task in flaky)
@@ -111,7 +150,11 @@ def markdown_report(metrics: Dict[int, float], flaky: Sequence[str]) -> str:
     return "\n".join(lines)
 
 
-def html_report(metrics: Dict[int, float], flaky: Sequence[str]) -> str:
+def html_report(
+    metrics: Dict[int, float],
+    flaky: Sequence[str],
+    incidents: Dict[str, float] | None = None,
+) -> str:
     """Generate a minimal HTML report for the evaluation metrics."""
 
     rows = "".join(
@@ -124,10 +167,22 @@ def html_report(metrics: Dict[int, float], flaky: Sequence[str]) -> str:
         ) + "</ul>"
     else:
         flaky_html = "<p>No flaky tasks detected.</p>"
+    if incidents:
+        incidents_html = (
+            "<ul>"
+            + "".join(
+                f"<li>{name}: {rate:.3f}</li>"
+                for name, rate in incidents.items()
+            )
+            + "</ul>"
+        )
+    else:
+        incidents_html = "<p>No incidents recorded.</p>"
     return (
         "<h1>Evaluation Report</h1>"
         "<table><tr><th>k</th><th>pass@k</th></tr>"
         f"{rows}</table>"
+        f"{incidents_html}"
         f"{flaky_html}"
     )
 
@@ -223,6 +278,7 @@ def generate_reports(
     ks: Sequence[int] = (1, 10),
     run_paths: Sequence[str] | None = None,
     baseline_path: str | None = None,
+    incident_paths: Sequence[str] | None = None,
 ) -> Dict[int, float]:
     """Compute metrics and emit Markdown/HTML reports.
 
@@ -240,6 +296,9 @@ def generate_reports(
     baseline_path:
         Optional path to a JSON file containing baseline metrics for
         comparison.  Baseline keys should be of the form ``"pass@k"``.
+    incident_paths:
+        Optional JSON files mapping task id → status string, used to
+        compute incident rates such as timeouts and sanitizer failures.
 
     Returns
     -------
@@ -257,10 +316,22 @@ def generate_reports(
     )
     flaky = flaky_tasks(runs) if runs else []
 
+    incidents = (
+        incident_rates(
+            [json.loads(Path(p).read_text()) for p in incident_paths]
+        )
+        if incident_paths
+        else None
+    )
+
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / "report.md").write_text(markdown_report(metrics, flaky))
-    (out_dir / "report.html").write_text(html_report(metrics, flaky))
+    (out_dir / "report.md").write_text(
+        markdown_report(metrics, flaky, incidents)
+    )
+    (out_dir / "report.html").write_text(
+        html_report(metrics, flaky, incidents)
+    )
 
     if baseline_path is not None:
         named_metrics = {f"pass@{k}": v for k, v in metrics.items()}
@@ -304,6 +375,12 @@ def main() -> None:  # pragma: no cover - CLI entry point
         default=None,
         help="JSON file with baseline metrics for comparison",
     )
+    parser.add_argument(
+        "--incidents",
+        nargs="*",
+        default=None,
+        help="JSON files of run status strings for incident rate computation",
+    )
     args = parser.parse_args()
     generate_reports(
         results_path=args.results,
@@ -311,6 +388,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
         ks=args.ks,
         run_paths=args.runs,
         baseline_path=args.baseline,
+        incident_paths=args.incidents,
     )
 
 

--- a/hrm_coder/tests/test_evaluation.py
+++ b/hrm_coder/tests/test_evaluation.py
@@ -1,10 +1,12 @@
 import json
+
 import pytest
 
 from hrm_coder.evaluation import (
     aggregate_pass_at_k,
     check_determinism,
     flaky_tasks,
+    incident_rates,
     markdown_report,
     html_report,
     compare_to_baseline,
@@ -38,13 +40,16 @@ def test_determinism_and_flaky_detection():
 
 def test_report_generation():
     metrics = {1: 0.5}
-    report_md = markdown_report(metrics, ['t2'])
+    incidents = {"timeout": 0.1}
+    report_md = markdown_report(metrics, ['t2'], incidents)
     assert '| 1 | 0.500 |' in report_md
     assert 'Flaky Tasks' in report_md
+    assert 'timeout' in report_md
 
-    report_html = html_report(metrics, [])
+    report_html = html_report(metrics, [], incidents)
     assert '<td>1</td><td>0.500</td>' in report_html
     assert 'No flaky tasks' in report_html
+    assert 'timeout' in report_html
 
 
 def test_baseline_comparison(tmp_path):
@@ -64,6 +69,16 @@ def test_baseline_comparison(tmp_path):
     assert "<td>0.600</td>" in report_html
 
 
+def test_incident_rates():
+    runs = [
+        {"a": "timeout", "b": "pass"},
+        {"a": "sanitizer", "b": "timeout"},
+    ]
+    rates = incident_rates(runs)
+    assert rates["timeout"] == pytest.approx(2 / 4)
+    assert rates["sanitizer"] == pytest.approx(1 / 4)
+
+
 def test_generate_reports(tmp_path):
     results = {"t1": [True, False], "t2": [False, False]}
     results_file = tmp_path / "results.json"
@@ -74,6 +89,11 @@ def test_generate_reports(tmp_path):
     run1_file.write_text(json.dumps({"t1": True, "t2": False}))
     run2_file.write_text(json.dumps({"t1": True, "t2": True}))
 
+    incident1_file = tmp_path / "inc1.json"
+    incident2_file = tmp_path / "inc2.json"
+    incident1_file.write_text(json.dumps({"t1": "timeout", "t2": "pass"}))
+    incident2_file.write_text(json.dumps({"t1": "pass", "t2": "timeout"}))
+
     baseline_file = tmp_path / "baseline.json"
     baseline_file.write_text(json.dumps({"pass@1": 0.0, "pass@2": 0.0}))
 
@@ -83,11 +103,13 @@ def test_generate_reports(tmp_path):
         ks=[1, 2],
         run_paths=[str(run1_file), str(run2_file)],
         baseline_path=str(baseline_file),
+        incident_paths=[str(incident1_file), str(incident2_file)],
     )
 
     assert metrics[1] == pytest.approx(0.25)
     report_md = (tmp_path / "report.md").read_text()
     assert "Flaky Tasks" in report_md and "t2" in report_md
+    assert "Incident Rates" in report_md
     assert (tmp_path / "report.html").exists()
     assert (tmp_path / "baseline.md").exists()
     assert (tmp_path / "baseline.html").exists()


### PR DESCRIPTION
## Summary
- support computing timeout/sanitizer incident rates across runs
- include incident statistics in evaluation Markdown/HTML reports
- expose incident files via CLI and test harness

## Testing
- `pre-commit run --files hrm_coder/evaluation.py hrm_coder/tests/test_evaluation.py`
- `pytest hrm_coder/tests/test_evaluation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06634a5a083318b0a36a63ecc5b72