### PR TITLE
Add toolchain detection utility

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -16,8 +16,9 @@ Save new code files in: C:\repos\hrm-coder
     [~] Setup project operation within isolate/gVisor runner images
     [~] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
         - Added sandbox detection utility for isolate, nsjail, and gVisor runsc runtime
+        - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
-    [ ] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
+    [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
     [ ] Draft sandbox Threat Model and initial security requirements for native binaries
     [ ] Write ADRs for sandbox choice, experiment tracker, and GUI stack
     [ ] Create initial risk register and mitigation plan

--- a/docs/hrmCoder_plan.md
+++ b/docs/hrmCoder_plan.md
@@ -143,6 +143,7 @@ Stubbed early with mock run objects and static artifact samples.
 * Inventory HRM APIs for code-token/AST edit integration.
 * Compare **isolate** vs **nsjail** vs **gVisor**; choose default + fallbacks.
 * Select toolchain: GCC 13+/Clang 17+, **llvm-cov**; decide sanitizer matrix.
+* Toolchain detection utility (`runners/toolchain_detector.py`) reports available compilers and coverage tools.
 * Dataset curation plan, licenses, and contamination checks.
 * Threat model for native execution; initial sandbox policy.
 * ADRs for sandbox, tracker, GUI stack; risk register.

--- a/runners/toolchain_detector.py
+++ b/runners/toolchain_detector.py
@@ -1,0 +1,64 @@
+"""Detect available compilers and coverage tools for C++ runs.
+
+Phase 0 requires surveying the host environment for existing C++
+compilers and coverage utilities.  This module inspects the current
+``PATH`` for a small set of expected tools and returns structured
+information describing their availability and version strings.  The
+results help decide which parts of the toolchain are usable on a given
+system.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Dict, Optional
+
+
+class ToolInfo(Dict[str, Optional[str]]):
+    """Dictionary describing an installed tool.
+
+    Keys
+    ----
+    available:
+        ``True`` if the binary is present on ``PATH``.
+    version:
+        First line of ``--version`` output (``None`` if unavailable).
+    path:
+        Resolved path to the binary (``None`` if missing).
+    """
+
+
+def _probe_version(cmd: list[str]) -> Optional[str]:
+    """Return the first line of ``cmd`` output if it executes successfully."""
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError:
+        return None
+    if proc.returncode != 0:
+        return None
+    line = proc.stdout.strip().splitlines()
+    return line[0] if line else None
+
+
+def detect_toolchains() -> Dict[str, ToolInfo]:
+    """Detect availability of common compiler and coverage utilities."""
+    tools = {
+        "g++": ["g++", "--version"],
+        "clang++": ["clang++", "--version"],
+        "lcov": ["lcov", "--version"],
+        "llvm-cov": ["llvm-cov", "--version"],
+        "gcov": ["gcov", "--version"],
+    }
+    results: Dict[str, ToolInfo] = {}
+    for name, cmd in tools.items():
+        path = shutil.which(cmd[0])
+        info: ToolInfo = ToolInfo(available=False, version=None, path=None)
+        if path:
+            info["available"] = True
+            info["path"] = path
+            info["version"] = _probe_version(cmd)
+        results[name] = info
+    return results
+
+
+__all__ = ["detect_toolchains", "ToolInfo"]

--- a/tests/test_toolchain_detector.py
+++ b/tests/test_toolchain_detector.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from runners import toolchain_detector  # noqa: E402
+
+
+def test_detect_toolchains_all_missing(monkeypatch):
+    monkeypatch.setattr(toolchain_detector.shutil, "which", lambda cmd: None)
+    result = toolchain_detector.detect_toolchains()
+    expected = {"g++", "clang++", "lcov", "llvm-cov", "gcov"}
+    assert set(result.keys()) == expected
+    assert all(not info["available"] for info in result.values())
+
+
+def test_detect_toolchains_reports_version(monkeypatch):
+    def fake_which(cmd: str):
+        return f"/usr/bin/{cmd}"
+
+    def fake_run(cmd, capture_output, text):
+        return SimpleNamespace(returncode=0, stdout=f"{cmd[0]} version 1.2\n")
+
+    monkeypatch.setattr(toolchain_detector.shutil, "which", fake_which)
+    monkeypatch.setattr(toolchain_detector.subprocess, "run", fake_run)
+    result = toolchain_detector.detect_toolchains()
+    assert all(info["available"] for info in result.values())
+    assert all(info["version"].endswith("1.2") for info in result.values())


### PR DESCRIPTION
## Summary
- detect g++, clang++, lcov, llvm-cov, and gcov versions via new helper module
- cover toolchain detection with unit tests
- track toolchain detector and acceptance thresholds in documentation

## Testing
- `pre-commit run --files runners/toolchain_detector.py tests/test_toolchain_detector.py docs/hrmCoder_checklist.md docs/hrmCoder_plan.md`
- `pytest tests/test_toolchain_detector.py tests/test_sandbox_detector.py hrm_coder/tests/test_acceptance.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0661e12f083319adeb841794ce1e3