### PR TITLE
Handle lcov unused exclude error in coverage workflow

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           if [ -d build ]; then
             lcov --capture --directory build --output-file coverage.info
-            lcov --remove coverage.info '/usr/*' --output-file coverage.info
+            lcov --remove coverage.info '/usr/*' --output-file coverage.info --ignore-errors unused
             genhtml coverage.info --output-directory coverage_html
           else
             echo "No coverage generated."

--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           if [ -d build ]; then
             lcov --capture --directory build --output-file coverage.info
-            lcov --remove coverage.info '/usr/*' --output-file coverage.info
+            lcov --remove coverage.info '/usr/*' --output-file coverage.info --ignore-errors unused
             genhtml coverage.info --output-directory coverage_html
           else
             echo "No coverage generated."


### PR DESCRIPTION
## Summary
- prevent lcov from failing when '/usr/*' exclude pattern matches nothing

## Testing
- `pre-commit run --files .github/workflows/cpp-ci.yml .github/workflows/nightly-eval.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a091c94ff08331a2029efb391d2928