### PR TITLE
feat: expose JUnit summary in GUI

### DIFF
--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 from pathlib import Path
+import xml.etree.ElementTree as ET
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -78,6 +79,38 @@ def list_artifacts(run_id: int) -> Dict[str, List[str]]:
         raise HTTPException(status_code=404, detail="artifact not found")
     files = [str(p.relative_to(path)) for p in path.rglob("*") if p.is_file()]
     return {"files": files}
+
+
+@app.get("/runs/{run_id}/junit")
+def junit_summary(run_id: int) -> Dict[str, int]:
+    """Return a summary of JUnit results for a run."""
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    junit_path = ARTIFACT_DIR / f"run_{run_id}" / "junit.xml"
+    if not junit_path.exists():
+        raise HTTPException(status_code=404, detail="junit not found")
+    try:
+        root = ET.parse(junit_path).getroot()
+    except ET.ParseError:
+        raise HTTPException(status_code=400, detail="invalid junit")
+
+    def _extract(node: ET.Element) -> tuple[int, int]:
+        tests = int(node.attrib.get("tests", 0))
+        failures = int(node.attrib.get("failures", 0))
+        errors = int(node.attrib.get("errors", 0))
+        return tests, failures + errors
+
+    if root.tag == "testsuites":
+        total_tests = total_failures = 0
+        for child in root.findall("testsuite"):
+            t, f = _extract(child)
+            total_tests += t
+            total_failures += f
+    else:
+        total_tests, total_failures = _extract(root)
+
+    return {"tests": total_tests, "failures": total_failures}
 
 
 class RunUpdate(BaseModel):

--- a/hrm_coder/static/run.html
+++ b/hrm_coder/static/run.html
@@ -8,6 +8,7 @@
   <h1>Run <span id="run_id"></span></h1>
   <div>Status: <span id="status"></span></div>
   <div>Artifact: <span id="artifact"></span></div>
+  <div id="junit"></div>
   <pre id="logs"></pre>
   <script>
     const params = new URLSearchParams(window.location.search);
@@ -27,6 +28,15 @@
       }
     }
     loadRun();
+
+    async function loadJunit() {
+      const resp = await fetch(`/runs/${runId}/junit`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      document.getElementById('junit').textContent =
+        `Tests: ${data.tests}, Failures: ${data.failures}`;
+    }
+    loadJunit();
 
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const ws = new WebSocket(`${proto}//${location.host}/logs/ws/${runId}`);

--- a/hrm_coder/tests/test_artifacts.py
+++ b/hrm_coder/tests/test_artifacts.py
@@ -1,10 +1,19 @@
 from pathlib import Path
 from fastapi.testclient import TestClient
+from itertools import count
 
 from .. import app
+from ..run_registry import registry
+
+
+def _reset_registry():
+    registry._runs.clear()
+    registry._log_queues.clear()
+    registry._id_counter = count(1)
 
 
 def test_artifact_static_server(tmp_path):
+    _reset_registry()
     client = TestClient(app)
     run = client.post('/train', json={}).json()
     run_id = run['id']
@@ -16,6 +25,7 @@ def test_artifact_static_server(tmp_path):
 
 
 def test_artifact_listing(tmp_path):
+    _reset_registry()
     client = TestClient(app)
     run = client.post('/train', json={}).json()
     run_id = run['id']
@@ -27,3 +37,4 @@ def test_artifact_listing(tmp_path):
     files = resp.json()['files']
     assert 'junit.xml' in files
     assert 'coverage/index.html' in files
+    _reset_registry()

--- a/hrm_coder/tests/test_junit_summary.py
+++ b/hrm_coder/tests/test_junit_summary.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+from itertools import count
+
+from .. import app
+from ..run_registry import registry
+
+
+def test_junit_summary_endpoint(tmp_path):
+    registry._runs.clear()
+    registry._log_queues.clear()
+    registry._id_counter = count(1)
+
+    client = TestClient(app)
+    run = client.post('/train', json={}).json()
+    run_id = run['id']
+    artifact_dir = Path('hrm_coder/artifacts') / f'run_{run_id}'
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    junit = '<testsuite tests="3" failures="1" errors="1"></testsuite>'
+    (artifact_dir / 'junit.xml').write_text(junit)
+    resp = client.get(f'/runs/{run_id}/junit')
+    assert resp.status_code == 200
+    assert resp.json() == {'tests': 3, 'failures': 2}
+
+    registry._runs.clear()
+    registry._log_queues.clear()
+    registry._id_counter = count(1)


### PR DESCRIPTION
## Summary
- add API endpoint to summarize JUnit artifacts
- surface JUnit test counts on run detail page
- cover JUnit summary with unit tests

## Testing
- `pre-commit run --files hrm_coder/api.py hrm_coder/static/run.html hrm_coder/tests/test_artifacts.py hrm_coder/tests/test_junit_summary.py`
- `pytest hrm_coder/tests/test_junit_summary.py hrm_coder/tests/test_artifacts.py hrm_coder/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06624f5808331a837f382357a0e35