### PR TITLE
chore: extend runner config for resources

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -29,6 +29,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
     [~] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
     [~] Define Hydra config schema and default configs under conf/
+        - Added CPU and memory limit options to runner config defaults
     [?] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [X] Implement environment pinning and seed/tz/locale normalization module
     [X] Add minimal CMake build helper for C++ harnesses

--- a/hrm_coder/conf/runner/default.yaml
+++ b/hrm_coder/conf/runner/default.yaml
@@ -1,3 +1,5 @@
 compiler: g++
 sandbox: nsjail
 timeout: 5
+memory_limit: 256
+cpus: 1

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -43,6 +43,8 @@ class RunnerConfig:
     compiler: str = "g++"
     sandbox: str = "nsjail"
     timeout: int = 5
+    memory_limit: int = 256  # in megabytes
+    cpus: int = 1
 
 
 @dataclass

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -7,6 +7,8 @@ def test_load_config_defaults():
     assert cfg.dataset.name == "humaneval-cpp"
     assert cfg.runner.compiler == "g++"
     assert cfg.runner.timeout == 5
+    assert cfg.runner.memory_limit == 256
+    assert cfg.runner.cpus == 1
     assert cfg.acceptance.pass_at_1 == 0.5
     assert cfg.acceptance.max_timeout_rate == 0.05
     assert cfg.training.baseline_coef == 0.5
@@ -19,6 +21,8 @@ def test_load_config_override():
     cfg = load_config([
         "model.learning_rate=0.01",
         "runner.timeout=10",
+        "runner.memory_limit=512",
+        "runner.cpus=2",
         "acceptance.pass_at_1=0.9",
         "training.baseline_coef=0.7",
         "training.curriculum_stage=hidden",
@@ -26,6 +30,8 @@ def test_load_config_override():
     ])
     assert cfg.model.learning_rate == 0.01
     assert cfg.runner.timeout == 10
+    assert cfg.runner.memory_limit == 512
+    assert cfg.runner.cpus == 2
     assert cfg.acceptance.pass_at_1 == 0.9
     assert cfg.training.baseline_coef == 0.7
     assert cfg.training.curriculum_stage == "hidden"


### PR DESCRIPTION
## Summary
- extend RunnerConfig with `memory_limit` and `cpus`
- document resource fields in runner defaults
- test config overrides for new runner options

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md hrm_coder/conf/runner/default.yaml hrm_coder/config.py hrm_coder/tests/test_config.py`
- `pytest hrm_coder/tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a08cb015c08331a53fee0cd71aa0a1