### PR TITLE
feat: auto-select sandbox for runner

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -17,6 +17,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
         - Added sandbox detection utility for isolate, nsjail, and gVisor runsc runtime
         - Added default sandbox selection helper to prefer isolate and fall back to nsjail or runsc
+        - Integrated sandbox auto-selection into runner configuration
         - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)

--- a/hrm_coder/conf/runner/default.yaml
+++ b/hrm_coder/conf/runner/default.yaml
@@ -1,5 +1,5 @@
 compiler: g++
-sandbox: nsjail
+sandbox: auto
 timeout: 5
 memory_limit: 256
 cpus: 1

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -8,6 +8,8 @@ from typing import Sequence
 from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
 
+from runners import sandbox_detector
+
 
 @dataclass
 class ModelConfig:
@@ -38,10 +40,15 @@ class RunnerConfig:
     These defaults are intentionally lightweight but provide a
     foundation for Phase 1 deterministic execution. They will be
     expanded in later phases to cover additional runner options.
+
+    ``sandbox`` supports the special value ``"auto"`` which selects the
+    first available backend from :mod:`runners.sandbox_detector` in the
+    order ``isolate`` → ``nsjail`` → ``runsc``. When no sandbox is
+    detected the value ``"none"`` is used.
     """
 
     compiler: str = "g++"
-    sandbox: str = "nsjail"
+    sandbox: str = "auto"
     timeout: int = 5
     memory_limit: int = 256  # in megabytes
     cpus: int = 1
@@ -96,10 +103,16 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
             overrides=list(overrides) if overrides else [],
         )
     cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+
+    runner_cfg = RunnerConfig(**cfg_dict["runner"])
+    if runner_cfg.sandbox == "auto":
+        selected, _ = sandbox_detector.select_sandbox()
+        runner_cfg.sandbox = selected or "none"
+
     return AppConfig(
         model=ModelConfig(**cfg_dict["model"]),
         dataset=DatasetConfig(**cfg_dict["dataset"]),
-        runner=RunnerConfig(**cfg_dict["runner"]),
+        runner=runner_cfg,
         acceptance=AcceptanceConfig(**cfg_dict["acceptance"]),
         training=TrainingConfig(**cfg_dict["training"]),
         environment=EnvironmentConfig(**cfg_dict["environment"]),

--- a/tests/test_config_auto_sandbox.py
+++ b/tests/test_config_auto_sandbox.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+from hrm_coder import config as cfg  # noqa: E402
+from runners import sandbox_detector  # noqa: E402
+
+
+def test_load_config_auto_selects_available(monkeypatch):
+    monkeypatch.setattr(
+        sandbox_detector,
+        "select_sandbox",
+        lambda info=None, preference=("isolate", "nsjail", "runsc"): ("isolate", {}),
+    )
+    conf = cfg.load_config(overrides=["runner.sandbox=auto"])
+    assert conf.runner.sandbox == "isolate"
+
+
+def test_load_config_auto_handles_missing(monkeypatch):
+    monkeypatch.setattr(
+        sandbox_detector,
+        "select_sandbox",
+        lambda info=None, preference=("isolate", "nsjail", "runsc"): (None, None),
+    )
+    conf = cfg.load_config(overrides=["runner.sandbox=auto"])
+    assert conf.runner.sandbox == "none"
+


### PR DESCRIPTION
## Summary
- default sandbox resolves dynamically using new detection helper
- document Phase 0 progress for sandbox integration
- add tests covering automatic sandbox selection

## Testing
- `pytest tests/test_config_auto_sandbox.py tests/test_sandbox_detector.py tests/test_toolchain_detector.py tests/test_env_probe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09246860c83319a1626586a9ff3e5