### PR TITLE
feat: propagate env vars to sandbox runners

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -323,7 +323,9 @@ def run_binary(
         Optional address-space limit in bytes.  When a sandbox is supplied the
         value is converted to kilobytes for the adapter.
     env:
-        Extra environment variables to inject when executing directly.
+        Extra environment variables to inject. When a sandbox is provided
+        the variables are forwarded to it, otherwise they are passed to
+        :func:`subprocess.run` directly.
     sandbox:
         Optional :class:`~runners.isolate.IsolateRunner` used to enforce
         resource limits and disable networking.
@@ -347,15 +349,26 @@ def run_binary(
                     memory=memory_kb,
                     stdin=input_data,
                     workdir=str(cwd),
+                    env=env,
                 )
             except TypeError:
-                proc = sandbox.run(
-                    [str(binary)],
-                    time_limit=int(timeout),
-                    wall_time=int(timeout),
-                    memory=memory_kb,
-                    stdin=input_data,
-                )
+                try:
+                    proc = sandbox.run(
+                        [str(binary)],
+                        time_limit=int(timeout),
+                        wall_time=int(timeout),
+                        memory=memory_kb,
+                        stdin=input_data,
+                        env=env,
+                    )
+                except TypeError:
+                    proc = sandbox.run(
+                        [str(binary)],
+                        time_limit=int(timeout),
+                        wall_time=int(timeout),
+                        memory=memory_kb,
+                        stdin=input_data,
+                    )
         except SandboxError as exc:
             return -1, "", str(exc)
         return proc.returncode, proc.stdout, proc.stderr

--- a/runners/isolate.py
+++ b/runners/isolate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Mapping
 
 
 class SandboxError(RuntimeError):
@@ -41,6 +41,7 @@ class IsolateRunner:
         readonly_dirs: Optional[Iterable[str]] = None,
         stdout: Optional[str] = None,
         stderr: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None,
     ) -> List[str]:
         """Build an ``isolate --run`` invocation.
 
@@ -67,6 +68,9 @@ class IsolateRunner:
         stdout, stderr:
             Optional filenames (inside the sandbox) to capture the
             respective streams.
+        env:
+            Optional mapping of environment variables to define inside the
+            sandbox.
         """
         isolate_cmd = [
             self.isolate_path,
@@ -89,6 +93,9 @@ class IsolateRunner:
             isolate_cmd.append(f"--stdout={stdout}")
         if stderr is not None:
             isolate_cmd.append(f"--stderr={stderr}")
+        if env is not None:
+            for key, value in env.items():
+                isolate_cmd.append(f"--env={key}={value}")
         isolate_cmd.extend(["--run", "--"])
         isolate_cmd.extend(command)
         return isolate_cmd
@@ -107,6 +114,7 @@ class IsolateRunner:
         stdout: Optional[str] = None,
         stderr: Optional[str] = None,
         stdin: Optional[bytes] = None,
+        env: Optional[Mapping[str, str]] = None,
     ) -> subprocess.CompletedProcess:
         """Execute ``command`` within ``isolate``.
 
@@ -142,6 +150,7 @@ class IsolateRunner:
                 readonly_dirs=readonly_dirs,
                 stdout=stdout,
                 stderr=stderr,
+                env=env,
             )
             proc = subprocess.run(
                 cmd,

--- a/runners/nsjail.py
+++ b/runners/nsjail.py
@@ -1,6 +1,6 @@
 import shutil
 import subprocess
-from typing import List, Optional
+from typing import List, Optional, Mapping
 
 
 class SandboxError(RuntimeError):
@@ -28,6 +28,7 @@ class NSJailRunner:
         memory: int = 256 * 1024,
         processes: int = 1,
         network: bool = False,
+        env: Optional[Mapping[str, str]] = None,
     ) -> List[str]:
         """Construct an ``nsjail`` invocation.
 
@@ -46,6 +47,9 @@ class NSJailRunner:
             Maximum number of processes.
         network:
             Allow network access if ``True``.
