### PR TITLE
Add minimal CMake build helper for HRM Coder

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -31,6 +31,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Define Hydra config schema and default configs under conf/
     [?] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [X] Implement environment pinning and seed/tz/locale normalization module
+    [X] Add minimal CMake build helper for C++ harnesses
 
 ** [~] Phase 2: GUI Stub and Backend Skeleton
     [X] Scaffold FastAPI app with /runs, /train, /eval, /logs/ws endpoints

--- a/runners/cpp_build.py
+++ b/runners/cpp_build.py
@@ -1,0 +1,58 @@
+"""Minimal CMake build helpers for Phase 1 scaffolding.
+
+These utilities wrap ``cmake`` and ``ctest`` to compile and execute the
+placeholder C++ harnesses included with the project. They intentionally
+expose only a tiny subset of options required for the early deterministic
+environment work. Later phases will expand the interface with richer
+configuration and diagnostics.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from subprocess import CompletedProcess
+
+
+def configure(
+    source_dir: Path,
+    build_dir: Path,
+    preset: str = "sanitized",
+) -> CompletedProcess:
+    """Run a basic CMake configure step into ``build_dir``.
+
+    Currently only a ``sanitized`` preset is supported which enables
+    AddressSanitizer and UndefinedBehaviorSanitizer for deterministic
+    debugging. The ``preset`` argument is reserved for future expansion.
+    """
+    build_dir.mkdir(parents=True, exist_ok=True)
+    if preset != "sanitized":
+        raise ValueError(f"unsupported preset: {preset}")
+    cmd = [
+        "cmake",
+        "-S",
+        str(source_dir),
+        "-B",
+        str(build_dir),
+        "-G",
+        "Ninja",
+        "-DCMAKE_BUILD_TYPE=Debug",
+        "-DCMAKE_CXX_FLAGS=-O1 -g -fsanitize=address,undefined "
+        "-fno-omit-frame-pointer",
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def build(build_dir: Path) -> CompletedProcess:
+    """Invoke ``cmake --build`` for the given ``build_dir``."""
+    cmd = ["cmake", "--build", str(build_dir)]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def run_tests(build_dir: Path) -> CompletedProcess:
+    """Execute ``ctest`` in ``build_dir`` and return the completed process."""
+    cmd = ["ctest", "--test-dir", str(build_dir)]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+__all__ = ["configure", "build", "run_tests"]

--- a/tests/test_cpp_build.py
+++ b/tests/test_cpp_build.py
@@ -1,0 +1,27 @@
+"""Tests for the minimal CMake build helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from runners.cpp_build import build, configure, run_tests  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "hrm_coder" / "cpp"
+
+
+def test_build_and_test(tmp_path: Path) -> None:
+    """Configure, build, and run the placeholder C++ tests."""
+    build_dir = tmp_path / "build"
+    cfg = configure(SRC_DIR, build_dir)
+    assert cfg.returncode == 0, cfg.stderr
+
+    comp = build(build_dir)
+    assert comp.returncode == 0, comp.stderr
+
+    res = run_tests(build_dir)
+    assert res.returncode == 0, res.stderr


### PR DESCRIPTION
## Summary
- add basic `cpp_build` utility wrapping cmake/ctest for sanitized builds
- test helper by configuring, building, and running placeholder C++ project
- update Phase 1 checklist to reflect new build helper

## Testing
- `pre-commit run --files runners/cpp_build.py tests/test_cpp_build.py docs/hrmCoder_checklist.md`
- `pytest tests/test_cpp_build.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06aa4ce3c8331967896cc5c9c1acf