### PR TITLE
Add GitHub Pages workflow for report publishing

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,45 @@
+name: Publish Reports to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Prepare Pages artifact
+        run: |
+          if [ -d reports ]; then
+            python scripts/publish_reports.py reports public
+          else
+            echo "No reports directory found, creating placeholder."
+            mkdir -p public
+            echo '<html><body><h1>No reports available</h1></body></html>' > public/index.html
+          fi
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -92,7 +92,7 @@ Save new code files in: C:\repos\hrm-coder
     [?] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
     [~] Create nightly full evaluation job with retention and tagging
     [X] Implement version stamping (git SHA, Docker digest, seeds) in runs
-    [~] Configure GitHub Pages publish for latest report artifacts
+    [X] Configure GitHub Pages publish for latest report artifacts
     [ ] Bootstrap MLflow or W\&B project with tags and run summaries
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)


### PR DESCRIPTION
## Summary
- add workflow to publish evaluation reports to GitHub Pages
- update phase 8 checklist marking Pages publishing as complete

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e8bed048331a8ad890f3aabf577