### PR TITLE
feat: bundle evaluation artifacts

### DIFF
--- a/hrm_coder/artifacts/bundle.py
+++ b/hrm_coder/artifacts/bundle.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Utility helpers for bundling and uploading evaluation artifacts."""
+
+from pathlib import Path
+from typing import Sequence
+import tarfile
+import shutil
+
+
+def bundle_artifacts(files: Sequence[str], bundle_path: str) -> str:
+    """Create a gzipped tarball containing the given files.
+
+    Parameters
+    ----------
+    files:
+        Iterable of file paths to include in the archive. Non-existent
+        paths are ignored.
+    bundle_path:
+        Destination path for the ``.tar.gz`` archive.
+
+    Returns
+    -------
+    str
+        The path to the created bundle.
+    """
+
+    bundle = Path(bundle_path)
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(bundle, "w:gz") as tar:
+        for f in files:
+            p = Path(f)
+            if p.exists():
+                tar.add(p, arcname=p.name)
+    return str(bundle)
+
+
+def upload_bundle(bundle_path: str, destination_dir: str) -> str:
+    """Copy a bundle to a destination directory.
+
+    This is a light-weight stand-in for uploading artifacts to remote
+    storage.  It simply copies ``bundle_path`` into ``destination_dir`` and
+    returns the path to the copied file.
+    """
+
+    bundle = Path(bundle_path)
+    dest_dir = Path(destination_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / bundle.name
+    shutil.copy2(bundle, dest)
+    return str(dest)

--- a/hrm_coder/evaluation.py
+++ b/hrm_coder/evaluation.py
@@ -15,6 +15,8 @@ import argparse
 from pathlib import Path
 from typing import Dict, Sequence, List, Optional
 
+from .artifacts.bundle import bundle_artifacts, upload_bundle
+
 
 @dataclass
 class TaskEvaluation:
@@ -279,6 +281,8 @@ def generate_reports(
     run_paths: Sequence[str] | None = None,
     baseline_path: str | None = None,
     incident_paths: Sequence[str] | None = None,
+    bundle_path: str | None = None,
+    upload_dir: str | None = None,
 ) -> Dict[int, float]:
     """Compute metrics and emit Markdown/HTML reports.
 
@@ -299,6 +303,14 @@ def generate_reports(
     incident_paths:
         Optional JSON files mapping task id → status string, used to
         compute incident rates such as timeouts and sanitizer failures.
+    bundle_path:
+        Optional path for a bundled ``.tar.gz`` archive containing the
+        generated reports and raw JSON. If ``None`` the bundle is skipped
+        unless ``upload_dir`` is provided.
+    upload_dir:
+        Optional destination directory to copy the bundle to. If
+        provided, a bundle will be created even when ``bundle_path`` is
+        ``None``.
 
     Returns
     -------
@@ -326,12 +338,21 @@ def generate_reports(
 
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Persist raw results and aggregated metrics for bundling
+    (out_dir / "results.json").write_text(json.dumps(results))
+    (out_dir / "metrics.json").write_text(
+        json.dumps({str(k): v for k, v in metrics.items()})
+    )
+
     (out_dir / "report.md").write_text(
         markdown_report(metrics, flaky, incidents)
     )
     (out_dir / "report.html").write_text(
         html_report(metrics, flaky, incidents)
     )
+
+    bundle_file: str | None = None
 
     if baseline_path is not None:
         named_metrics = {f"pass@{k}": v for k, v in metrics.items()}
@@ -342,6 +363,22 @@ def generate_reports(
         (out_dir / "baseline.html").write_text(
             comparison_html_report(comparison)
         )
+
+    if bundle_path is not None or upload_dir is not None:
+        bundle_file = bundle_path or str(out_dir / "artifacts.tar.gz")
+        files = [
+            out_dir / "report.md",
+            out_dir / "report.html",
+            out_dir / "results.json",
+            out_dir / "metrics.json",
+        ]
+        if baseline_path is not None:
+            files.extend(
+                [out_dir / "baseline.md", out_dir / "baseline.html"]
+            )
+        bundle_artifacts([str(f) for f in files], bundle_file)
+        if upload_dir is not None:
+            upload_bundle(bundle_file, upload_dir)
 
     return metrics
 
@@ -381,6 +418,16 @@ def main() -> None:  # pragma: no cover - CLI entry point
         default=None,
         help="JSON files of run status strings for incident rate computation",
     )
+    parser.add_argument(
+        "--bundle",
+        default=None,
+        help="Path to write a bundled tar.gz of reports and JSON",
+    )
+    parser.add_argument(
+        "--upload",
+        default=None,
+        help="Directory to copy the bundle to (artifact upload)",
+    )
     args = parser.parse_args()
     generate_reports(
         results_path=args.results,
@@ -389,6 +436,8 @@ def main() -> None:  # pragma: no cover - CLI entry point
         run_paths=args.runs,
         baseline_path=args.baseline,
         incident_paths=args.incidents,
+        bundle_path=args.bundle,
+        upload_dir=args.upload,
     )
 
 

--- a/hrm_coder/tests/test_evaluation.py
+++ b/hrm_coder/tests/test_evaluation.py
@@ -97,6 +97,9 @@ def test_generate_reports(tmp_path):
     baseline_file = tmp_path / "baseline.json"
     baseline_file.write_text(json.dumps({"pass@1": 0.0, "pass@2": 0.0}))
 
+    bundle_path = tmp_path / "bundle.tar.gz"
+    upload_dir = tmp_path / "uploaded"
+
     metrics = generate_reports(
         results_path=str(results_file),
         output_dir=str(tmp_path),
@@ -104,6 +107,8 @@ def test_generate_reports(tmp_path):
         run_paths=[str(run1_file), str(run2_file)],
         baseline_path=str(baseline_file),
         incident_paths=[str(incident1_file), str(incident2_file)],
+        bundle_path=str(bundle_path),
+        upload_dir=str(upload_dir),
     )
 
     assert metrics[1] == pytest.approx(0.25)
@@ -113,3 +118,12 @@ def test_generate_reports(tmp_path):
     assert (tmp_path / "report.html").exists()
     assert (tmp_path / "baseline.md").exists()
     assert (tmp_path / "baseline.html").exists()
+    assert bundle_path.exists()
+    assert (upload_dir / "bundle.tar.gz").exists()
+
+    import tarfile
+
+    with tarfile.open(bundle_path, "r:gz") as tar:
+        names = tar.getnames()
+        assert "report.md" in names
+        assert "results.json" in names


### PR DESCRIPTION
## Summary
- bundle evaluation reports and raw metrics into a tarball
- add optional upload of bundled artifacts and CLI flags
- save raw results/metrics for inclusion in reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06ab2ed688331bb88e8351b50ddeb