### PR TITLE
Add coverage support to gtest runner

### DIFF
--- a/runners/gtest_runner.py
+++ b/runners/gtest_runner.py
@@ -8,10 +8,11 @@ provided the binary is executed directly via :mod:`subprocess`.
 """
 from __future__ import annotations
 
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 from xml.etree import ElementTree as ET
 
 from .isolate import IsolateRunner, SandboxError
@@ -50,6 +51,49 @@ def _parse_gtest_xml(xml: str) -> Dict[str, object]:
     }
 
 
+def _parse_gcov_file(path: Path) -> float:
+    """Return line coverage ratio from a ``gcov`` report file."""
+    executed = 0
+    total = 0
+    for line in path.read_text().splitlines():
+        parts = line.split(":", 2)
+        if len(parts) < 2:
+            continue
+        count = parts[0].strip()
+        if count in ("-", "====="):
+            continue
+        if count == "#####":
+            total += 1
+            continue
+        try:
+            num = int(count)
+        except ValueError:
+            continue
+        total += 1
+        if num > 0:
+            executed += 1
+    return executed / total if total else 0.0
+
+
+def _collect_coverage(sources: Sequence[Path], workdir: Path) -> float:
+    """Run ``gcov`` on ``sources`` in ``workdir`` and average coverage."""
+    if shutil.which("gcov") is None:
+        return 0.0
+    covs: List[float] = []
+    for src in sources:
+        subprocess.run(
+            ["gcov", str(src), "-o", str(workdir)],
+            capture_output=True,
+            text=True,
+            cwd=str(workdir),
+            check=False,
+        )
+        gcov_file = workdir / f"{src.name}.gcov"
+        if gcov_file.exists():
+            covs.append(_parse_gcov_file(gcov_file))
+    return sum(covs) / len(covs) if covs else 0.0
+
+
 def run_gtests(
     binary: Path,
     *,
@@ -58,6 +102,8 @@ def run_gtests(
     wall_time: int = 5,
     memory: int = 256 * 1024,
     cache: Optional[SandboxCache] = None,
+    collect_coverage: bool = False,
+    sources: Optional[Sequence[Path]] = None,
 ) -> Dict[str, object]:
     """Execute ``binary`` and return parsed GoogleTest results.
 
@@ -72,18 +118,29 @@ def run_gtests(
     cache:
         Optional :class:`SandboxCache` instance used to memoize results for
         identical binaries and limits.
+    collect_coverage:
+        When ``True`` compute a line coverage ratio for ``sources`` using
+        ``gcov``.  The binary must have been built with ``--coverage`` flags.
+    sources:
+        Sequence of source files corresponding to the compiled
+        binary. Required when ``collect_coverage`` is ``True``.
     """
 
     key: Optional[str] = None
     if cache is not None:
-        key = cache.hash_parts(
-            [
-                binary.read_bytes(),
-                str(time_limit).encode(),
-                str(wall_time).encode(),
-                str(memory).encode(),
-            ]
-        )
+        parts = [
+            binary.read_bytes(),
+            str(time_limit).encode(),
+            str(wall_time).encode(),
+            str(memory).encode(),
+        ]
+        if collect_coverage:
+            if not sources:
+                raise ValueError("sources must be provided for coverage")
+            for src in sources:
+                parts.append(Path(src).read_bytes())
+            parts.append(b"coverage")
+        key = cache.hash_parts(parts)
         cached = cache.load(key)
         if cached is not None:
             return cached
@@ -102,7 +159,9 @@ def run_gtests(
             except SandboxError as exc:  # pragma: no cover - defensive
                 raise GTestExecutionError("sandbox execution failed") from exc
         else:
-            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, check=False
+            )
 
         if proc.returncode != 0:
             raise GTestExecutionError(
@@ -113,6 +172,10 @@ def run_gtests(
         xml = xml_path.read_text()
 
     result = _parse_gtest_xml(xml)
+    if collect_coverage:
+        if not sources:
+            raise ValueError("sources must be provided for coverage")
+        result["coverage"] = _collect_coverage(sources, binary.parent)
     if cache is not None and key is not None:
         cache.store(key, result)
     return result

--- a/tests/test_gtest_runner.py
+++ b/tests/test_gtest_runner.py
@@ -7,23 +7,28 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from runners.gtest_runner import run_gtests
-from runners.sandbox_cache import SandboxCache
+from runners.gtest_runner import run_gtests  # noqa: E402
+from runners.sandbox_cache import SandboxCache  # noqa: E402
 
-if shutil.which("g++") is None or not Path("/usr/include/gtest/gtest.h").exists():
+if shutil.which("g++") is None or not Path(
+    "/usr/include/gtest/gtest.h"
+).exists():
     pytest.skip("gtest headers not available", allow_module_level=True)
 
 
-def build_sample_test(tmpdir: Path) -> Path:
+def build_sample_test(
+    tmpdir: Path, *, coverage: bool = False
+) -> tuple[Path, Path]:
     code = (
         "#include <gtest/gtest.h>\n"
         "TEST(Sample, Adds){EXPECT_EQ(2+2,4);}\n"
-        "int main(int argc,char**argv){::testing::InitGoogleTest(&argc, argv);return RUN_ALL_TESTS();}\n"
+        "int main(int argc,char**argv){::testing::InitGoogleTest(&argc, "
+        "argv);return RUN_ALL_TESTS();}\n"
     )
     src = tmpdir / "sample_test.cpp"
     src.write_text(code)
     binary = tmpdir / "sample_test"
-    subprocess.check_call([
+    cmd = [
         "g++",
         str(src),
         "-lgtest",
@@ -31,12 +36,15 @@ def build_sample_test(tmpdir: Path) -> Path:
         "-pthread",
         "-o",
         str(binary),
-    ])
-    return binary
+    ]
+    if coverage:
+        cmd.insert(1, "--coverage")
+    subprocess.check_call(cmd)
+    return binary, src
 
 
 def test_run_gtests(tmp_path):
-    binary = build_sample_test(tmp_path)
+    binary, _ = build_sample_test(tmp_path)
     result = run_gtests(binary)
     assert result["tests"] == 1
     assert result["failures"] == 0
@@ -54,7 +62,7 @@ class SpyRunner:
 
 
 def test_run_gtests_cache(tmp_path):
-    binary = build_sample_test(tmp_path)
+    binary, _ = build_sample_test(tmp_path)
     cache = SandboxCache(tmp_path / "cache")
     spy = SpyRunner()
     first = run_gtests(binary, sandbox=spy, cache=cache)
@@ -62,3 +70,10 @@ def test_run_gtests_cache(tmp_path):
     second = run_gtests(binary, sandbox=spy, cache=cache)
     assert spy.calls == 1
     assert first == second
+
+
+def test_run_gtests_coverage(tmp_path):
+    binary, src = build_sample_test(tmp_path, coverage=True)
+    result = run_gtests(binary, collect_coverage=True, sources=[src])
+    assert "coverage" in result
+    assert 0.0 <= result["coverage"] <= 1.0


### PR DESCRIPTION
## Summary
- add optional line coverage collection to `run_gtests`
- record coverage in cache keys and results
- test gtest coverage path

## Testing
- `pre-commit run --files runners/gtest_runner.py tests/test_gtest_runner.py`
- `pytest tests/test_gtest_runner.py tests/test_cpp_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68a07e818f288331966fd0f230be311a