### PR TITLE
Add I/O judge runner with caching and integrate into C++ sandbox flow

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -54,6 +54,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
     [~] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
     [~] Implement caching layer keyed by prompt+code+tests+limits hash
+    [X] Implement standalone I/O judge with whitespace-normalized diff and caching
     [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
     [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)
 

--- a/runners/__init__.py
+++ b/runners/__init__.py
@@ -1,6 +1,7 @@
 """Sandbox runner adapters for HRM Coder."""
 
 from .gvisor import GVisorRunner
+from .io_judge import run_io_tests
 from .isolate import IsolateRunner
 from .nsjail import NSJailRunner
 from .error_taxonomy import classify_compile, classify_runtime
@@ -11,4 +12,5 @@ __all__ = [
     "NSJailRunner",
     "classify_compile",
     "classify_runtime",
+    "run_io_tests",
 ]

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -19,7 +19,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
 
-from .error_taxonomy import classify_compile, classify_runtime
+from .error_taxonomy import classify_compile
+from .io_judge import run_io_tests
 from .isolate import IsolateRunner, SandboxError
 from .sandbox_cache import SandboxCache
 from utils.diagnostics import compiler_diagnostics
@@ -333,7 +334,6 @@ def run_codeforces_tests(
     compile_status = classify_compile(
         compile_res.success, compile_res.stderr
     )
-    results = []
     if not compile_res.success or compile_res.binary is None:
         data = {
             "compile_stdout": compile_res.stdout,
@@ -341,49 +341,27 @@ def run_codeforces_tests(
             "compile_warnings": compile_res.warnings,
             "compile_errors": compile_res.errors,
             "compile_status": compile_status,
-            "results": results,
+            "results": [],
         }
         if cache is not None and key is not None:
             cache.store(key, data)
         return data
 
-    for input_file in sorted(Path(tests_dir).glob("*.in")):
-        test_name = input_file.stem
-        expected_file = input_file.with_suffix(".out")
-        input_data = input_file.read_text()
-        expected = expected_file.read_text() if expected_file.exists() else ""
-        try:
-            code, stdout, stderr = run_binary(
-                compile_res.binary,
-                input_data=input_data,
-                timeout=timeout,
-                memory_limit=memory_limit,
-                env=env,
-                sandbox=sandbox,
-            )
-            timed_out = False
-        except subprocess.TimeoutExpired:
-            code, stdout, stderr = -1, "", "TIMEOUT"
-            timed_out = True
-        error_type = classify_runtime(code, stderr, timed_out=timed_out)
-        passed = stdout.strip() == expected.strip() and code == 0
-        results.append(
-            {
-                "test": test_name,
-                "passed": passed,
-                "stdout": stdout,
-                "stderr": stderr,
-                "error_type": error_type,
-            }
-        )
-
+    run_res = run_io_tests(
+        compile_res.binary,
+        tests_dir,
+        timeout=timeout,
+        memory_limit=memory_limit,
+        env=env,
+        sandbox=sandbox,
+    )
     data = {
         "compile_stdout": compile_res.stdout,
         "compile_stderr": compile_res.stderr,
         "compile_warnings": compile_res.warnings,
         "compile_errors": compile_res.errors,
         "compile_status": compile_status,
-        "results": results,
+        "results": run_res["results"],
     }
     if cache is not None and key is not None:
         cache.store(key, data)

--- a/runners/io_judge.py
+++ b/runners/io_judge.py
@@ -1,0 +1,106 @@
+"""Run binaries against I/O tests with optional sandbox and caching."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional
+
+from .error_taxonomy import classify_runtime
+from .isolate import IsolateRunner
+from .sandbox_cache import SandboxCache
+
+
+def _run_binary(*args, **kwargs):
+    from .cpp_runner import run_binary  # lazy import
+    return run_binary(*args, **kwargs)
+
+
+def _normalize(text: str) -> str:
+    """Normalize whitespace for output comparison."""
+    return "\n".join(line.rstrip() for line in text.strip().splitlines())
+
+
+def run_io_tests(
+    binary: Path,
+    tests_dir: Path,
+    *,
+    timeout: float = 2.0,
+    memory_limit: Optional[int] = None,
+    env: Optional[Mapping[str, str]] = None,
+    sandbox: Optional[IsolateRunner] = None,
+    cache: Optional[SandboxCache] = None,
+) -> Dict[str, object]:
+    """Run ``binary`` against I/O testcases in ``tests_dir``.
+
+    Parameters
+    ----------
+    binary:
+        Path to the compiled executable to test.
+    tests_dir:
+        Directory containing ``*.in``/``*.out`` file pairs.
+    timeout:
+        Maximum wall-clock time in seconds for each test case.
+    memory_limit:
+        Optional memory limit in bytes.
+    env:
+        Additional environment variables for execution.
+    sandbox:
+        Optional :class:`IsolateRunner` enforcing resource limits.
+    cache:
+        Optional :class:`SandboxCache` to memoize results.
+
+    Returns
+    -------
+    dict
+        Dictionary with a ``results`` key listing per-test outcomes.
+    """
+
+    key: Optional[str] = None
+    if cache is not None:
+        parts: List[bytes] = [binary.read_bytes(), str(timeout).encode()]
+        if memory_limit is not None:
+            parts.append(str(memory_limit).encode())
+        for f in sorted(Path(tests_dir).glob("*")):
+            if f.is_file():
+                parts.append(f.read_bytes())
+        key = cache.hash_parts(parts)
+        cached = cache.load(key)
+        if cached is not None:
+            return cached
+
+    results: List[Dict[str, object]] = []
+    for input_file in sorted(Path(tests_dir).glob("*.in")):
+        test_name = input_file.stem
+        expected_file = input_file.with_suffix(".out")
+        input_data = input_file.read_text()
+        expected = expected_file.read_text() if expected_file.exists() else ""
+        try:
+            code, stdout, stderr = _run_binary(
+                binary,
+                input_data=input_data,
+                timeout=timeout,
+                memory_limit=memory_limit,
+                env=env,
+                sandbox=sandbox,
+            )
+            timed_out = False
+        except subprocess.TimeoutExpired:
+            code, stdout, stderr = -1, "", "TIMEOUT"
+            timed_out = True
+        passed = _normalize(stdout) == _normalize(expected) and code == 0
+        error_type = classify_runtime(code, stderr, timed_out=timed_out)
+        results.append(
+            {
+                "test": test_name,
+                "passed": passed,
+                "stdout": stdout,
+                "stderr": stderr,
+                "error_type": error_type,
+            }
+        )
+
+    data = {"results": results}
+    if cache is not None and key is not None:
+        cache.store(key, data)
+    return data

--- a/tests/test_io_judge.py
+++ b/tests/test_io_judge.py
@@ -1,0 +1,65 @@
+import pathlib
+import pytest
+
+from runners.cpp_runner import compile_cpp_sources
+from runners.io_judge import run_io_tests
+from runners.sandbox_cache import SandboxCache
+
+
+def test_run_io_tests_basic(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        "#include <iostream>\n"
+        "int main(){int a,b; if(!(std::cin>>a>>b)) return 0; "
+        "std::cout<<a+b;}"
+    )
+    res = compile_cpp_sources([src])
+    assert res.success and res.binary is not None
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("1 2\n")
+    (tests_dir / "a.out").write_text("3   \n")
+
+    results = run_io_tests(res.binary, tests_dir)
+    assert results["results"][0]["passed"]
+
+
+def test_run_io_tests_cache(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        "#include <iostream>\n"
+        "int main(){int a,b; if(!(std::cin>>a>>b)) return 0; "
+        "std::cout<<a+b;}"
+    )
+    res = compile_cpp_sources([src])
+    assert res.success and res.binary is not None
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("1 2\n")
+    (tests_dir / "a.out").write_text("3\n")
+
+    cache = SandboxCache(tmp_path / "cache")
+
+    calls = {"run": 0}
+    original_run_binary = run_io_tests.__globals__["_run_binary"]
+
+    def wrapped_run_binary(*args, **kwargs):
+        calls["run"] += 1
+        return original_run_binary(*args, **kwargs)
+
+    monkeypatch.setitem(
+        run_io_tests.__globals__, "_run_binary", wrapped_run_binary
+    )
+
+    first = run_io_tests(
+        res.binary, tests_dir, cache=cache
+    )
+    second = run_io_tests(
+        res.binary, tests_dir, cache=cache
+    )
+    assert first == second
+    assert calls["run"] == 1


### PR DESCRIPTION
## Summary
- Implement standalone `io_judge` module to execute binaries on I/O tests with whitespace-normalized comparisons and optional caching
- Integrate the I/O judge into the C++ runner and export via `runners.__init__`
- Document Phase 4 progress and add unit tests for I/O judging and cache behavior

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md runners/__init__.py runners/cpp_runner.py runners/io_judge.py tests/test_io_judge.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0662c7a348331b436b5a30c507fdc