### PR TITLE
Add checkpointing to Phase 6 training demo

### DIFF
--- a/hrm/training_loop.py
+++ b/hrm/training_loop.py
@@ -9,7 +9,7 @@ complete but to provide a concrete starting point that unblocks Phase 6
 development.
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Callable, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -47,6 +47,35 @@ class HRMTrainer:
         self.model = model
         self.optimizer = optimizer
         self.config = config or HRMTrainingConfig()
+
+    # ------------------------------------------------------------------
+    # Checkpointing
+    # ------------------------------------------------------------------
+    def save_checkpoint(self, path: str) -> None:
+        """Serialise ``model`` and ``optimizer`` state to ``path``.
+
+        The configuration is stored alongside the state dictionaries so a
+        resumed run can continue with identical hyper‑parameters.
+        """
+
+        state = {
+            "model": self.model.state_dict(),
+            "optimizer": self.optimizer.state_dict(),
+            "config": asdict(self.config),
+        }
+        torch.save(state, path)
+
+    def load_checkpoint(
+        self, path: str, map_location: Optional[str] = None
+    ) -> None:
+        """Restore ``model`` and ``optimizer`` state from ``path``."""
+
+        checkpoint = torch.load(path, map_location=map_location)
+        self.model.load_state_dict(checkpoint["model"])
+        self.optimizer.load_state_dict(checkpoint["optimizer"])
+        cfg_dict = checkpoint.get("config")
+        if cfg_dict is not None:
+            self.config = HRMTrainingConfig(**cfg_dict)
 
     # ------------------------------------------------------------------
     # Curriculum handling

--- a/hrm_coder/tests/test_train_script.py
+++ b/hrm_coder/tests/test_train_script.py
@@ -2,10 +2,37 @@ import subprocess
 import sys
 
 
-def test_train_module_runs():
-    """Ensure the training entry point executes end-to-end."""
+def test_train_module_runs(tmp_path):
+    """Ensure the training entry point executes end-to-end and checkpoints."""
+    ckpt = tmp_path / "ckpt.pt"
     result = subprocess.run(
-        [sys.executable, "-m", "hrm_coder.train"], capture_output=True, text=True, check=True
+        [
+            sys.executable,
+            "-m",
+            "hrm_coder.train",
+            "--checkpoint",
+            str(ckpt),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
     )
     assert "avg_loss=" in result.stdout
-    assert "reinforce:" in result.stdout
+    assert "Checkpoint written" in result.stdout
+    assert ckpt.exists()
+
+    # Resume to exercise load path
+    result2 = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hrm_coder.train",
+            "--checkpoint",
+            str(ckpt),
+            "--resume",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Resumed from" in result2.stdout

--- a/hrm_coder/train.py
+++ b/hrm_coder/train.py
@@ -10,6 +10,7 @@ CI can run it within tight runtime budgets.
 
 from dataclasses import asdict
 import argparse
+import os
 from pprint import pformat
 
 import torch
@@ -42,6 +43,17 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--seed", type=int, default=0, help="PRNG seed")
     parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default=None,
+        help="Path to save/load a checkpoint",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from --checkpoint if it exists",
+    )
+    parser.add_argument(
         "overrides",
         nargs="*",
         help="Hydra-style overrides, e.g. model.learning_rate=1e-4",
@@ -60,12 +72,18 @@ def main() -> None:
     inputs = torch.eye(vocab)[:5]
     targets = torch.arange(5) % vocab
     dataset = TensorDataset(inputs, targets)
-    loader = DataLoader(dataset, batch_size=1, shuffle=True)
+    g = torch.Generator()
+    g.manual_seed(args.seed)
+    loader = DataLoader(dataset, batch_size=1, shuffle=True, generator=g)
 
     # Initialise model and trainer.
     model = TinyModel(vocab)
     opt = torch.optim.SGD(model.parameters(), lr=cfg.model.learning_rate)
     trainer = HRMTrainer(model, opt, HRMTrainingConfig())
+
+    if args.resume and args.checkpoint and os.path.exists(args.checkpoint):
+        trainer.load_checkpoint(args.checkpoint, map_location="cpu")
+        print(f"Resumed from {args.checkpoint}")
 
     # --- Supervised fine-tuning ---------------------------------------
     avg_loss = trainer.sft_epoch(loader)
@@ -74,18 +92,31 @@ def main() -> None:
     # --- Reinforcement learning ---------------------------------------
     def reward_fn_factory(target: torch.Tensor):
         def reward_fn(actions: torch.Tensor) -> torch.Tensor:
-            return torch.where(actions == target, torch.tensor(1.0), torch.tensor(0.0))
+            return torch.where(
+                actions == target, torch.tensor(1.0), torch.tensor(0.0)
+            )
 
         return reward_fn
 
-    rl_stats = {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "reward": 0.0}
+    rl_stats = {
+        "policy_loss": 0.0,
+        "value_loss": 0.0,
+        "entropy": 0.0,
+        "reward": 0.0,
+    }
     for inp, target in dataset:
-        stats = trainer.reinforce_step(inp.unsqueeze(0), reward_fn_factory(target))
+        stats = trainer.reinforce_step(
+            inp.unsqueeze(0), reward_fn_factory(target)
+        )
         for k, v in stats.items():
             rl_stats[k] += v
     for k in rl_stats:
         rl_stats[k] /= len(dataset)
     print("reinforce:", " ".join(f"{k}={v:.4f}" for k, v in rl_stats.items()))
+
+    if args.checkpoint:
+        trainer.save_checkpoint(args.checkpoint)
+        print(f"Checkpoint written to {args.checkpoint}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- support saving and loading checkpoints in HRMTrainer
- allow train script to resume from checkpoints with deterministic dataloader
- test training CLI end-to-end with checkpoint resume

## Testing
- `pre-commit run --files hrm/training_loop.py hrm_coder/train.py hrm_coder/tests/test_train_script.py`
- `pytest hrm_coder/tests/test_train_script.py -q`
- `pytest hrm_coder/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a06ab0b7e88331b569a7217a04f371