### PR TITLE
Integrate JUnit parsing into reward pipeline

### DIFF
--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import Dict, List
 from pathlib import Path
-import xml.etree.ElementTree as ET
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+
+from utils.junit import parse_junit_summary
 
 from .run_registry import registry, Run
 
@@ -91,26 +92,10 @@ def junit_summary(run_id: int) -> Dict[str, int]:
     if not junit_path.exists():
         raise HTTPException(status_code=404, detail="junit not found")
     try:
-        root = ET.parse(junit_path).getroot()
-    except ET.ParseError:
+        passed, total = parse_junit_summary(junit_path.read_text())
+    except ValueError:
         raise HTTPException(status_code=400, detail="invalid junit")
-
-    def _extract(node: ET.Element) -> tuple[int, int]:
-        tests = int(node.attrib.get("tests", 0))
-        failures = int(node.attrib.get("failures", 0))
-        errors = int(node.attrib.get("errors", 0))
-        return tests, failures + errors
-
-    if root.tag == "testsuites":
-        total_tests = total_failures = 0
-        for child in root.findall("testsuite"):
-            t, f = _extract(child)
-            total_tests += t
-            total_failures += f
-    else:
-        total_tests, total_failures = _extract(root)
-
-    return {"tests": total_tests, "failures": total_failures}
+    return {"tests": total, "failures": total - passed}
 
 
 class RunUpdate(BaseModel):

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -1,0 +1,25 @@
+import pytest
+
+from utils.junit import parse_junit_summary
+
+
+def test_parse_single_testsuite():
+    xml = '<testsuite tests="3" failures="1" errors="0"></testsuite>'
+    passed, total = parse_junit_summary(xml)
+    assert (passed, total) == (2, 3)
+
+
+def test_parse_testsuites():
+    xml = (
+        '<testsuites>'
+        '<testsuite tests="2" failures="1" />'
+        '<testsuite tests="1" errors="1" />'
+        '</testsuites>'
+    )
+    passed, total = parse_junit_summary(xml)
+    assert (passed, total) == (1, 3)
+
+
+def test_invalid_xml():
+    with pytest.raises(ValueError):
+        parse_junit_summary('<notxml>')

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -189,6 +189,34 @@ def test_compile_diagnostics_penalty():
     assert abs(r - manual) < 1e-6
 
 
+def test_compute_from_outputs_uses_junit():
+    agg = RewardAggregator(
+        weights={'compile': 0.1, 'tests': 0.2},
+        max_edit_penalty=0.0,
+        max_time_penalty=0.0,
+        max_memory_penalty=0.0,
+    )
+    junit = '<testsuite tests="2" failures="1"></testsuite>'
+    r = agg.compute_from_outputs(
+        compile_success=True,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        junit_xml=junit,
+    )
+    manual = agg.compute(
+        compile_success=True,
+        tests_passed=1,
+        tests_total=2,
+        coverage=0.0,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+    )
+    assert abs(r - manual) < 1e-6
+
+
 def test_sanitizer_bonus_and_penalty():
     agg = RewardAggregator(
         weights={'compile': 0.1, 'tests': 0.2, 'sanitizer': 0.1},

--- a/utils/junit.py
+++ b/utils/junit.py
@@ -1,0 +1,55 @@
+"""JUnit XML parsing helpers.
+
+This module provides lightweight utilities to extract test
+statistics from JUnit formatted XML strings.  The intent is to
+support Phase 5 of the project where per-test rewards are derived
+from unit-test results.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+import xml.etree.ElementTree as ET
+
+
+def parse_junit_summary(xml: str) -> Tuple[int, int]:
+    """Return the number of passed tests and total tests.
+
+    Parameters
+    ----------
+    xml:
+        String containing a JUnit ``<testsuite>`` or ``<testsuites>``
+        document.
+
+    Returns
+    -------
+    Tuple[int, int]
+        A pair ``(passed, total)`` with the count of tests that passed
+        and the total number of tests executed.
+
+    Raises
+    ------
+    ValueError
+        If ``xml`` cannot be parsed as JUnit XML.
+    """
+    try:
+        root = ET.fromstring(xml)
+    except ET.ParseError as exc:
+        raise ValueError("invalid junit xml") from exc
+
+    def _extract(node: ET.Element) -> Tuple[int, int]:
+        tests = int(node.attrib.get("tests", 0))
+        failures = int(node.attrib.get("failures", 0))
+        errors = int(node.attrib.get("errors", 0))
+        return tests - (failures + errors), tests
+
+    if root.tag == "testsuites":
+        passed = total = 0
+        for suite in root.findall("testsuite"):
+            p, t = _extract(suite)
+            passed += p
+            total += t
+        return passed, total
+
+    passed, total = _extract(root)
+    return passed, total

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -10,6 +10,7 @@ from .diagnostics import (
     diagnostics_score,
     sanitizer_clean,
 )
+from .junit import parse_junit_summary
 
 
 @dataclass
@@ -140,12 +141,13 @@ class RewardAggregator:
     def compute_from_outputs(
         self,
         compile_success: bool,
-        tests_passed: int,
-        tests_total: int,
         coverage: float,
         edit_cost: float,
         time_used: float,
         memory_used: float,
+        tests_passed: int | None = None,
+        tests_total: int | None = None,
+        junit_xml: str | None = None,
         clang_output: str = "",
         compiler_stdout: str = "",
         compiler_stderr: str = "",
@@ -163,6 +165,9 @@ class RewardAggregator:
 
         Parameters
         ----------
+        junit_xml:
+            Optional JUnit XML string used to derive ``tests_passed`` and
+            ``tests_total`` when these are not supplied explicitly.
         clang_output:
             Raw stderr/stdout from clang-tidy.
         compiler_stdout:
@@ -190,6 +195,10 @@ class RewardAggregator:
             if sanitizer_output is not None
             else None
         )
+        if junit_xml is not None:
+            tests_passed, tests_total = parse_junit_summary(junit_xml)
+        if tests_passed is None or tests_total is None:
+            raise ValueError("tests_passed/tests_total or junit_xml required")
         return self.compute(
             compile_success=compile_success,
             tests_passed=tests_passed,


### PR DESCRIPTION
## Summary
- add reusable JUnit XML parser for extracting passed/total test counts
- allow RewardAggregator to derive test metrics from JUnit and update API to use parser
- cover JUnit utilities and aggregator path with new tests

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06aaee2488331a6cceca885da5b3b