### PR TITLE
feat: add evaluation CLI and robust compiler output decoding

### DIFF
--- a/hrm_coder/eval_cli.py
+++ b/hrm_coder/eval_cli.py
@@ -1,34 +1,130 @@
 from __future__ import annotations
 
-"""Phase 1 evaluation stub for HRM Coder.
+"""Command line interface for the evaluation harness.
 
-Loads configuration and pins the environment in preparation for
-future evaluation routines.
+This tool wraps the Phase 7 evaluation utilities to compute pass@k metrics,
+detect incidents and flakiness, generate HTML/Markdown reports and check
+acceptance criteria defined in the configuration.
 """
 
 import argparse
-from dataclasses import asdict
-from pprint import pformat
+import json
+from pathlib import Path
+from typing import Sequence
 
 from .config import load_config
 from .env import pin_environment
+from .evaluation import generate_reports, incident_rates
+from .acceptance import AcceptanceCriteria, evaluate_acceptance
 
 
-def main() -> None:
-    """Entry point for the evaluation stub."""
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "overrides", nargs="*", help="Hydra-style overrides for evaluation"
+        "results",
+        help="JSON file mapping task id → list[bool] attempts",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "output",
+        help="Directory for generated reports",
+    )
+    parser.add_argument(
+        "--k",
+        dest="ks",
+        type=int,
+        nargs="*",
+        default=[1, 10],
+        help="k values for pass@k computation",
+    )
+    parser.add_argument(
+        "--runs",
+        nargs="*",
+        default=None,
+        help="JSON files of run outcomes for flakiness detection",
+    )
+    parser.add_argument(
+        "--baseline",
+        default=None,
+        help="JSON file with baseline metrics for comparison",
+    )
+    parser.add_argument(
+        "--incidents",
+        nargs="*",
+        default=None,
+        help="JSON files mapping task id → status string for incident rates",
+    )
+    parser.add_argument(
+        "--bundle",
+        default=None,
+        help="Path to write a bundled tar.gz of reports and raw JSON",
+    )
+    parser.add_argument(
+        "--upload",
+        default=None,
+        help="Directory to copy the bundle to (artifact upload)",
+    )
+    parser.add_argument(
+        "--overrides",
+        nargs="*",
+        default=None,
+        help="Hydra-style configuration overrides",
+    )
+    return parser.parse_args()
 
+
+def _load_incident_runs(paths: Sequence[str] | None) -> Sequence[dict[str, str]]:
+    return [json.loads(Path(p).read_text()) for p in paths] if paths else []
+
+
+def main() -> None:  # pragma: no cover - exercised via tests
+    args = _parse_args()
     cfg = load_config(args.overrides)
     pin_environment()
 
-    print("Loaded configuration:")
-    print(pformat(asdict(cfg)))
-    print("Evaluation loop not yet implemented – Phase 1 placeholder")
+    # Generate reports and compute metrics
+    metrics = generate_reports(
+        results_path=args.results,
+        output_dir=args.output,
+        ks=args.ks,
+        run_paths=args.runs,
+        baseline_path=args.baseline,
+        incident_paths=args.incidents,
+        bundle_path=args.bundle,
+        upload_dir=args.upload,
+    )
+
+    # Prepare acceptance evaluation
+    incident_runs = _load_incident_runs(args.incidents)
+    incident_summary = incident_rates(incident_runs) if incident_runs else {}
+    sanitizer_failures = sum(
+        status == "sanitizer"
+        for run in incident_runs
+        for status in run.values()
+    )
+
+    acceptance_metrics = {
+        "pass@1": metrics.get(1, 0.0),
+        "pass@10": metrics.get(10, 0.0),
+        "timeout_rate": incident_summary.get("timeout", 0.0),
+        "sanitizer_failures": sanitizer_failures,
+    }
+
+    criteria = AcceptanceCriteria(
+        pass_at_1=cfg.acceptance.pass_at_1,
+        pass_at_10=cfg.acceptance.pass_at_10,
+        max_timeout_rate=cfg.acceptance.max_timeout_rate,
+        max_sanitizer_failures=cfg.acceptance.max_sanitizer_failures,
+    )
+
+    results = evaluate_acceptance(acceptance_metrics, criteria)
+    print("Acceptance results:")
+    for key, value in results.items():
+        print(f"{key}: {value}")
+
+    if not results["overall"]:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+

--- a/hrm_coder/tests/test_eval_cli.py
+++ b/hrm_coder/tests/test_eval_cli.py
@@ -1,0 +1,34 @@
+import json
+import sys
+
+from hrm_coder import eval_cli
+
+
+def test_eval_cli_generates_reports(tmp_path, monkeypatch):
+    results = {"t1": [True]}
+    results_file = tmp_path / "results.json"
+    results_file.write_text(json.dumps(results))
+
+    incident_file = tmp_path / "inc.json"
+    incident_file.write_text(json.dumps({"t1": "pass"}))
+
+    out_dir = tmp_path / "out"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "eval_cli",
+            str(results_file),
+            str(out_dir),
+            "--incidents",
+            str(incident_file),
+            "--overrides",
+            "acceptance.pass_at_1=0.0",
+            "acceptance.pass_at_10=0.0",
+        ],
+    )
+
+    eval_cli.main()
+
+    assert (out_dir / "report.md").exists()

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -125,7 +125,9 @@ def compile_cpp_sources(
         for p in rpath:
             cmd.append(f"-Wl,-rpath,{p}")
 
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
     success = proc.returncode == 0
     warnings, errors = compiler_diagnostics(proc.stdout, proc.stderr)
     return CompileResult(
@@ -177,7 +179,9 @@ def compile_shared_library(
 
     cmd += [str(s) for s in sources] + ["-o", str(output_path)] + list(flags)
 
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
     success = proc.returncode == 0
     warnings, errors = compiler_diagnostics(proc.stdout, proc.stderr)
     return CompileResult(
@@ -234,7 +238,9 @@ def compile_static_library(
         if use_ccache and shutil.which("ccache") is not None:
             cmd = ["ccache", compiler]
         cmd += [str(src), "-c", "-o", str(obj_path)] + list(flags)
-        proc = subprocess.run(cmd, capture_output=True, text=True)
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+        )
         stdout_parts.append(proc.stdout)
         stderr_parts.append(proc.stderr)
         w, e = compiler_diagnostics(proc.stdout, proc.stderr)
@@ -252,7 +258,9 @@ def compile_static_library(
         objs.append(obj_path)
 
     ar_cmd = ["ar", "rcs", str(output_path)] + [str(o) for o in objs]
-    ar_proc = subprocess.run(ar_cmd, capture_output=True, text=True)
+    ar_proc = subprocess.run(
+        ar_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
     stdout_parts.append(ar_proc.stdout)
     stderr_parts.append(ar_proc.stderr)
     success = ar_proc.returncode == 0
@@ -368,6 +376,8 @@ def run_binary(
         input=input_data,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
         preexec_fn=preexec,
         env={**os.environ, **env} if env is not None else None,
@@ -410,6 +420,8 @@ def _collect_coverage(sources: Sequence[Path], workdir: Path) -> float:
             ["gcov", str(src), "-o", str(workdir)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=str(workdir),
             check=False,
         )


### PR DESCRIPTION
## Summary
- add evaluation command-line tool that generates reports and checks acceptance criteria
- harden C++ runner by forcing UTF-8 decoding on subprocess outputs
- cover new evaluation entry point with a smoke test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07e8a10b4833191f631a27bccd76a