### PR TITLE
feat: add run deletion endpoint

### DIFF
--- a/docs/hrmCoder_gui_quickstart.md
+++ b/docs/hrmCoder_gui_quickstart.md
@@ -31,4 +31,7 @@ curl http://localhost:8000/artifacts/run_1/result.xml
 
 # Get coverage summary
 curl http://localhost:8000/runs/1/coverage
+
+# Delete a run
+curl -X DELETE http://localhost:8000/runs/1
 ```

--- a/hrm_coder/api.py
+++ b/hrm_coder/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List
 from pathlib import Path
 import json
-import xml.etree.ElementTree as ET
+import shutil
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -113,7 +113,11 @@ def coverage_summary(run_id: int) -> Dict[str, float]:
         data = json.loads(cov_path.read_text())
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="invalid coverage")
-    line_cov = data.get("line") or data.get("lines") or data.get("line_percent")
+    line_cov = (
+        data.get("line")
+        or data.get("lines")
+        or data.get("line_percent")
+    )
     try:
         line_cov = float(line_cov)
     except (TypeError, ValueError):
@@ -136,6 +140,19 @@ def update_run(run_id: int, payload: RunUpdate):
     if payload.status is not None:
         registry.update_status(run_id, payload.status)
     return registry.get_run(run_id)
+
+
+@app.delete("/runs/{run_id}", response_model=Run)
+def delete_run(run_id: int):
+    """Delete a run and its artifacts."""
+    run = registry.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    path = ARTIFACT_DIR / f"run_{run_id}"
+    if path.exists():
+        shutil.rmtree(path)
+    registry.delete_run(run_id)
+    return run
 
 
 class LogMessage(BaseModel):

--- a/hrm_coder/run_registry.py
+++ b/hrm_coder/run_registry.py
@@ -51,6 +51,12 @@ class RunRegistry:
         if run_id in self._runs:
             self._runs[run_id].status = status
 
+    def delete_run(self, run_id: int) -> bool:
+        """Remove a run and its log queue."""
+        removed = self._runs.pop(run_id, None)
+        self._log_queues.pop(run_id, None)
+        return removed is not None
+
     # Logging helpers -------------------------------------------------
 
     def append_log(self, run_id: int, message: str) -> None:

--- a/hrm_coder/tests/test_api.py
+++ b/hrm_coder/tests/test_api.py
@@ -3,14 +3,8 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from fastapi.testclient import TestClient
-
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
-from hrm_coder import app
-
+from fastapi.testclient import TestClient  # noqa: E402
+from hrm_coder import app  # noqa: E402
 
 
 def test_run_lifecycle():
@@ -34,7 +28,9 @@ def test_run_lifecycle():
     assert fetched["id"] == run["id"]
 
     # Update status
-    updated = client.patch(f"/runs/{run['id']}", json={"status": "done"}).json()
+    updated = client.patch(
+        f"/runs/{run['id']}", json={"status": "done"}
+    ).json()
     assert updated["status"] == "done"
 
     # Append a log line
@@ -42,3 +38,12 @@ def test_run_lifecycle():
     logs = client.get(f"/runs/{run['id']}").json()["logs"]
     assert "finished" in logs
 
+    # Delete run
+    art_dir = (
+        Path(__file__).resolve().parents[1] / "artifacts" / f"run_{run['id']}"
+    )
+    assert art_dir.exists()
+    deleted = client.delete(f"/runs/{run['id']}").json()
+    assert deleted["id"] == run["id"]
+    assert not art_dir.exists()
+    assert client.get("/runs").json() == []

--- a/hrm_coder/tests/test_run_registry.py
+++ b/hrm_coder/tests/test_run_registry.py
@@ -11,3 +11,11 @@ def test_run_records_docker_digest(monkeypatch):
     monkeypatch.setenv("DOCKER_DIGEST", "sha256:testdigest")
     run = registry.create_run()
     assert run.version.docker_digest == "sha256:testdigest"
+
+
+def test_delete_run_removes_entry():
+    run = registry.create_run()
+    run_id = run.id
+    assert registry.get_run(run_id)
+    assert registry.delete_run(run_id)
+    assert registry.get_run(run_id) is None


### PR DESCRIPTION
## Summary
- allow deleting runs and their artifacts via new REST endpoint
- document example run deletion in GUI quickstart
- cover deletion behavior with unit tests

## Testing
- `pre-commit run --files docs/hrmCoder_gui_quickstart.md hrm_coder/api.py hrm_coder/run_registry.py hrm_coder/tests/test_api.py hrm_coder/tests/test_run_registry.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a07e7c3d2c8331a49985cade26aa49