### PR TITLE
Add C++ compile helper with diagnostics

### DIFF
--- a/hrm_coder/cpp_compile.py
+++ b/hrm_coder/cpp_compile.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Utility functions for compiling C++ sources.
+
+This module provides a thin wrapper around ``g++`` or ``clang++``
+invocations. It captures diagnostics so that later phases can integrate
+warning and error counts into reward shaping or reporting pipelines.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+import subprocess
+
+# Default compile flags aimed at reasonably optimized yet deterministic
+# builds. These can be extended by callers for sanitizers or additional
+# warnings.
+DEFAULT_FLAGS: List[str] = ["-std=c++17", "-O2", "-pipe"]
+
+
+@dataclass
+class CompileResult:
+    """Result of a C++ compilation command."""
+
+    cmd: List[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    warnings: List[str]
+    errors: List[str]
+
+    @property
+    def success(self) -> bool:
+        """Whether the compilation finished without errors."""
+
+        return self.returncode == 0
+
+
+def compile_cpp(
+    sources: Sequence[Path],
+    output: Path,
+    *,
+    compiler: str = "g++",
+    flags: Iterable[str] | None = None,
+) -> CompileResult:
+    """Compile C++ ``sources`` into ``output`` using ``compiler``.
+
+    Parameters
+    ----------
+    sources:
+        Sequence of C++ source file paths to compile.
+    output:
+        Path to the output binary.
+    compiler:
+        Which compiler executable to invoke. Defaults to ``g++``.
+    flags:
+        Additional flags to pass to the compiler. ``DEFAULT_FLAGS`` are
+        prepended automatically.
+    """
+
+    src_args = [str(Path(s)) for s in sources]
+    cmd: List[str] = [compiler, *DEFAULT_FLAGS]
+    if flags:
+        cmd.extend(list(flags))
+    cmd.extend(src_args)
+    cmd.extend(["-o", str(output)])
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+
+    stderr_lines = proc.stderr.splitlines()
+    warnings = [line for line in stderr_lines if "warning:" in line]
+    errors = [line for line in stderr_lines if "error:" in line]
+
+    return CompileResult(
+        cmd=cmd,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        warnings=warnings,
+        errors=errors,
+    )

--- a/hrm_coder/tests/test_cpp_compile.py
+++ b/hrm_coder/tests/test_cpp_compile.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from hrm_coder.cpp_compile import compile_cpp
+
+
+def test_compile_success(tmp_path: Path) -> None:
+    src = tmp_path / "main.cc"
+    src.write_text("int main() { return 0; }\n")
+    out = tmp_path / "a.out"
+    result = compile_cpp([src], out)
+    assert result.success
+    assert result.errors == []
+    assert result.warnings == []
+
+
+def test_compile_failure(tmp_path: Path) -> None:
+    src = tmp_path / "main.cc"
+    src.write_text("int main() {\n")  # missing closing brace/semicolon
+    out = tmp_path / "a.out"
+    result = compile_cpp([src], out)
+    assert not result.success
+    assert result.errors  # expect at least one error line
+
+
+def test_compile_with_warning(tmp_path: Path) -> None:
+    src = tmp_path / "main.cc"
+    src.write_text("int main() { int x = 0; return 0; }\n")
+    out = tmp_path / "a.out"
+    result = compile_cpp([src], out, flags=["-Wall"])
+    assert result.success
+    assert result.warnings  # unused variable x should trigger warning


### PR DESCRIPTION
## Summary
- add `compile_cpp` helper to invoke g++/clang++ with standard flags and collect warnings/errors
- cover compile success, failure, and warning cases with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06abb81548331af4e0efbd7e05166