### PR TITLE
Add environment probe utility for Phase 0 audit

### DIFF
--- a/scripts/env_probe.py
+++ b/scripts/env_probe.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Report available sandbox and C++ toolchain components.
+
+This Phase 0 helper combines the sandbox and toolchain detectors to
+summarize the host environment.  The output is JSON and can be used to
+quickly assess whether required dependencies are installed before
+running more involved HRM Coder tasks.
+"""
+from __future__ import annotations
+
+import json
+import platform
+from typing import Any, Dict
+
+from pathlib import Path
+import sys
+
+# Ensure repository root is on the module search path so local packages can
+# be imported when this script is executed as a standalone file.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from runners import sandbox_detector, toolchain_detector  # noqa: E402
+
+
+def build_report() -> Dict[str, Any]:
+    """Collect sandbox and toolchain availability information."""
+    return {
+        "python": platform.python_version(),
+        "sandboxes": sandbox_detector.detect_sandboxes(),
+        "toolchains": toolchain_detector.detect_toolchains(),
+    }
+
+
+def main() -> None:
+    print(json.dumps(build_report(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_env_probe.py
+++ b/tests/test_env_probe.py
@@ -1,0 +1,21 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_env_probe_outputs_json(tmp_path):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "env_probe.py"
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo_root,
+    )
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert "sandboxes" in data
+    assert "toolchains" in data
+    assert "python" in data


### PR DESCRIPTION
## Summary
- add `env_probe.py` to report sandbox and compiler availability
- test `env_probe` JSON output for required sections

## Testing
- `pre-commit run --files scripts/env_probe.py tests/test_env_probe.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06aa0e9608331b99f42a6563ac035