### PR TITLE
Add schema validation for C++ dataset builders

### DIFF
--- a/dataset/build_atcoder_abc_dataset.py
+++ b/dataset/build_atcoder_abc_dataset.py
@@ -28,6 +28,7 @@ import json
 from pathlib import Path
 from typing import List
 
+from .schemas import AtCoderRecord
 from .split_manager import split_list
 
 
@@ -52,15 +53,18 @@ def load_tasks(path: Path) -> List[AtCoderTask]:
     tasks: List[AtCoderTask] = []
     with path.open() as fh:
         for line in fh:
-            raw = json.loads(line)
-            tests = [IOPair(**t) for t in raw["tests"]]
+            record = AtCoderRecord.model_validate_json(line)
+            tests = [
+                IOPair(input=io.input, output=io.output)
+                for io in record.tests
+            ]
             tasks.append(
                 AtCoderTask(
-                    task_id=raw["task_id"],
-                    prompt=raw["prompt"],
+                    task_id=record.task_id,
+                    prompt=record.prompt,
                     tests=tests,
-                    time_limit_ms=raw.get("time_limit_ms", 2000),
-                    memory_limit_kb=raw.get("memory_limit_kb", 102400),
+                    time_limit_ms=record.time_limit_ms,
+                    memory_limit_kb=record.memory_limit_kb,
                 )
             )
     return tasks

--- a/dataset/build_codeforces_intro_dataset.py
+++ b/dataset/build_codeforces_intro_dataset.py
@@ -25,6 +25,7 @@ import json
 from pathlib import Path
 from typing import List
 
+from .schemas import CodeforcesRecord
 from .split_manager import split_list
 
 
@@ -47,15 +48,18 @@ def load_tasks(path: Path) -> List[CodeforcesTask]:
     tasks: List[CodeforcesTask] = []
     with path.open() as fh:
         for line in fh:
-            raw = json.loads(line)
-            tests = [IOPair(**t) for t in raw["tests"]]
+            record = CodeforcesRecord.model_validate_json(line)
+            tests = [
+                IOPair(input=io.input, output=io.output)
+                for io in record.tests
+            ]
             tasks.append(
                 CodeforcesTask(
-                    task_id=raw["task_id"],
-                    prompt=raw["prompt"],
+                    task_id=record.task_id,
+                    prompt=record.prompt,
                     tests=tests,
-                    time_limit_ms=raw.get("time_limit_ms", 2000),
-                    memory_limit_kb=raw.get("memory_limit_kb", 256000),
+                    time_limit_ms=record.time_limit_ms,
+                    memory_limit_kb=record.memory_limit_kb,
                 )
             )
     return tasks
@@ -91,10 +95,21 @@ def build_dataset(raw_path: str, output_dir: str, seed: int = 0) -> None:
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Build Codeforces-Intro dataset")
-    parser.add_argument("raw_path", help="Path to raw JSONL dataset")
-    parser.add_argument("output_dir", help="Output directory for processed dataset")
-    parser.add_argument("--seed", type=int, default=0, help="Random seed for deterministic splits")
+    parser = argparse.ArgumentParser(
+        description="Build Codeforces-Intro dataset"
+    )
+    parser.add_argument(
+        "raw_path", help="Path to raw JSONL dataset"
+    )
+    parser.add_argument(
+        "output_dir", help="Output directory for processed dataset"
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for deterministic splits",
+    )
     args = parser.parse_args()
 
     build_dataset(args.raw_path, args.output_dir, args.seed)

--- a/dataset/build_humaneval_cpp_dataset.py
+++ b/dataset/build_humaneval_cpp_dataset.py
@@ -17,10 +17,10 @@ CMake/GoogleTest harness generation.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import json
 from pathlib import Path
-from typing import Iterable, List
+from typing import List
 
+from .schemas import HumanEvalCPPRecord
 from .split_manager import split_list
 
 
@@ -33,16 +33,18 @@ class HumanEvalCPPTask:
 
 
 def load_tasks(path: Path) -> List[HumanEvalCPPTask]:
+    """Load tasks from a JSONL file using the HumanEvalCPPRecord schema."""
+
     tasks: List[HumanEvalCPPTask] = []
     with path.open() as fh:
         for line in fh:
-            raw = json.loads(line)
+            record = HumanEvalCPPRecord.model_validate_json(line)
             tasks.append(
                 HumanEvalCPPTask(
-                    task_id=raw["task_id"],
-                    prompt=raw["prompt"],
-                    test=raw["test"],
-                    reference_solution=raw.get("reference_solution"),
+                    task_id=record.task_id,
+                    prompt=record.prompt,
+                    test=record.test,
+                    reference_solution=record.reference_solution,
                 )
             )
     return tasks
@@ -70,10 +72,21 @@ def build_dataset(raw_path: str, output_dir: str, seed: int = 0) -> None:
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Build HumanEval-CPP dataset")
-    parser.add_argument("raw_path", help="Path to raw JSONL dataset")
-    parser.add_argument("output_dir", help="Output directory for processed dataset")
-    parser.add_argument("--seed", type=int, default=0, help="Random seed for deterministic splits")
+    parser = argparse.ArgumentParser(
+        description="Build HumanEval-CPP dataset"
+    )
+    parser.add_argument(
+        "raw_path", help="Path to raw JSONL dataset"
+    )
+    parser.add_argument(
+        "output_dir", help="Output directory for processed dataset"
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for deterministic splits",
+    )
     args = parser.parse_args()
 
     build_dataset(args.raw_path, args.output_dir, args.seed)

