### PR TITLE
Add dataset catalog validation utility with tests

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -19,6 +19,7 @@ Save new code files in: C:\repos\hrm-coder
         - Added default sandbox selection helper to prefer isolate and fall back to nsjail or runsc
         - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
+        - Added dataset catalog utility with hash validation and unit tests
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
     [~] Draft sandbox Threat Model and initial security requirements for native binaries
     [~] Write ADRs for sandbox choice, experiment tracker, and GUI stack

--- a/scripts/dataset_catalog.py
+++ b/scripts/dataset_catalog.py
@@ -7,10 +7,11 @@ written to ``docs/dataset_catalog.json`` to support Phase 0 tracking.
 """
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 DATASETS = [
     {"name": "Codeforces-Intro", "path": Path("dataset/raw-data/codeforces_intro"), "license": "TBD"},
@@ -54,11 +55,39 @@ def build_catalog() -> List[Dict[str, Any]]:
     return catalog
 
 
+def validate_catalog(catalog: Iterable[Dict[str, Any]]) -> List[str]:
+    """Return names of datasets with missing files or mismatched hashes."""
+    problems: List[str] = []
+    for entry in catalog:
+        path = Path(entry["path"])
+        expected = entry.get("sha256")
+        actual = sha256_of_path(path)
+        if actual is None or (expected not in {actual, "TBD"}):
+            problems.append(entry["name"])
+    return problems
+
+
 def main() -> None:
-    catalog = build_catalog()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate existing catalog instead of rebuilding",
+    )
+    args = parser.parse_args()
+
     out_path = Path("docs/dataset_catalog.json")
-    out_path.write_text(json.dumps(catalog, indent=2) + "\n")
-    print(f"Wrote {out_path}")
+    if args.check:
+        catalog = json.loads(out_path.read_text())
+        problems = validate_catalog(catalog)
+        if problems:
+            print("Missing or mismatched datasets:", ", ".join(problems))
+            raise SystemExit(1)
+        print("Catalog OK")
+    else:
+        catalog = build_catalog()
+        out_path.write_text(json.dumps(catalog, indent=2) + "\n")
+        print(f"Wrote {out_path}")
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset_catalog_script.py
+++ b/tests/test_dataset_catalog_script.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import hashlib
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from scripts import dataset_catalog  # noqa: E402
+
+
+def test_sha256_of_path_file(tmp_path):
+    sample = tmp_path / "sample.txt"
+    sample.write_text("hello")
+    expected = hashlib.sha256(b"hello").hexdigest()
+    assert dataset_catalog.sha256_of_path(sample) == expected
+
+
+def test_sha256_of_path_directory(tmp_path):
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    (directory / "a.txt").write_text("a")
+    (directory / "b.txt").write_text("b")
+    expected = hashlib.sha256()
+    for file_path in sorted(p for p in directory.rglob("*") if p.is_file()):
+        expected.update(file_path.relative_to(directory).as_posix().encode())
+        expected.update(file_path.read_bytes())
+    assert dataset_catalog.sha256_of_path(directory) == expected.hexdigest()
+
+
+def test_build_catalog_with_custom_dataset(monkeypatch, tmp_path):
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("data")
+    sha = hashlib.sha256(b"data").hexdigest()
+    monkeypatch.setattr(
+        dataset_catalog,
+        "DATASETS",
+        [{"name": "tmp", "path": data_file, "license": "MIT"}],
+    )
+    catalog = dataset_catalog.build_catalog()
+    assert catalog == [
+        {
+            "name": "tmp",
+            "license": "MIT",
+            "path": str(data_file),
+            "sha256": sha,
+        }
+    ]
+
+
+def test_validate_catalog_flags_mismatch(monkeypatch, tmp_path):
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("data")
+    sha = hashlib.sha256(b"data").hexdigest()
+    catalog = [
+        {
+            "name": "tmp",
+            "license": "MIT",
+            "path": str(data_file),
+            "sha256": sha,
+        }
+    ]
+    catalog[0]["sha256"] = "bad"
+    problems = dataset_catalog.validate_catalog(catalog)
+    assert problems == ["tmp"]


### PR DESCRIPTION
## Summary
- Extend dataset catalog script with hash validation and a `--check` mode
- Note dataset catalog progress in Phase 0 checklist
- Add unit tests covering dataset catalog hashing and validation

## Testing
- `pytest tests/test_dataset_catalog_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09246860c83319a1626586a9ff3e5