### PR TITLE
Add sandbox selection helper and expand env probe

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -16,6 +16,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Setup project operation within isolate/gVisor runner images
     [~] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
         - Added sandbox detection utility for isolate, nsjail, and gVisor runsc runtime
+        - Added default sandbox selection helper to prefer isolate and fall back to nsjail or runsc
         - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)

--- a/runners/sandbox_detector.py
+++ b/runners/sandbox_detector.py
@@ -28,9 +28,11 @@ class SandboxInfo(Dict[str, Optional[str]]):
 
 
 def _probe_version(cmd: str) -> Optional[str]:
-    """Return the first line of ``cmd --version`` if it executes successfully."""
+    """Return first line of ``cmd --version`` if it executes successfully."""
     try:
-        proc = subprocess.run([cmd, "--version"], capture_output=True, text=True)
+        proc = subprocess.run(
+            [cmd, "--version"], capture_output=True, text=True
+        )
     except FileNotFoundError:
         return None
     if proc.returncode != 0:
@@ -54,10 +56,48 @@ def detect_sandboxes() -> Dict[str, SandboxInfo]:
     results: Dict[str, SandboxInfo] = {}
     for name, binary in tools.items():
         path = shutil.which(binary)
-        info: SandboxInfo = SandboxInfo(available=False, version=None, path=None)
+        info: SandboxInfo = SandboxInfo(
+            available=False, version=None, path=None
+        )
         if path:
             info["available"] = True
             info["path"] = path
             info["version"] = _probe_version(binary)
         results[name] = info
     return results
+
+
+def select_sandbox(
+    preference: tuple[str, ...] = ("isolate", "nsjail", "runsc"),
+    info: Optional[Dict[str, SandboxInfo]] = None,
+) -> tuple[Optional[str], Optional[SandboxInfo]]:
+    """Choose the first available sandbox from ``preference``.
+
+    Phase 0 compares multiple sandbox backends to decide on a default
+    runner.  This helper inspects the detection results and returns the
+    first backend that is marked as available.  If none of the preferred
+    sandboxes are present, ``(None, None)`` is returned.
+
+    Parameters
+    ----------
+    preference:
+        Tuple of sandbox names in descending priority order.
+    info:
+        Optional precomputed result from :func:`detect_sandboxes` to
+        avoid duplicate probes.
+
+    Returns
+    -------
+    (name, info):
+        ``name`` is the selected sandbox identifier or ``None`` if none
+        are available.  ``info`` is the corresponding
+        :class:`SandboxInfo` entry from ``info``.
+    """
+
+    if info is None:
+        info = detect_sandboxes()
+    for name in preference:
+        details = info.get(name)
+        if details and details.get("available"):
+            return name, details
+    return None, None

--- a/scripts/env_probe.py
+++ b/scripts/env_probe.py
@@ -26,9 +26,12 @@ from runners import sandbox_detector, toolchain_detector  # noqa: E402
 
 def build_report() -> Dict[str, Any]:
     """Collect sandbox and toolchain availability information."""
+    sandboxes = sandbox_detector.detect_sandboxes()
+    selected, _ = sandbox_detector.select_sandbox(info=sandboxes)
     return {
         "python": platform.python_version(),
-        "sandboxes": sandbox_detector.detect_sandboxes(),
+        "sandboxes": sandboxes,
+        "default_sandbox": selected,
         "toolchains": toolchain_detector.detect_toolchains(),
     }
 

--- a/tests/test_env_probe.py
+++ b/tests/test_env_probe.py
@@ -19,3 +19,4 @@ def test_env_probe_outputs_json(tmp_path):
     assert "sandboxes" in data
     assert "toolchains" in data
     assert "python" in data
+    assert "default_sandbox" in data

--- a/tests/test_sandbox_detector.py
+++ b/tests/test_sandbox_detector.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from runners import sandbox_detector
+from runners import sandbox_detector  # noqa: E402
 
 
 def test_detect_sandboxes_all_missing(monkeypatch):
@@ -26,3 +26,31 @@ def test_detect_sandboxes_reports_version(monkeypatch):
     result = sandbox_detector.detect_sandboxes()
     assert all(info["available"] for info in result.values())
     assert all(info["version"].endswith("1.2") for info in result.values())
+
+
+def test_select_sandbox_prefers_first_available(monkeypatch):
+    def fake_detect():
+        return {
+            "isolate": {"available": False},
+            "nsjail": {"available": True},
+            "runsc": {"available": True},
+        }
+
+    monkeypatch.setattr(sandbox_detector, "detect_sandboxes", fake_detect)
+    name, info = sandbox_detector.select_sandbox()
+    assert name == "nsjail"
+    assert info["available"]
+
+
+def test_select_sandbox_returns_none_when_missing(monkeypatch):
+    monkeypatch.setattr(
+        sandbox_detector,
+        "detect_sandboxes",
+        lambda: {
+            "isolate": {"available": False},
+            "nsjail": {"available": False},
+            "runsc": {"available": False},
+        },
+    )
+    name, info = sandbox_detector.select_sandbox()
+    assert name is None and info is None


### PR DESCRIPTION
## Summary
- choose a default sandbox backend based on availability
- expose selected sandbox in env_probe report
- document Phase 0 sandbox progress

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md runners/sandbox_detector.py scripts/env_probe.py tests/test_sandbox_detector.py tests/test_env_probe.py`
- `pytest tests/test_sandbox_detector.py tests/test_toolchain_detector.py tests/test_env_probe.py`


------
https://chatgpt.com/codex/tasks/task_e_68a08cab0fd083318c4bc8d231c09e55