+        env:
+            Optional mapping of environment variables to set inside the
+            sandbox.
         """
         nsjail_cmd = [
             self.nsjail_path,
@@ -56,6 +60,9 @@ class NSJailRunner:
         ]
         if network:
             nsjail_cmd.append("--disable_clone_newnet")
+        if env is not None:
+            for key, value in env.items():
+                nsjail_cmd.extend(["--env", f"{key}={value}"])
         nsjail_cmd.append("--")
         nsjail_cmd.extend(command)
         return nsjail_cmd
@@ -70,6 +77,7 @@ class NSJailRunner:
         processes: int = 1,
         network: bool = False,
         stdin: Optional[bytes] = None,
+        env: Optional[Mapping[str, str]] = None,
     ) -> subprocess.CompletedProcess:
         """Execute a command within ``nsjail``.
 
@@ -87,6 +95,7 @@ class NSJailRunner:
             memory=memory,
             processes=processes,
             network=network,
+            env=env,
         )
         return subprocess.run(
             cmd,

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -196,6 +196,52 @@ def test_warning_count(tmp_path: Path) -> None:
     assert res.warnings >= 1
 
 
+def test_run_binary_passes_env_to_sandbox(tmp_path: Path) -> None:
+    lib_src = tmp_path / "double.cpp"
+    lib_src.write_text('extern "C" int times_two(int x){return 2*x;}\n')
+    lib_path = tmp_path / "libdouble.so"
+    lib_res = compile_shared_library([lib_src], output=lib_path)
+    assert lib_res.success
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+extern "C" int times_two(int);
+int main(){std::cout<<times_two(7);}
+"""
+    )
+    main_res = compile_cpp_sources(
+        [main], library_dirs=[tmp_path], libraries=["double"]
+    )
+    assert main_res.success and main_res.binary is not None
+
+    class EnvRunner:
+        def __init__(self) -> None:
+            self.env = None
+
+        def run(self, cmd, **kwargs):
+            self.env = kwargs.get("env")
+            return subprocess.run(
+                cmd,
+                input=kwargs.get("stdin"),
+                capture_output=True,
+                text=True,
+                check=False,
+                env=self.env,
+            )
+
+    runner = EnvRunner()
+    code, stdout, stderr = run_binary(
+        main_res.binary,
+        env={"LD_LIBRARY_PATH": str(tmp_path)},
+        sandbox=runner,
+    )
+    assert code == 0
+    assert stdout.strip() == "14"
+    assert runner.env == {"LD_LIBRARY_PATH": str(tmp_path)}
+
+
 class SpyRunner:
     def __init__(self) -> None:
         self.calls = 0

--- a/tests/test_isolate.py
+++ b/tests/test_isolate.py
@@ -39,3 +39,10 @@ def test_build_command_with_filesystem_options():
     assert "--stdout=out.txt" in cmd
     assert "--stderr=err.txt" in cmd
 
+
+def test_build_command_with_env():
+    runner = IsolateRunner(isolate_path="isolate", box_id=2)
+    cmd = runner.build_command(["/bin/true"], env={"LD_LIBRARY_PATH": "/libs", "FOO": "BAR"})
+    assert "--env=LD_LIBRARY_PATH=/libs" in cmd
+    assert "--env=FOO=BAR" in cmd
+

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -26,3 +26,11 @@ def test_build_command_allows_network_when_requested():
     runner = NSJailRunner(nsjail_path="nsjail")
     cmd = runner.build_command(["/bin/echo", "hi"], network=True)
     assert "--disable_clone_newnet" in cmd
+
+
+def test_build_command_with_env():
+    runner = NSJailRunner(nsjail_path="nsjail")
+    cmd = runner.build_command(["/bin/true"], env={"LD_LIBRARY_PATH": "/libs"})
+    assert "--env" in cmd
+    env_idx = cmd.index("--env")
+    assert cmd[env_idx + 1] == "LD_LIBRARY_PATH=/libs"


### PR DESCRIPTION
## Summary
- forward env vars through `run_binary` so dynamic libs resolve in sandboxes
- add env support to `IsolateRunner` and `NSJailRunner`
- test sandbox env propagation and command building

## Testing
- `pytest tests/test_isolate.py tests/test_nsjail.py tests/test_cpp_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68a07e926e1483318981dbb4b72077d2