### PR TITLE
feat: orchestrate dataset builds from catalog

### DIFF
--- a/dataset/build_from_catalog.py
+++ b/dataset/build_from_catalog.py
@@ -1,0 +1,104 @@
+"""Dataset build orchestration from a catalog.
+
+This utility reads a dataset catalog JSON file and invokes the
+appropriate builder for each listed dataset.  It optionally verifies
+deterministic outputs and records hashes in a versions file, which
+helps progress Phase 3's reproducible dataset pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Dict
+
+from .build_atcoder_abc_dataset import build_dataset as build_atcoder
+from .build_codeforces_intro_dataset import build_dataset as build_codeforces
+from .build_humaneval_cpp_dataset import build_dataset as build_humaneval
+from .determinism import validate_build_determinism
+
+# Map human-friendly dataset names to their builder functions.
+BUILDERS: Dict[str, Callable[[str, str, int, str | None], None]] = {
+    "HumanEval-CPP": build_humaneval,
+    "Codeforces-Intro": build_codeforces,
+    "AtCoder-ABC": build_atcoder,
+}
+
+
+def build_from_catalog(
+    catalog_path: str,
+    output_root: str,
+    versions_file: str,
+    *,
+    seed: int = 0,
+    check_determinism: bool = True,
+) -> None:
+    """Build datasets listed in *catalog_path* into *output_root*.
+
+    Parameters
+    ----------
+    catalog_path:
+        Path to a JSON file following the format of ``docs/dataset_catalog.json``.
+    output_root:
+        Directory where processed datasets will be written. One subdirectory per
+        dataset name is created.
+    versions_file:
+        Path to ``versions.yml`` where dataset hashes are recorded.
+    seed:
+        Random seed forwarded to each builder.
+    check_determinism:
+        If ``True``, the builder is run twice in temporary directories to
+        confirm deterministic outputs before writing to ``output_root``.
+    """
+
+    catalog = json.loads(Path(catalog_path).read_text())
+    out_root = Path(output_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    for entry in catalog:
+        name = entry.get("name")
+        raw_path = entry.get("path")
+        build_fn = BUILDERS.get(name)
+
+        if not build_fn or raw_path is None:
+            # Unknown dataset or missing path; skip silently for now.
+            continue
+
+        dataset_dir = out_root / name
+
+        if check_determinism:
+            validate_build_determinism(
+                lambda rp, od, sd: build_fn(rp, od, sd), raw_path, seed=seed
+            )
+
+        build_fn(raw_path, str(dataset_dir), seed=seed, versions_path=versions_file)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI wrapper
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Build one or more datasets defined in a catalog"
+    )
+    parser.add_argument("catalog", help="Path to dataset_catalog.json")
+    parser.add_argument(
+        "output_root", help="Directory to write processed datasets into"
+    )
+    parser.add_argument(
+        "--versions", required=True, help="Path to versions.yml for hash locking"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for splits")
+    parser.add_argument(
+        "--no-check", action="store_true", help="Skip deterministic build check"
+    )
+
+    args = parser.parse_args()
+
+    build_from_catalog(
+        args.catalog,
+        args.output_root,
+        args.versions,
+        seed=args.seed,
+        check_determinism=not args.no_check,
+    )
+

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -48,7 +48,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement Codeforces-Intro builder (I/O testcases, constraints, per-problem time limits)
     [~] Implement AtCoder ABC subset builder with normalized input/output cases
     [X] Write determinism validator to re-run and hash equality of artifacts
-    [ ] Integrate DVC pipelines and data/versions.yml locking
+    [~] Integrate DVC pipelines and data/versions.yml locking
     [X] Add dataset schema contracts and unit tests for loaders
     [X] Implement dataset split manager for train/val/test with fixed seeds
 

--- a/tests/test_build_from_catalog.py
+++ b/tests/test_build_from_catalog.py
@@ -1,0 +1,54 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from dataset.build_from_catalog import build_from_catalog  # noqa: E402
+
+
+def _write_sample_humaneval(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "task1",
+            "prompt": "int add(int a,int b){return a+b;}\n",
+            "test": "#include <cassert>\nint main(){assert(add(1,2)==3);}\n",
+        },
+        {
+            "task_id": "task2",
+            "prompt": "int sub(int a,int b){return a-b;}\n",
+            "test": "#include <cassert>\nint main(){assert(sub(3,1)==2);}\n",
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_build_from_catalog(tmp_path):
+    raw = tmp_path / "humaneval.jsonl"
+    _write_sample_humaneval(raw)
+
+    catalog = [
+        {
+            "name": "HumanEval-CPP",
+            "license": "MIT",
+            "path": str(raw),
+            "sha256": "TBD",
+        }
+    ]
+
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(json.dumps(catalog))
+
+    out_dir = tmp_path / "out"
+    versions_file = tmp_path / "versions.yml"
+
+    build_from_catalog(str(catalog_path), str(out_dir), str(versions_file), seed=0)
+
+    # Dataset directory should exist with train split populated
+    assert (out_dir / "HumanEval-CPP" / "train").exists()
+
+    data = json.loads(versions_file.read_text())
+    assert "humaneval_cpp" in data
+


### PR DESCRIPTION
## Summary
- add build_from_catalog utility to orchestrate dataset builders and version locking
- mark progress on dataset versioning in Phase 3 checklist
- test catalog builder on sample HumanEval-CPP dataset

## Testing
- `pytest tests/test_build_from_catalog.py tests/test_dataset_determinism.py tests/test_build_dataset_version_lock.py tests/test_build_codeforces_intro_dataset.py tests/test_build_atcoder_abc_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68a08cb56b148331b93e47d2a8582a2b