--- a/dataset/schemas.py
+++ b/dataset/schemas.py
@@ -1,0 +1,48 @@
+"""Pydantic models defining raw dataset schemas.
+
+These models provide explicit contracts for the JSONL records consumed by
+the dataset builders. Using them ensures that malformed entries are caught
+early during the build step, which is a requirement for the deterministic
+dataset pipeline in Phase 3.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class IOPairRecord(BaseModel):
+    """Simple input/output pair used by Codeforces and AtCoder tasks."""
+
+    input: str
+    output: str
+
+
+class HumanEvalCPPRecord(BaseModel):
+    """Schema for a single HumanEval-CPP JSONL record."""
+
+    task_id: str
+    prompt: str
+    test: str
+    reference_solution: Optional[str] = None
+
+
+class CodeforcesRecord(BaseModel):
+    """Schema for a Codeforces-Intro dataset record."""
+
+    task_id: str
+    prompt: str
+    tests: List[IOPairRecord]
+    time_limit_ms: int = Field(default=2000, ge=1)
+    memory_limit_kb: int = Field(default=256_000, ge=1)
+
+
+class AtCoderRecord(BaseModel):
+    """Schema for an AtCoder ABC dataset record."""
+
+    task_id: str
+    prompt: str
+    tests: List[IOPairRecord]
+    time_limit_ms: int = Field(default=2000, ge=1)
+    memory_limit_kb: int = Field(default=102_400, ge=1)

--- a/tests/test_dataset_schemas.py
+++ b/tests/test_dataset_schemas.py
@@ -1,0 +1,85 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root is on the import path so the local ``dataset`` package
+# is used instead of the similarly named third-party library.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.build_atcoder_abc_dataset import (  # noqa: E402
+    load_tasks as load_atcoder,
+)
+from dataset.build_codeforces_intro_dataset import (  # noqa: E402
+    load_tasks as load_codeforces,
+)
+from dataset.build_humaneval_cpp_dataset import (  # noqa: E402
+    load_tasks as load_humaneval,
+)
+from pydantic import ValidationError  # noqa: E402
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with path.open("w") as fh:
+        for rec in records:
+            json.dump(rec, fh)
+            fh.write("\n")
+
+
+def test_humaneval_schema_enforced(tmp_path: Path) -> None:
+    good = {"task_id": "t1", "prompt": "//", "test": "//"}
+    good_path = tmp_path / "good_he.jsonl"
+    _write_jsonl(good_path, [good])
+    tasks = load_humaneval(good_path)
+    assert tasks[0].task_id == "t1"
+
+    bad = {"task_id": "t1", "prompt": "//"}  # missing test field
+    bad_path = tmp_path / "bad_he.jsonl"
+    _write_jsonl(bad_path, [bad])
+    with pytest.raises(ValidationError):
+        load_humaneval(bad_path)
+
+
+def test_codeforces_schema_enforced(tmp_path: Path) -> None:
+    good = {
+        "task_id": "cf1",
+        "prompt": "p",
+        "tests": [{"input": "1\n", "output": "1\n"}],
+    }
+    good_path = tmp_path / "good_cf.jsonl"
+    _write_jsonl(good_path, [good])
+    tasks = load_codeforces(good_path)
+    assert tasks[0].tests[0].output == "1\n"
+
+    bad = {
+        "task_id": "cf2",
+        "prompt": "p",
+        "tests": [{"input": "1\n"}],  # missing output
+    }
+    bad_path = tmp_path / "bad_cf.jsonl"
+    _write_jsonl(bad_path, [bad])
+    with pytest.raises(ValidationError):
+        load_codeforces(bad_path)
+
+
+def test_atcoder_schema_enforced(tmp_path: Path) -> None:
+    good = {
+        "task_id": "ac1",
+        "prompt": "p",
+        "tests": [{"input": "1\n", "output": "1\n"}],
+    }
+    good_path = tmp_path / "good_ac.jsonl"
+    _write_jsonl(good_path, [good])
+    tasks = load_atcoder(good_path)
+    assert tasks[0].tests[0].input == "1\n"
+
+    bad = {
+        "task_id": "ac2",
+        "prompt": "p",
+        "tests": [{"input": "1\n"}],  # missing output
+    }
+    bad_path = tmp_path / "bad_ac.jsonl"
+    _write_jsonl(bad_path, [bad])
+    with pytest.raises(ValidationError):
+        load_atcoder(bad_path)


### PR DESCRIPTION
## Summary
- define pydantic schemas for HumanEval-CPP, Codeforces-Intro, and AtCoder ABC datasets
- validate JSONL records in dataset builders using these schemas
- add tests ensuring invalid records are caught during load

## Testing
- `pre-commit run --files dataset/schemas.py dataset/build_humaneval_cpp_dataset.py dataset/build_codeforces_intro_dataset.py dataset/build_atcoder_abc_dataset.py tests/test_dataset_schemas.py`
- `PYTHONPATH=. pytest tests/test_dataset_schemas.py tests/test_build_codeforces_intro_dataset.py tests/test_build_atcoder_abc_dataset.py tests/test_humaneval_cpp_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06629f4608331a5d2dca064b7c429