### PR TITLE
feat: add ablation comparison utility

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -101,7 +101,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Define edit action space for insert, replace, and delete operations
     [?] Implement cursor policy module for region selection by HRM high-level
     [X] Implement decoder constraint checker to avoid invalid AST states
-    [ ] Add ablation job configs and comparison report against token baseline
+    [~] Add ablation job configs and comparison report against token baseline
 
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)
     [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing

--- a/hrm_coder/ablation.py
+++ b/hrm_coder/ablation.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Utilities for generating ablation comparison reports.
+
+This module provides a small helper used in Phase 9 of the HRM Coder
+roadmap.  It compares evaluation metrics from a current run against a
+baseline (typically the token-based model) and writes a report whose format
+is inferred from the output file extension.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+from .evaluation import (
+    compare_to_baseline,
+    comparison_html_report,
+    comparison_markdown_report,
+)
+
+
+def generate_ablation_report(
+    current_metrics_path: str, baseline_metrics_path: str, output_path: str
+) -> Dict[str, Dict[str, Optional[float]]]:
+    """Generate a comparison report between ``current`` and ``baseline``.
+
+    Parameters
+    ----------
+    current_metrics_path:
+        Path to a JSON file containing metrics from the current run.
+    baseline_metrics_path:
+        Path to a JSON file with baseline metrics.
+    output_path:
+        Destination for the generated report.  The format is determined by the
+        file extension: ``.md`` for Markdown, ``.html``/``.htm`` for HTML and
+        JSON otherwise.
+    """
+
+    current = json.loads(Path(current_metrics_path).read_text())
+    comparison = compare_to_baseline(current, baseline_metrics_path)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if out.suffix.lower() == ".md":
+        out.write_text(comparison_markdown_report(comparison))
+    elif out.suffix.lower() in {".html", ".htm"}:
+        out.write_text(comparison_html_report(comparison))
+    else:
+        out.write_text(json.dumps(comparison))
+    return comparison
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "current", help="JSON file with metrics from current run"
+    )
+    parser.add_argument(
+        "baseline", help="JSON file with baseline metrics"
+    )
+    parser.add_argument(
+        "output",
+        help="Path to write comparison report (extension determines format)",
+    )
+    args = parser.parse_args()
+    generate_ablation_report(args.current, args.baseline, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_ablation_report.py
+++ b/tests/test_ablation_report.py
@@ -1,0 +1,27 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+
+from hrm_coder.ablation import generate_ablation_report  # noqa: E402
+
+
+def test_generate_ablation_report(tmp_path: Path) -> None:
+    baseline = {"pass@1": 0.4}
+    current = {"pass@1": 0.6}
+    baseline_file = tmp_path / "baseline.json"
+    current_file = tmp_path / "current.json"
+    report_file = tmp_path / "report.json"
+    baseline_file.write_text(json.dumps(baseline))
+    current_file.write_text(json.dumps(current))
+
+    comparison = generate_ablation_report(
+        str(current_file), str(baseline_file), str(report_file)
+    )
+
+    assert report_file.exists()
+    assert json.loads(report_file.read_text()) == comparison
+    assert comparison["pass@1"]["delta"] == pytest.approx(0.2)


### PR DESCRIPTION
## Summary
- add utility to generate ablation comparison reports between current metrics and baseline
- mark ablation report task as in progress in phase 9 checklist

## Testing
- `pre-commit run --files hrm_coder/ablation.py tests/test_ablation_report.py docs/hrmCoder_checklist.md`
- `pytest tests/test_ablation_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68a07e8f266c83319b41eb85ef3b335f