### PR TITLE
Add static library build support to C++ runner

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -189,6 +189,82 @@ def compile_shared_library(
     )
 
 
+def compile_static_library(
+    sources: Sequence[Path],
+    output: Optional[Path] = None,
+    *,
+    compiler: str = "g++",
+    flags: Optional[Iterable[str]] = None,
+    sanitize: bool = True,
+    use_ccache: bool = False,
+) -> CompileResult:
+    """Compile ``sources`` into a static ``.a`` library.
+
+    This helper builds each source into an object file and archives them
+    together using ``ar``.  It mirrors :func:`compile_shared_library` so that
+    Phase 10 experiments can easily link against lightweight library stubs
+    without relying on dynamic libraries.
+    """
+
+    if flags is None:
+        flags = list(DEFAULT_FLAGS)
+    else:
+        flags = list(flags)
+    if sanitize:
+        flags = list(flags) + SANITIZER_FLAGS
+
+    if output is None:
+        tmp = tempfile.NamedTemporaryFile(suffix=".a", delete=False)
+        output_path = Path(tmp.name)
+        tmp.close()
+    else:
+        output_path = Path(output)
+
+    objs: List[Path] = []
+    stdout_parts: List[str] = []
+    stderr_parts: List[str] = []
+    total_warnings = 0
+    total_errors = 0
+    for src in sources:
+        obj_tmp = tempfile.NamedTemporaryFile(suffix=".o", delete=False)
+        obj_path = Path(obj_tmp.name)
+        obj_tmp.close()
+        cmd: List[str] = [compiler]
+        if use_ccache and shutil.which("ccache") is not None:
+            cmd = ["ccache", compiler]
+        cmd += [str(src), "-c", "-o", str(obj_path)] + list(flags)
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        stdout_parts.append(proc.stdout)
+        stderr_parts.append(proc.stderr)
+        w, e = compiler_diagnostics(proc.stdout, proc.stderr)
+        total_warnings += w
+        total_errors += e
+        if proc.returncode != 0:
+            return CompileResult(
+                False,
+                "".join(stdout_parts),
+                "".join(stderr_parts),
+                None,
+                total_warnings,
+                total_errors,
+            )
+        objs.append(obj_path)
+
+    ar_cmd = ["ar", "rcs", str(output_path)] + [str(o) for o in objs]
+    ar_proc = subprocess.run(ar_cmd, capture_output=True, text=True)
+    stdout_parts.append(ar_proc.stdout)
+    stderr_parts.append(ar_proc.stderr)
+    success = ar_proc.returncode == 0
+    return CompileResult(
+        success,
+        "".join(stdout_parts),
+        "".join(stderr_parts),
+        output_path if success else None,
+        total_warnings,
+        total_errors,
+    )
+
+
 def compile_cpp(
     source: Path,
     output: Optional[Path] = None,

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -14,6 +14,7 @@ import runners.cpp_runner as cpp_runner
 from runners.cpp_runner import (
     compile_cpp_sources,
     compile_shared_library,
+    compile_static_library,
     run_binary,
     run_codeforces_tests,
 )
@@ -112,6 +113,36 @@ int main(){std::cout<<times_two(5);}
     )
     assert code == 0
     assert stdout.strip() == "10"
+
+
+def test_static_library_link(tmp_path: Path) -> None:
+    """Build a static library and link it into a main program."""
+    lib_src = tmp_path / "math.cpp"
+    lib_src.write_text("int add(int a,int b){return a+b;}\n")
+
+    lib_path = tmp_path / "libmath.a"
+    lib_res = compile_static_library([lib_src], output=lib_path)
+    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.binary is not None
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+extern int add(int, int);
+int main(){std::cout<<add(2,3);}
+"""
+    )
+
+    main_res = compile_cpp_sources(
+        [main], library_dirs=[tmp_path], libraries=["math"]
+    )
+    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.binary is not None
+
+    code, stdout, stderr = run_binary(main_res.binary)
+    assert code == 0
+    assert stdout.strip() == "5"
 
 
 def test_static_build(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow building `.a` archives from C++ source files for linking library stubs
- test linking a program against a generated static library

## Testing
- `pytest tests/test_cpp_runner.py::test_static_library_link -q`
- `pytest tests/test_cpp_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0663d4aa483319d87432001b0b7af