### PR TITLE
feat: add sandbox runner factory

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -31,6 +31,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
+        - Added helper to instantiate sandbox runners from configuration
     [?] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [X] Implement environment pinning and seed/tz/locale normalization module
     [X] Add minimal CMake build helper for C++ harnesses

--- a/hrm_coder/runner.py
+++ b/hrm_coder/runner.py
@@ -1,0 +1,64 @@
+"""Utilities to construct sandbox runners from configuration."""
+from __future__ import annotations
+
+from typing import List, Optional
+import subprocess
+
+from runners import GVisorRunner, IsolateRunner, NSJailRunner, sandbox_detector
+from .config import RunnerConfig
+
+
+def create_sandbox_runner(config: RunnerConfig) -> object:
+    """Instantiate the sandbox runner specified by ``config``.
+
+    When ``config.sandbox`` is set to ``"auto"`` the function probes the
+    environment and picks the first available backend in the order
+    ``isolate`` → ``nsjail`` → ``runsc``.
+    """
+
+    sandbox = config.sandbox
+    if sandbox in ("auto", ""):  # auto-select
+        selected, _ = sandbox_detector.select_sandbox()
+        if selected is None:
+            raise RuntimeError("no supported sandbox available")
+        sandbox = selected
+    if sandbox == "isolate":
+        return IsolateRunner()
+    if sandbox == "nsjail":
+        return NSJailRunner()
+    if sandbox in {"runsc", "gvisor"}:
+        return GVisorRunner()
+    raise ValueError(f"unsupported sandbox: {sandbox}")
+
+
+def run_in_sandbox(
+    command: List[str],
+    config: RunnerConfig,
+    *,
+    network: bool = False,
+    stdin: Optional[bytes] = None,
+) -> subprocess.CompletedProcess:
+    """Execute ``command`` inside the sandbox described by ``config``."""
+
+    runner = create_sandbox_runner(config)
+    memory_kb = config.memory_limit * 1024
+    common_kwargs = dict(
+        time_limit=config.timeout,
+        wall_time=config.timeout,
+        memory=memory_kb,
+        processes=config.cpus,
+        network=network,
+        stdin=stdin,
+    )
+    if isinstance(runner, IsolateRunner):
+        return runner.run(command, **common_kwargs)
+    if isinstance(runner, NSJailRunner):
+        return runner.run(command, **common_kwargs)
+    if isinstance(runner, GVisorRunner):
+        # gVisor's runner does not support wall_time; ignore it
+        common_kwargs.pop("wall_time", None)
+        return runner.run(command, **common_kwargs)
+    raise TypeError(f"Unsupported runner type: {type(runner).__name__}")
+
+
+__all__ = ["create_sandbox_runner", "run_in_sandbox"]

--- a/hrm_coder/tests/test_runner_utils.py
+++ b/hrm_coder/tests/test_runner_utils.py
@@ -1,0 +1,39 @@
+import subprocess
+
+from hrm_coder.config import RunnerConfig
+from hrm_coder.runner import create_sandbox_runner, run_in_sandbox
+from runners import IsolateRunner, NSJailRunner, sandbox_detector
+
+
+def test_create_sandbox_runner_explicit():
+    cfg = RunnerConfig(sandbox="isolate")
+    runner = create_sandbox_runner(cfg)
+    assert isinstance(runner, IsolateRunner)
+
+
+def test_create_sandbox_runner_auto(monkeypatch):
+    cfg = RunnerConfig(sandbox="auto")
+
+    def _fake_select():
+        return "nsjail", {}
+
+    monkeypatch.setattr(sandbox_detector, "select_sandbox", _fake_select)
+    runner = create_sandbox_runner(cfg)
+    assert isinstance(runner, NSJailRunner)
+
+
+def test_run_in_sandbox_passes_limits(monkeypatch):
+    cfg = RunnerConfig(sandbox="isolate", timeout=3, memory_limit=128, cpus=2)
+
+    called = {}
+
+    def fake_run(self, command, **kwargs):
+        called.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(IsolateRunner, "run", fake_run)
+    run_in_sandbox(["/bin/true"], cfg)
+    assert called["time_limit"] == 3
+    assert called["wall_time"] == 3
+    assert called["memory"] == 128 * 1024
+    assert called["processes"] == 2

--- a/runners/__init__.py
+++ b/runners/__init__.py
@@ -5,6 +5,7 @@ from .io_judge import run_io_tests
 from .isolate import IsolateRunner
 from .nsjail import NSJailRunner
 from .error_taxonomy import classify_compile, classify_runtime
+from . import sandbox_detector
 
 __all__ = [
     "GVisorRunner",
@@ -13,4 +14,5 @@ __all__ = [
     "classify_compile",
     "classify_runtime",
     "run_io_tests",
+    "sandbox_detector",
 ]


### PR DESCRIPTION
## Summary
- add `create_sandbox_runner` and `run_in_sandbox` helpers to instantiate and execute sandbox backends from configuration
- expose `sandbox_detector` via runners package
- track runner factory progress in Phase 1 checklist

## Testing
- `pre-commit run --files hrm_coder/runner.py runners/__init__.py docs/hrmCoder_checklist.md hrm_coder/tests/test_runner_utils.py`
- `pytest hrm_coder/tests/test_runner_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0924e26c48331936ff30c55e03779