### PR TITLE
Add coverage summary endpoint and GUI display

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -40,6 +40,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement artifact static server for JUnit XML and lcov/llvm-cov HTML
     [X] Add WebSocket log streamer with tail-follow behavior
     [X] Provide GUI quickstart docs and sample configs
+    [X] Expose coverage summary endpoint and display on run page
 
 ** [ ] Phase 3: Deterministic Dataset Pipeline (C++)
     [~] Implement HumanEval-CPP builder with harness generator and reference solutions

--- a/docs/hrmCoder_gui_quickstart.md
+++ b/docs/hrmCoder_gui_quickstart.md
@@ -28,4 +28,7 @@ curl http://localhost:8000/runs/1/artifacts
 
 # Fetch an artifact file
 curl http://localhost:8000/artifacts/run_1/result.xml
+
+# Get coverage summary
+curl http://localhost:8000/runs/1/coverage
 ```

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 from pathlib import Path
+import json
 import xml.etree.ElementTree as ET
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -111,6 +112,27 @@ def junit_summary(run_id: int) -> Dict[str, int]:
         total_tests, total_failures = _extract(root)
 
     return {"tests": total_tests, "failures": total_failures}
+
+
+@app.get("/runs/{run_id}/coverage")
+def coverage_summary(run_id: int) -> Dict[str, float]:
+    """Return line coverage percentage for a run."""
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    cov_path = ARTIFACT_DIR / f"run_{run_id}" / "coverage.json"
+    if not cov_path.exists():
+        raise HTTPException(status_code=404, detail="coverage not found")
+    try:
+        data = json.loads(cov_path.read_text())
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="invalid coverage")
+    line_cov = data.get("line") or data.get("lines") or data.get("line_percent")
+    try:
+        line_cov = float(line_cov)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="invalid coverage")
+    return {"line": line_cov}
 
 
 class RunUpdate(BaseModel):

--- a/hrm_coder/static/jobs.html
+++ b/hrm_coder/static/jobs.html
@@ -11,6 +11,7 @@
       <tr>
         <th onclick="sortTable(0)">ID</th>
         <th onclick="sortTable(1)">Status</th>
+        <th onclick="sortTable(2)">Coverage</th>
         <th>Artifact</th>
       </tr>
     </thead>
@@ -24,7 +25,15 @@
       tbody.innerHTML = '';
       for (const r of runs) {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td><a href="run.html?id=${r.id}">${r.id}</a></td><td>${r.status}</td><td>${r.artifact ? `<a href="${r.artifact}">link</a>` : ''}</td>`;
+        let cov = '';
+        try {
+          const resp = await fetch(`/runs/${r.id}/coverage`);
+          if (resp.ok) {
+            const data = await resp.json();
+            cov = data.line + '%';
+          }
+        } catch {}
+        tr.innerHTML = `<td><a href="run.html?id=${r.id}">${r.id}</a></td><td>${r.status}</td><td>${cov}</td><td>${r.artifact ? `<a href="${r.artifact}">link</a>` : ''}</td>`;
         tbody.appendChild(tr);
       }
     }

--- a/hrm_coder/static/run.html
+++ b/hrm_coder/static/run.html
@@ -9,6 +9,7 @@
   <div>Status: <span id="status"></span></div>
   <div>Artifact: <span id="artifact"></span></div>
   <div id="junit"></div>
+  <div>Coverage: <span id="coverage"></span></div>
   <pre id="logs"></pre>
   <script>
     const params = new URLSearchParams(window.location.search);
@@ -37,6 +38,14 @@
         `Tests: ${data.tests}, Failures: ${data.failures}`;
     }
     loadJunit();
+
+    async function loadCoverage() {
+      const resp = await fetch(`/runs/${runId}/coverage`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      document.getElementById('coverage').textContent = data.line + '%';
+    }
+    loadCoverage();
 
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const ws = new WebSocket(`${proto}//${location.host}/logs/ws/${runId}`);

--- a/hrm_coder/tests/test_coverage_summary.py
+++ b/hrm_coder/tests/test_coverage_summary.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+from itertools import count
+
+from .. import app
+from ..run_registry import registry
+
+
+def test_coverage_summary_endpoint(tmp_path):
+    registry._runs.clear()
+    registry._log_queues.clear()
+    registry._id_counter = count(1)
+
+    client = TestClient(app)
+    run = client.post('/train', json={}).json()
+    run_id = run['id']
+    artifact_dir = Path('hrm_coder/artifacts') / f'run_{run_id}'
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / 'coverage.json').write_text('{"line": 87.5}')
+
+    resp = client.get(f'/runs/{run_id}/coverage')
+    assert resp.status_code == 200
+    assert resp.json() == {'line': 87.5}
+
+    registry._runs.clear()
+    registry._log_queues.clear()
+    registry._id_counter = count(1)
+


### PR DESCRIPTION
## Summary
- expose new `/runs/{id}/coverage` API endpoint parsing coverage.json for line coverage
- show coverage percentages in run detail and jobs pages
- document API usage and extend checklist; add regression test for coverage summary

## Testing
- `pytest hrm_coder/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06aa72f008331b384486819a49fb1