### PR TITLE
feat: add report publisher for gh-pages

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -90,7 +90,7 @@ Save new code files in: C:\repos\hrm-coder
     [?] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [~] Create nightly full evaluation job with retention and tagging
     [X] Implement version stamping (git SHA, Docker digest, seeds) in runs
-    [ ] Configure GitHub Pages publish for latest report artifacts
+    [~] Configure GitHub Pages publish for latest report artifacts
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)

--- a/scripts/publish_reports.py
+++ b/scripts/publish_reports.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Utility to copy report artifacts into a GitHub Pages directory.
+
+This script helps Phase 8 (CI/CD and Automation) by preparing the
+latest evaluation reports for publication via GitHub Pages. It copies
+all files from a source directory into a destination directory and
+generates a simple ``index.html`` listing the contained artifacts.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import shutil
+from pathlib import Path
+
+
+def build_index(dest: Path) -> None:
+    """Generate a basic ``index.html`` with links to files in ``dest``."""
+    lines = ["<html><body><h1>HRM Reports</h1><ul>"]
+    for path in sorted(p for p in dest.rglob("*") if p.is_file()):
+        rel = path.relative_to(dest).as_posix()
+        lines.append(f'<li><a href="{html.escape(rel)}">{html.escape(rel)}</a></li>')
+    lines.append("</ul></body></html>")
+    (dest / "index.html").write_text("\n".join(lines))
+
+
+def publish(source: Path, dest: Path) -> None:
+    """Copy ``source`` directory tree into ``dest`` and create an index."""
+    if not source.exists():
+        raise FileNotFoundError(f"Source directory {source} does not exist")
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(source, dest)
+    build_index(dest)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="Path to report artifacts")
+    parser.add_argument("dest", type=Path, help="Destination directory for Pages")
+    args = parser.parse_args()
+    publish(args.source, args.dest)
+    print(f"Published reports from {args.source} to {args.dest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utility to publish evaluation reports to GitHub Pages
- mark Phase 8 checklist item as in progress

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06ab53194833180a283163da4760d