### PR TITLE
feat: add configurable environment settings

### DIFF
--- a/hrm_coder/conf/config.yaml
+++ b/hrm_coder/conf/config.yaml
@@ -3,4 +3,5 @@ defaults:
   - model: small
   - runner: default
   - acceptance: default
+  - environment: default
   - _self_

--- a/hrm_coder/conf/environment/default.yaml
+++ b/hrm_coder/conf/environment/default.yaml
@@ -1,0 +1,3 @@
+seed: 0
+timezone: UTC
+locale: C

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -23,6 +23,15 @@ class DatasetConfig:
 
 
 @dataclass
+class EnvironmentConfig:
+    """Process-wide environment settings for determinism."""
+
+    seed: int = 0
+    timezone: str = "UTC"
+    locale: str = "C"
+
+
+@dataclass
 class RunnerConfig:
     """Configuration for the sandbox runner.
 
@@ -57,6 +66,7 @@ class AppConfig:
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     runner: RunnerConfig = field(default_factory=RunnerConfig)
     acceptance: AcceptanceConfig = field(default_factory=AcceptanceConfig)
+    environment: EnvironmentConfig = field(default_factory=EnvironmentConfig)
 
 
 def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
@@ -79,6 +89,7 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
         dataset=DatasetConfig(**cfg_dict["dataset"]),
         runner=RunnerConfig(**cfg_dict["runner"]),
         acceptance=AcceptanceConfig(**cfg_dict["acceptance"]),
+        environment=EnvironmentConfig(**cfg_dict["environment"]),
     )
 
 
@@ -88,5 +99,6 @@ __all__ = [
     "ModelConfig",
     "RunnerConfig",
     "AcceptanceConfig",
+    "EnvironmentConfig",
     "load_config",
 ]

--- a/hrm_coder/eval_cli.py
+++ b/hrm_coder/eval_cli.py
@@ -23,7 +23,9 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = load_config(args.overrides)
-    pin_environment()
+    pin_environment(
+        cfg.environment.seed, cfg.environment.timezone, cfg.environment.locale
+    )
 
     print("Loaded configuration:")
     print(pformat(asdict(cfg)))

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -9,6 +9,8 @@ def test_load_config_defaults():
     assert cfg.runner.timeout == 5
     assert cfg.acceptance.pass_at_1 == 0.5
     assert cfg.acceptance.max_timeout_rate == 0.05
+    assert cfg.environment.seed == 0
+    assert cfg.environment.timezone == "UTC"
 
 
 def test_load_config_override():
@@ -16,7 +18,9 @@ def test_load_config_override():
         "model.learning_rate=0.01",
         "runner.timeout=10",
         "acceptance.pass_at_1=0.9",
+        "environment.seed=123",
     ])
     assert cfg.model.learning_rate == 0.01
     assert cfg.runner.timeout == 10
     assert cfg.acceptance.pass_at_1 == 0.9
+    assert cfg.environment.seed == 123

--- a/hrm_coder/train.py
+++ b/hrm_coder/train.py
@@ -41,7 +41,12 @@ def main() -> None:
     """Run a tiny end-to-end training demo."""
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--seed", type=int, default=0, help="PRNG seed")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Override deterministic seed from configuration",
+    )
     parser.add_argument(
         "--checkpoint",
         type=str,
@@ -61,8 +66,10 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = load_config(args.overrides)
-    pin_environment(args.seed)
-    torch.manual_seed(args.seed)
+
+    seed = args.seed if args.seed is not None else cfg.environment.seed
+    pin_environment(seed, cfg.environment.timezone, cfg.environment.locale)
+    torch.manual_seed(seed)
 
     print("Loaded configuration:")
     print(pformat(asdict(cfg)))
@@ -73,7 +80,7 @@ def main() -> None:
     targets = torch.arange(5) % vocab
     dataset = TensorDataset(inputs, targets)
     g = torch.Generator()
-    g.manual_seed(args.seed)
+    g.manual_seed(seed)
     loader = DataLoader(dataset, batch_size=1, shuffle=True, generator=g)
 
     # Initialise model and trainer.


### PR DESCRIPTION
## Summary
- add `EnvironmentConfig` dataclass with seed/timezone/locale
- load environment section from Hydra config and default file
- train and eval CLIs now pin environment using config and support seed override

## Testing
- `pre-commit run --files hrm_coder/config.py hrm_coder/conf/config.yaml hrm_coder/conf/environment/default.yaml hrm_coder/train.py hrm_coder/eval_cli.py hrm_coder/tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07e78ee888331a7129ad395c62622