### PR TITLE
Add C++ build scaffolding and presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.20)
+project(hrm_coder LANGUAGES CXX)
+
+enable_testing()
+add_subdirectory(hrm_coder/cpp)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,42 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20
+  },
+  "configurePresets": [
+    {
+      "name": "sanitized",
+      "displayName": "Sanitized",
+      "generator": "Ninja",
+      "binaryDir": "build/sanitized",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "generator": "Ninja",
+      "binaryDir": "build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS": "-O2 -pipe",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "warnings",
+      "displayName": "Warnings",
+      "generator": "Ninja",
+      "binaryDir": "build/warnings",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,31 @@
-
-.PHONY: data build_runner train eval report smoke
+.PHONY: data build_runner train eval report smoke cpp-build cpp-test
 
 # Placeholder targets for Phase 1 scaffold
 
 data:
-        @echo "Data pipeline not implemented yet"
+	@echo "Data pipeline not implemented yet"
 
 build_runner:
-        docker build -f runner.Dockerfile -t hrm-runner .
+	docker build -f runner.Dockerfile -t hrm-runner .
 
 train:
-        python -m hrm_coder.train $(ARGS)
+	python -m hrm_coder.train $(ARGS)
 
 eval:
-        python -m hrm_coder.eval_cli $(ARGS)
+	python -m hrm_coder.eval_cli $(ARGS)
 
 report:
-        @echo "Report generation not implemented yet"
+	@echo "Report generation not implemented yet"
 
 smoke:
-        python scripts/smoke_train.py
+	python scripts/smoke_train.py
+
+# Basic C++ build and test targets for Phase 1 scaffolding
+CPP_PRESET ?= sanitized
+
+cpp-build:
+	cmake --preset $(CPP_PRESET) -S hrm_coder/cpp
+	cmake --build build/$(CPP_PRESET)
+
+cpp-test: cpp-build
+	ctest --test-dir build/$(CPP_PRESET) --output-on-failure

--- a/hrm_coder/cpp/CMakeLists.txt
+++ b/hrm_coder/cpp/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20)
+project(hrm_coder_cpp LANGUAGES CXX)
+
+add_executable(dummy placeholder.cc)
+
+enable_testing()
+add_test(NAME dummy COMMAND dummy)

--- a/hrm_coder/cpp/placeholder.cc
+++ b/hrm_coder/cpp/placeholder.cc
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 HRM Contributors
+
+/*
+ * Placeholder C++ source for Phase 1 harness scaffolding.
+ *
+ * This file exists to exercise the CMake presets and
+ * integration with build tooling. It will be replaced
+ * with real GoogleTest harnesses in later phases.
+ */
+
+int hrm_placeholder() { return 0; } // NOLINT
+
+int main() { return hrm_placeholder(); }


### PR DESCRIPTION
## Summary
- scaffold minimal C++ project for Phase 1 with placeholder source and CTest integration
- add CMake presets for sanitized, release, and warnings builds
- extend Makefile with cpp-build and cpp-test targets

## Testing
- `pre-commit run --files CMakePresets.json hrm_coder/cpp/CMakeLists.txt hrm_coder/cpp/placeholder.cc Makefile CMakeLists.txt`
- `pytest -q`
- `cmake --preset sanitized`
- `cmake --build build/sanitized`
- `ctest --test-dir build/sanitized`


------
https://chatgpt.com/codex/tasks/task_e_68a06621a2008331be14187d003f8c0d