### PR TITLE
feat: compute reward from artifact directory

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -61,7 +61,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
     [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)
 
-** [ ] Phase 5: Reward Shaping and Safety Gates
+** [?] Phase 5: Reward Shaping and Safety Gates
     [X] Implement reward aggregator with weighted compile/link status, tests, and coverage signals
     [X] Integrate clang-tidy/clang++ -Wall -Wextra -Werror diagnostics into normalized lint score
     [X] Incorporate compiler warning/error counts into reward diagnostics score

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -373,3 +373,58 @@ def test_drift_check_detects_mean_shift(caplog):
     assert any(
         "outside expected range" in r.message for r in caplog.records
     )
+
+
+def test_compute_from_dir(tmp_path):
+    agg = RewardAggregator(
+        weights={
+            'compile': 0.1,
+            'tests': 0.3,
+            'coverage': 0.2,
+            'coverage_delta': 0.2,
+            'lint': 0.1,
+            'static': 0.1,
+        },
+        max_edit_penalty=0.0,
+        max_time_penalty=0.0,
+        max_memory_penalty=0.0,
+    )
+
+    (tmp_path / 'junit.xml').write_text(
+        '<testsuite tests="2" failures="0"></testsuite>'
+    )
+    (tmp_path / 'coverage.json').write_text('{"line": 0.5}')
+    (tmp_path / 'clang_tidy.log').write_text(
+        'a.cpp:1:1: warning: thing [misc]'
+    )
+    (tmp_path / 'cppcheck.log').write_text('[warning] x')
+    (tmp_path / 'compile.stdout').write_text('a.cpp:1:1: warning: w')
+    (tmp_path / 'compile.stderr').write_text('')
+    (tmp_path / 'sanitizer.log').write_text('')
+
+    meta = {
+        'compile_success': True,
+        'edit_cost': 0.0,
+        'time_used': 0.0,
+        'memory_used': 0.0,
+        'prev_coverage': 0.3,
+    }
+
+    r_dir = agg.compute_from_dir(tmp_path, meta=meta)
+    r_manual = agg.compute_from_outputs(
+        compile_success=True,
+        tests_passed=2,
+        tests_total=2,
+        coverage=0.5,
+        edit_cost=0.0,
+        time_used=0.0,
+        memory_used=0.0,
+        clang_output='a.cpp:1:1: warning: thing [misc]',
+        cppcheck_output='[warning] x',
+        compiler_stdout='a.cpp:1:1: warning: w',
+        compiler_stderr='',
+        sanitizer_output='',
+        prev_coverage=0.3,
+    )
+
+    assert abs(r_dir - r_manual) < 1e-6

--- a/utils/reward.py
+++ b/utils/reward.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 import logging
+import json
+from pathlib import Path
 
 from .diagnostics import (
     clang_tidy_score,
@@ -188,7 +190,9 @@ class RewardAggregator:
         """
 
         lint = clang_tidy_score(clang_output)
-        warnings, errors = compiler_diagnostics(compiler_stdout, compiler_stderr)
+        warnings, errors = compiler_diagnostics(
+            compiler_stdout, compiler_stderr
+        )
         static = cppcheck_score(cppcheck_output)
         san = (
             sanitizer_clean(sanitizer_output)
@@ -215,6 +219,88 @@ class RewardAggregator:
             prev_coverage=prev_coverage,
             time_limit=time_limit,
             memory_limit=memory_limit,
+        )
+
+    def compute_from_dir(
+        self,
+        path: Path,
+        *,
+        meta: Optional[Dict[str, float | int | bool]] = None,
+    ) -> float:
+        """Compute reward by reading standard artifact files from ``path``.
+
+        The directory is expected to contain files named ``junit.xml`` and
+        ``coverage.json`` along with optional logs:
+        ``clang_tidy.log``, ``compile.stdout``, ``compile.stderr``,
+        ``cppcheck.log`` and ``sanitizer.log``.  Additional numeric metadata
+        such as ``edit_cost`` or ``time_used`` can be supplied via the
+        ``meta`` mapping.
+        """
+
+        meta = meta or {}
+
+        junit_xml = None
+        junit_path = path / "junit.xml"
+        if junit_path.exists():
+            junit_xml = junit_path.read_text()
+
+        coverage = 0.0
+        cov_path = path / "coverage.json"
+        if cov_path.exists():
+            try:
+                cov_data = json.loads(cov_path.read_text())
+                coverage = float(
+                    cov_data.get("line")
+                    or cov_data.get("lines")
+                    or cov_data.get("line_percent")
+                    or 0.0
+                )
+            except Exception:
+                coverage = 0.0
+
+        clang_output = (
+            (path / "clang_tidy.log").read_text()
+            if (path / "clang_tidy.log").exists()
+            else ""
+        )
+        compiler_stdout = (
+            (path / "compile.stdout").read_text()
+            if (path / "compile.stdout").exists()
+            else ""
+        )
+        compiler_stderr = (
+            (path / "compile.stderr").read_text()
+            if (path / "compile.stderr").exists()
+            else ""
+        )
+        cppcheck_output = (
+            (path / "cppcheck.log").read_text()
+            if (path / "cppcheck.log").exists()
+            else ""
+        )
+        sanitizer_output = (
+            (path / "sanitizer.log").read_text()
+            if (path / "sanitizer.log").exists()
+            else None
+        )
+
+        return self.compute_from_outputs(
+            compile_success=bool(meta.get("compile_success", True)),
+            tests_passed=meta.get("tests_passed"),
+            tests_total=meta.get("tests_total"),
+            coverage=coverage,
+            edit_cost=float(meta.get("edit_cost", 0.0)),
+            time_used=float(meta.get("time_used", 0.0)),
+            memory_used=float(meta.get("memory_used", 0.0)),
+            junit_xml=junit_xml,
+            clang_output=clang_output,
+            compiler_stdout=compiler_stdout,
+            compiler_stderr=compiler_stderr,
+            cppcheck_output=cppcheck_output,
+            sanitizer_output=sanitizer_output,
+            prev_coverage=meta.get("prev_coverage"),
+            time_limit=meta.get("time_limit"),
+            memory_limit=meta.get("memory_limit"),
         )
 
     def histogram(self, bins: int = 10) -> List[int]:


### PR DESCRIPTION
## Summary
- extend reward aggregator with `compute_from_dir` to parse standard run artifacts
- test reward calculation from artifact directories
- mark Phase 5 checklist as awaiting review

## Testing
- `pre-commit run --files utils/reward.py tests/test_reward.py docs/hrmCoder_checklist.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07e854d048331bf6425b71d1f7fbb