### PR TITLE
feat: add scored AST cursor policy

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -97,7 +97,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Integrate Tree-sitter C++ grammar and bindings
     [X] Implement node type schema and AST embedding encoder for C++
     [X] Define edit action space for insert, replace, and delete operations
-    [~] Implement cursor policy module for region selection by HRM high-level
+    [?] Implement cursor policy module for region selection by HRM high-level
     [X] Implement decoder constraint checker to avoid invalid AST states
     [ ] Add ablation job configs and comparison report against token baseline
 

--- a/tests/test_ast_cursor.py
+++ b/tests/test_ast_cursor.py
@@ -1,13 +1,18 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from utils.ast_edit import CppAst
-from utils.ast_cursor import CursorPolicy, find_node_by_type
+
+import pytest  # noqa: E402
+from utils.ast_edit import CppAst  # noqa: E402
+from utils.ast_cursor import (  # noqa: E402
+    CursorPolicy,
+    ScoredCursorPolicy,
+    find_node_by_type,
+)
 
 CPP_SNIPPET = """int add(int a, int b) { return a + b; }"""
+REASON = "Tree-sitter parser unavailable"
 
 
 def _parser_available() -> bool:
@@ -19,7 +24,7 @@ def _parser_available() -> bool:
         return False
 
 
-@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+@pytest.mark.skipif(not _parser_available(), reason=REASON)
 def test_find_node_by_type():
     ast = CppAst()
     tree = ast.parse(CPP_SNIPPET)
@@ -28,12 +33,26 @@ def test_find_node_by_type():
     assert func.type == "function_definition"
 
 
-@pytest.mark.skipif(not _parser_available(), reason="Tree-sitter parser unavailable")
+@pytest.mark.skipif(not _parser_available(), reason=REASON)
 def test_cursor_policy_with_custom_predicate():
     ast = CppAst()
     tree = ast.parse(CPP_SNIPPET)
     # predicate that selects the return statement
     policy = CursorPolicy(lambda n: n.type == "return_statement")
+    node = policy.select(tree)
+    assert node is not None
+    assert node.type == "return_statement"
+
+
+@pytest.mark.skipif(not _parser_available(), reason=REASON)
+def test_scored_cursor_policy_prefers_high_score():
+    ast = CppAst()
+    tree = ast.parse(CPP_SNIPPET)
+
+    def scorer(node):
+        return 1.0 if node.type == "return_statement" else 0.0
+
+    policy = ScoredCursorPolicy(scorer)
     node = policy.select(tree)
     assert node is not None
     assert node.type == "return_statement"

--- a/utils/ast_cursor.py
+++ b/utils/ast_cursor.py
@@ -8,8 +8,10 @@ parse tree in breadth‑first order returning the first node that satisfies
 the predicate.
 
 The initial implementation is intentionally simple – it supports only
-predicate based searches and returns the first match.  It can be expanded in
-later phases with scores, multi-node selections or learned policies.
+predicate based searches and returns the first match.  For Phase 9 we also
+include a tiny scored policy that walks the tree once and returns the node
+with the highest score.  This serves as a lightweight placeholder for a
+future learned cursor module.
 """
 from __future__ import annotations
 
@@ -20,6 +22,7 @@ from tree_sitter import Node, Tree
 
 
 Predicate = Callable[[Node], bool]
+ScoreFn = Callable[[Node], float]
 
 
 @dataclass
@@ -48,6 +51,32 @@ class CursorPolicy:
                 return node
             queue.extend(node.children)
         return None
+
+
+@dataclass
+class ScoredCursorPolicy:
+    """Select the node with the highest ``scorer`` value.
+
+    The traversal is breadth‑first and considers all nodes.  If ``predicate``
+    is provided, only nodes satisfying it are scored.
+    """
+
+    scorer: ScoreFn
+    predicate: Optional[Predicate] = None
+
+    def select(self, tree: Tree) -> Optional[Node]:
+        best_score = float("-inf")
+        best_node: Optional[Node] = None
+        queue = [tree.root_node]
+        while queue:
+            node = queue.pop(0)
+            if self.predicate is None or self.predicate(node):
+                score = self.scorer(node)
+                if score > best_score:
+                    best_score = score
+                    best_node = node
+            queue.extend(node.children)
+        return best_node
 
 
 def find_node_by_type(tree: Tree, node_type: str) -> Optional[Node]:


### PR DESCRIPTION
## Summary
- add ScoredCursorPolicy to select highest-scoring AST node
- test cursor policies and integrate skip reason constant
- update Phase 9 checklist for cursor policy progress

## Testing
- `pre-commit run --files utils/ast_cursor.py tests/test_ast_cursor.py docs/hrmCoder_checklist.md`
- `pytest tests/test_ast_cursor.py`

------
https://chatgpt.com/codex/tasks/task_e_68a06ab75a54833184efbb8c524f4b94