### PR TITLE
Add gcov coverage collection to C++ sandbox runner

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -303,6 +303,7 @@ def run_binary(
     memory_limit: Optional[int] = None,
     env: Optional[Mapping[str, str]] = None,
     sandbox: Optional[IsolateRunner] = None,
+    cwd: Optional[Path] = None,
 ) -> Tuple[int, str, str]:
     """Execute a compiled ``binary`` with optional limits and environment.
 
@@ -326,18 +327,35 @@ def run_binary(
     sandbox:
         Optional :class:`~runners.isolate.IsolateRunner` used to enforce
         resource limits and disable networking.
+    cwd:
+        Working directory for execution. Defaults to the directory of
+        ``binary`` so that coverage artifacts are written alongside the
+        executable.
     """
+
+    if cwd is None:
+        cwd = binary.parent
 
     if sandbox is not None:
         memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
         try:
-            proc = sandbox.run(
-                [str(binary)],
-                time_limit=int(timeout),
-                wall_time=int(timeout),
-                memory=memory_kb,
-                stdin=input_data,
-            )
+            try:
+                proc = sandbox.run(
+                    [str(binary)],
+                    time_limit=int(timeout),
+                    wall_time=int(timeout),
+                    memory=memory_kb,
+                    stdin=input_data,
+                    workdir=str(cwd),
+                )
+            except TypeError:
+                proc = sandbox.run(
+                    [str(binary)],
+                    time_limit=int(timeout),
+                    wall_time=int(timeout),
+                    memory=memory_kb,
+                    stdin=input_data,
+                )
         except SandboxError as exc:
             return -1, "", str(exc)
         return proc.returncode, proc.stdout, proc.stderr
@@ -353,8 +371,52 @@ def run_binary(
         timeout=timeout,
         preexec_fn=preexec,
         env={**os.environ, **env} if env is not None else None,
+        cwd=str(cwd),
     )
     return proc.returncode, proc.stdout, proc.stderr
