### PR TITLE
Add AtCoder ABC dataset loader and tests

### DIFF
--- a/dataset/atcoder_abc_loader.py
+++ b/dataset/atcoder_abc_loader.py
@@ -1,0 +1,96 @@
+"""Loader for the AtCoder ABC dataset with schema validation.
+
+This module reads a processed AtCoder ABC dataset directory and returns
+structured objects for each task. It validates the presence of required
+files and uses ``pydantic`` models to enforce the schema. The layout
+matches the output of ``build_atcoder_abc_dataset.py``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+
+class IOPair(BaseModel):
+    """Container for a single input/output example."""
+
+    input: str
+    output: str
+
+
+class AtCoderRecord(BaseModel):
+    """Represents one AtCoder ABC task."""
+
+    task_id: str
+    prompt: str
+    tests: List[IOPair]
+    time_limit_ms: int
+    memory_limit_kb: int
+    split: str
+
+
+def _load_task(task_dir: Path, split: str) -> AtCoderRecord:
+    """Load a single task located at *task_dir*.
+
+    Parameters
+    ----------
+    task_dir:
+        Directory containing ``prompt.txt``, ``tests`` subdirectory and
+        ``meta.json``.
+    split:
+        Name of the dataset split (``train``, ``val`` or ``test``).
+    """
+    prompt_path = task_dir / "prompt.txt"
+    tests_dir = task_dir / "tests"
+    meta_path = task_dir / "meta.json"
+    missing = [
+        p.name
+        for p in [prompt_path, tests_dir, meta_path]
+        if not p.exists()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"Missing required paths in {task_dir}: {', '.join(missing)}"
+        )
+
+    prompt = prompt_path.read_text()
+    meta = json.loads(meta_path.read_text())
+
+    tests: List[IOPair] = []
+    for in_file in sorted(tests_dir.glob("*.in")):
+        out_file = in_file.with_suffix(".out")
+        if not out_file.exists():
+            raise FileNotFoundError(f"Missing expected output file {out_file}")
+        tests.append(
+            IOPair(input=in_file.read_text(), output=out_file.read_text())
+        )
+
+    return AtCoderRecord(
+        task_id=task_dir.name,
+        prompt=prompt,
+        tests=tests,
+        time_limit_ms=meta.get("time_limit_ms", 2000),
+        memory_limit_kb=meta.get("memory_limit_kb", 102400),
+        split=split,
+    )
+
+
+def load_dataset(root: str | Path) -> Dict[str, List[AtCoderRecord]]:
+    """Load all tasks from a processed AtCoder ABC dataset."""
+    root_path = Path(root)
+    splits: Dict[str, List[AtCoderRecord]] = {
+        "train": [],
+        "val": [],
+        "test": [],
+    }
+    for split in splits:
+        split_dir = root_path / split
+        if not split_dir.exists():
+            continue
+        for task_dir in sorted(p for p in split_dir.iterdir() if p.is_dir()):
+            record = _load_task(task_dir, split)
+            splits[split].append(record)
+    return splits

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -47,8 +47,8 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement AtCoder ABC subset builder with normalized input/output cases
     [X] Write determinism validator to re-run and hash equality of artifacts
     [ ] Integrate DVC pipelines and data/versions.yml locking
-    [~] Add dataset schema contracts and unit tests for loaders
-    [~] Implement dataset split manager for train/val/test with fixed seeds
+    [X] Add dataset schema contracts and unit tests for loaders
+    [X] Implement dataset split manager for train/val/test with fixed seeds
 
 ** [ ] Phase 4: Sandbox Executor
     [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies

--- a/tests/test_atcoder_abc_loader.py
+++ b/tests/test_atcoder_abc_loader.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure repository root is on import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.build_atcoder_abc_dataset import build_dataset  # noqa: E402
+from dataset.atcoder_abc_loader import (  # noqa: E402
+    AtCoderRecord,
+    load_dataset,
+)
+
+
+def _write_sample_dataset(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "abc001",
+            "prompt": "Echo input",
+            "tests": [{"input": "42\n", "output": "42\n"}],
+            "time_limit_ms": 2000,
+            "memory_limit_kb": 65536,
+        },
+        {
+            "task_id": "abc002",
+            "prompt": "Add numbers",
+            "tests": [{"input": "1 2\n", "output": "3\n"}],
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_loader_round_trip(tmp_path: Path) -> None:
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    splits = load_dataset(out_dir)
+    assert set(splits.keys()) == {"train", "val", "test"}
+    all_tasks = [t for tasks in splits.values() for t in tasks]
+    assert len(all_tasks) == 2
+    first = next(t for t in all_tasks if t.task_id == "abc001")
+    assert isinstance(first, AtCoderRecord)
+    assert first.tests[0].output.strip() == "42"
+
+
+def test_loader_missing_meta(tmp_path: Path) -> None:
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    # remove meta.json from one task to trigger error
+    task_dir = next((out_dir / "train").iterdir())
+    (task_dir / "meta.json").unlink()
+    with pytest.raises(FileNotFoundError):
+        load_dataset(out_dir)

--- a/tests/test_split_manager.py
+++ b/tests/test_split_manager.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.split_manager import split_list  # noqa: E402
+
+
+def test_split_deterministic() -> None:
+    items = list(range(10))
+    splits_a = split_list(items, seed=123)
+    splits_b = split_list(items, seed=123)
+    assert splits_a == splits_b
+    assert sum(len(v) for v in splits_a.values()) == len(items)


### PR DESCRIPTION
## Summary
- add loader for processed AtCoder ABC datasets with schema validation
- cover loader and deterministic split manager with unit tests
- update checklist to mark dataset schema contracts and split manager complete

## Testing
- `pytest tests/test_atcoder_abc_loader.py tests/test_split_manager.py -q`
- `pre-commit run --files dataset/atcoder_abc_loader.py tests/test_atcoder_abc_loader.py tests/test_split_manager.py docs/hrmCoder_checklist.md`


------
https://chatgpt.com/codex/tasks/task_e_68a06aa9eaa483319076ca3e4eb16bcf