### PR TITLE
feat: add ablation job config and CLI

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -101,7 +101,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Define edit action space for insert, replace, and delete operations
     [?] Implement cursor policy module for region selection by HRM high-level
     [X] Implement decoder constraint checker to avoid invalid AST states
-    [~] Add ablation job configs and comparison report against token baseline
+    [X] Add ablation job configs and comparison report against token baseline
 
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)
     [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing

--- a/hrm_coder/ablation_cli.py
+++ b/hrm_coder/ablation_cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""CLI entry point for generating ablation comparison reports.
+
+This small utility loads its configuration from ``conf/ablation/default.yaml``
+using :mod:`omegaconf`.  Paths can be overridden on the command line using
+``key=value`` arguments.
+"""
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from omegaconf import OmegaConf
+
+from .ablation import generate_ablation_report
+
+
+@dataclass
+class AblationConfig:
+    """Configuration for an ablation comparison job."""
+
+    current_metrics: str
+    baseline_metrics: str
+    output_report: str
+
+
+def load_ablation_config(overrides: Sequence[str] | None = None) -> AblationConfig:
+    """Load ablation configuration from YAML and apply overrides."""
+
+    config_path = Path(__file__).parent / "conf" / "ablation" / "default.yaml"
+    cfg = OmegaConf.load(config_path)
+    if overrides:
+        override_cfg = OmegaConf.from_dotlist(list(overrides))
+        cfg = OmegaConf.merge(cfg, override_cfg)
+    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+    return AblationConfig(**cfg_dict)  # type: ignore[arg-type]
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Generate an ablation report using Hydra-style overrides."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        help="Hydra-style overrides, e.g. current_metrics=path/to.json",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    cfg = load_ablation_config(args.overrides)
+    generate_ablation_report(
+        cfg.current_metrics, cfg.baseline_metrics, cfg.output_report
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/hrm_coder/conf/ablation/default.yaml
+++ b/hrm_coder/conf/ablation/default.yaml
@@ -1,0 +1,3 @@
+current_metrics: current.json
+baseline_metrics: baseline.json
+output_report: report.json

--- a/tests/test_ablation_cli.py
+++ b/tests/test_ablation_cli.py
@@ -1,0 +1,31 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+from hrm_coder.ablation_cli import main  # noqa: E402
+
+
+def test_ablation_cli_generates_report(tmp_path: Path) -> None:
+    baseline = {"pass@1": 0.4}
+    current = {"pass@1": 0.6}
+    baseline_file = tmp_path / "baseline.json"
+    current_file = tmp_path / "current.json"
+    report_file = tmp_path / "report.json"
+    baseline_file.write_text(json.dumps(baseline))
+    current_file.write_text(json.dumps(current))
+
+    main(
+        [
+            f"current_metrics={current_file}",
+            f"baseline_metrics={baseline_file}",
+            f"output_report={report_file}",
+        ]
+    )
+
+    assert report_file.exists()
+    data = json.loads(report_file.read_text())
+    assert data["pass@1"]["delta"] == pytest.approx(0.2)
+


### PR DESCRIPTION
## Summary
- add OmegaConf-based ablation CLI for comparing runs
- provide default ablation job configuration
- test CLI and update phase 9 checklist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08cce3f748331a19157956b3f1a4b