+
+
+def _parse_gcov_file(path: Path) -> float:
+    """Return line coverage ratio from a ``gcov`` report file."""
+    executed = 0
+    total = 0
+    for line in path.read_text().splitlines():
+        parts = line.split(":", 2)
+        if len(parts) < 2:
+            continue
+        count = parts[0].strip()
+        if count in ("-", "====="):
+            continue
+        if count == "#####":
+            total += 1
+            continue
+        try:
+            num = int(count)
+        except ValueError:
+            continue
+        total += 1
+        if num > 0:
+            executed += 1
+    return executed / total if total else 0.0
+
+
+def _collect_coverage(sources: Sequence[Path], workdir: Path) -> float:
+    """Run ``gcov`` on ``sources`` in ``workdir`` and average coverage."""
+    if shutil.which("gcov") is None:
+        return 0.0
+    covs: List[float] = []
+    for src in sources:
+        subprocess.run(
+            ["gcov", str(src), "-o", str(workdir)],
+            capture_output=True,
+            text=True,
+            cwd=str(workdir),
+            check=False,
+        )
+        gcov_file = workdir / f"{src.name}.gcov"
+        if gcov_file.exists():
+            covs.append(_parse_gcov_file(gcov_file))
+    return sum(covs) / len(covs) if covs else 0.0
 
 
 def run_codeforces_tests(
@@ -374,12 +436,15 @@ def run_codeforces_tests(
     env: Optional[Mapping[str, str]] = None,
     sandbox: Optional[IsolateRunner] = None,
     cache: Optional[SandboxCache] = None,
+    collect_coverage: bool = False,
 ) -> dict:
     """Compile ``sources`` and run them against all tests in ``tests_dir``.
 
     The directory is expected to contain pairs of ``*.in`` and ``*.out`` files.
     Results include compilation diagnostics and a list of per-test outcomes
-    with error classifications.
+    with error classifications.  When ``collect_coverage`` is ``True`` the
+    program is instrumented with ``--coverage`` and ``gcov`` is used to compute
+    a line coverage ratio.
     """
 
     key: Optional[str] = None
@@ -391,15 +456,20 @@ def run_codeforces_tests(
         parts.append(str(timeout).encode())
         if memory_limit is not None:
             parts.append(str(memory_limit).encode())
+        if collect_coverage:
+            parts.append(b"coverage")
         key = cache.hash_parts(parts)
         cached = cache.load(key)
         if cached is not None:
             return cached
 
+    compile_flags = list(flags) if flags is not None else list(DEFAULT_FLAGS)
+    if collect_coverage:
+        compile_flags.append("--coverage")
     compile_res = compile_cpp_sources(
         sources,
         compiler=compiler,
-        flags=flags,
+        flags=compile_flags,
         sanitize=sanitize,
         static=static,
         library_dirs=library_dirs,
@@ -431,6 +501,9 @@ def run_codeforces_tests(
         env=env,
         sandbox=sandbox,
     )
+    coverage_ratio = 0.0
+    if collect_coverage:
+        coverage_ratio = _collect_coverage(sources, compile_res.binary.parent)
     data = {
         "compile_stdout": compile_res.stdout,
         "compile_stderr": compile_res.stderr,
@@ -439,6 +512,8 @@ def run_codeforces_tests(
         "compile_status": compile_status,
         "results": run_res["results"],
     }
+    if collect_coverage:
+        data["coverage"] = coverage_ratio
     if cache is not None and key is not None:
         cache.store(key, data)
     return data

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,24 +1,21 @@
 from pathlib import Path
-
-from pathlib import Path
-import pathlib
 import re
 import subprocess
 import sys
 
-import pytest
+import pytest  # noqa: F401
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import runners.cpp_runner as cpp_runner
-from runners.cpp_runner import (
+import runners.cpp_runner as cpp_runner  # noqa: E402
+from runners.cpp_runner import (  # noqa: E402
     compile_cpp_sources,
     compile_shared_library,
     compile_static_library,
     run_binary,
     run_codeforces_tests,
 )
-from runners.sandbox_cache import SandboxCache
+from runners.sandbox_cache import SandboxCache  # noqa: E402
 
 
 def test_compile_multi_file(tmp_path: Path) -> None:
@@ -53,7 +50,9 @@ def test_shared_library_link(tmp_path: Path) -> None:
 
     lib_path = tmp_path / "libdouble.so"
     lib_res = compile_shared_library([lib_src], output=lib_path)
-    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.success, (
+        f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    )
     assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
@@ -71,7 +70,9 @@ int main(){std::cout<<times_two(5);}
         libraries=["double"],
         rpath=[tmp_path],
     )
-    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.success, (
+        f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    )
     assert main_res.binary is not None
 
     code, stdout, stderr = run_binary(main_res.binary)
@@ -88,7 +89,9 @@ def test_shared_library_env_link(tmp_path: Path) -> None:
 
     lib_path = tmp_path / "libdouble.so"
     lib_res = compile_shared_library([lib_src], output=lib_path)
-    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.success, (
+        f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    )
     assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
@@ -105,7 +108,9 @@ int main(){std::cout<<times_two(5);}
         library_dirs=[tmp_path],
         libraries=["double"],
     )
-    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.success, (
+        f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    )
     assert main_res.binary is not None
 
     code, stdout, stderr = run_binary(
@@ -122,7 +127,9 @@ def test_static_library_link(tmp_path: Path) -> None:
 
     lib_path = tmp_path / "libmath.a"
     lib_res = compile_static_library([lib_src], output=lib_path)
-    assert lib_res.success, f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    assert lib_res.success, (
+        f"lib compile failed: {lib_res.stdout}\n{lib_res.stderr}"
+    )
     assert lib_res.binary is not None
 
     main = tmp_path / "main.cpp"
@@ -137,7 +144,9 @@ int main(){std::cout<<add(2,3);}
     main_res = compile_cpp_sources(
         [main], library_dirs=[tmp_path], libraries=["math"]
     )
-    assert main_res.success, f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    assert main_res.success, (
+        f"compile failed: {main_res.stdout}\n{main_res.stderr}"
+    )
     assert main_res.binary is not None
 
     code, stdout, stderr = run_binary(main_res.binary)
@@ -154,7 +163,9 @@ def test_static_build(tmp_path: Path) -> None:
     assert res.success, f"compile failed: {res.stdout}\n{res.stderr}"
     assert res.binary is not None
 
-    ldd = subprocess.run(["ldd", str(res.binary)], capture_output=True, text=True)
+    ldd = subprocess.run(
+        ["ldd", str(res.binary)], capture_output=True, text=True
+    )
     assert "not a dynamic executable" in (ldd.stdout + ldd.stderr)
 
 
@@ -203,7 +214,7 @@ class SpyRunner:
 def test_run_codeforces_tests_cache(tmp_path: Path, monkeypatch):
     src = tmp_path / "main.cpp"
     src.write_text(
-        "#include <iostream>\nint main(){int a,b; if(!(std::cin>>a>>b)) return 0; std::cout<<a+b;}"
+        "#include <iostream>\nint main(){int a,b; if(!(std::cin>>a>>b)) return 0; std::cout<<a+b;}"  # noqa: E501
     )
     tests_dir = tmp_path / "tests"
     tests_dir.mkdir()
@@ -229,3 +240,24 @@ def test_run_codeforces_tests_cache(tmp_path: Path, monkeypatch):
     assert calls["compile"] == 1
     assert spy.calls == 1
     assert first == second
+
+
+def test_run_codeforces_tests_coverage(tmp_path: Path) -> None:
+    """Ensure coverage metrics are returned when requested."""
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        """
+#include <iostream>
+int main(){int x; if(!(std::cin>>x)) return 0;
+if(x>0) std::cout<<1; else std::cout<<0;}
+"""  # noqa: E501
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("1\n")
+    (tests_dir / "a.out").write_text("1\n")
+
+    res = run_codeforces_tests([src], tests_dir, collect_coverage=True)
+    assert "coverage" in res
+    assert 0.0 <= res["coverage"] <= 1.0
+    assert res["coverage"] < 1.0


### PR DESCRIPTION
## Summary
- support running binaries from their own directory to emit coverage data
- add gcov-based coverage collection and optional flag in run_codeforces_tests
- test coverage reporting in Codeforces-style runs

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py`
- `pytest tests/test_cpp_runner.py tests/test_io_judge.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06aac36b88331a55321d96276fc42