### PR TITLE
Add smoke evaluation workflow

### DIFF
--- a/.github/workflows/ci-smoke-eval.yml
+++ b/.github/workflows/ci-smoke-eval.yml
@@ -1,0 +1,33 @@
+name: CI Smoke Evaluation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  smoke-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run smoke evaluation
+        run: python scripts/smoke_eval.py
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-eval
+          path: smoke_eval

--- a/scripts/smoke_eval.py
+++ b/scripts/smoke_eval.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Minimal smoke evaluation script for CI.
+
+This script exercises the evaluation harness on a small
+synthetic set of task results.  It generates a report and
+bundles the artifacts so CI can upload them.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import sys
+
+# Ensure repository root is on the import path when executed directly.
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils import eval_harness  # noqa: E402
+
+
+def main() -> None:
+    # Synthetic results: two tasks with a couple of candidate outcomes.
+    task_results = {
+        "task_a": [True, False, False],
+        "task_b": [False, False],
+    }
+    metrics = {
+        "pass@1": eval_harness.compute_pass_at_k(task_results, k=1),
+        "pass@10": eval_harness.compute_pass_at_k(task_results, k=10),
+    }
+
+    out_dir = pathlib.Path("smoke_eval")
+    out_dir.mkdir(exist_ok=True)
+
+    report_path = out_dir / "report.json"
+    eval_harness.generate_report(metrics, str(report_path))
+
+    # Bundle and "upload" to a local directory for CI artifact collection.
+    bundle_path = out_dir / "artifacts.zip"
+    upload_dir = out_dir / "upload"
+    eval_harness.bundle_and_upload(
+        [str(report_path)], str(bundle_path), str(upload_dir)
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add smoke_eval script to exercise evaluation harness and bundle artifacts
- run smoke evaluation in CI on push, PR and nightly schedule

## Testing
- `pre-commit run --files scripts/smoke_eval.py .github/workflows/ci-smoke-eval.yml`
- `pytest` *(fails: ModuleNotFoundError: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a057a9ceb4833198f2ecf4f8a2fb7f