### PR TITLE
Add Kattis micro dataset builder and loader

### DIFF
--- a/dataset/build_from_catalog.py
+++ b/dataset/build_from_catalog.py
@@ -15,6 +15,7 @@ from typing import Callable, Dict
 from .build_atcoder_abc_dataset import build_dataset as build_atcoder
 from .build_codeforces_intro_dataset import build_dataset as build_codeforces
 from .build_humaneval_cpp_dataset import build_dataset as build_humaneval
+from .build_kattis_micro_dataset import build_dataset as build_kattis
 from .determinism import validate_build_determinism
 
 # Map human-friendly dataset names to their builder functions.
@@ -22,6 +23,7 @@ BUILDERS: Dict[str, Callable[[str, str, int, str | None], None]] = {
     "HumanEval-CPP": build_humaneval,
     "Codeforces-Intro": build_codeforces,
     "AtCoder-ABC": build_atcoder,
+    "Kattis-micro": build_kattis,
 }
 
 
@@ -38,17 +40,18 @@ def build_from_catalog(
     Parameters
     ----------
     catalog_path:
-        Path to a JSON file following the format of ``docs/dataset_catalog.json``.
+        Path to a JSON file following the format of
+        ``docs/dataset_catalog.json``.
     output_root:
-        Directory where processed datasets will be written. One subdirectory per
-        dataset name is created.
+        Directory where processed datasets will be written. One
+        subdirectory per dataset name is created.
     versions_file:
         Path to ``versions.yml`` where dataset hashes are recorded.
     seed:
         Random seed forwarded to each builder.
     check_determinism:
-        If ``True``, the builder is run twice in temporary directories to
-        confirm deterministic outputs before writing to ``output_root``.
+        If ``True``, the builder is run twice in temporary directories
+        to confirm deterministic outputs before writing to ``output_root``.
     """
 
     catalog = json.loads(Path(catalog_path).read_text())
@@ -71,7 +74,12 @@ def build_from_catalog(
                 lambda rp, od, sd: build_fn(rp, od, sd), raw_path, seed=seed
             )
 
-        build_fn(raw_path, str(dataset_dir), seed=seed, versions_path=versions_file)
+        build_fn(
+            raw_path,
+            str(dataset_dir),
+            seed=seed,
+            versions_path=versions_file,
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI wrapper
@@ -85,11 +93,17 @@ if __name__ == "__main__":  # pragma: no cover - CLI wrapper
         "output_root", help="Directory to write processed datasets into"
     )
     parser.add_argument(
-        "--versions", required=True, help="Path to versions.yml for hash locking"
+        "--versions",
+        required=True,
+        help="Path to versions.yml for hash locking",
     )
-    parser.add_argument("--seed", type=int, default=0, help="Random seed for splits")
     parser.add_argument(
-        "--no-check", action="store_true", help="Skip deterministic build check"
+        "--seed", type=int, default=0, help="Random seed for splits"
+    )
+    parser.add_argument(
+        "--no-check",
+        action="store_true",
+        help="Skip deterministic build check",
     )
 
     args = parser.parse_args()
@@ -101,4 +115,3 @@ if __name__ == "__main__":  # pragma: no cover - CLI wrapper
         seed=args.seed,
         check_determinism=not args.no_check,
     )
-

--- a/dataset/build_kattis_micro_dataset.py
+++ b/dataset/build_kattis_micro_dataset.py
@@ -1,0 +1,131 @@
+"""Builder for the Kattis micro dataset.
+
+This builder expects a JSONL file where each line describes a single
+Kattis-style programming problem. Each record follows the
+:class:`dataset.schemas.KattisRecord` schema with fields:
+
+- ``task_id``: unique identifier for the problem
+- ``prompt``: textual description or starter code
+- ``tests``: list of input/output pairs
+- ``time_limit_ms``: optional time limit in milliseconds (default 2000)
+- ``memory_limit_kb``: optional memory limit in kilobytes (default 256000)
+
+The script splits tasks deterministically into train/val/test subsets and
+writes each task to ``output_dir/<split>/<task_id>/``. The directory layout
+mirrors the Codeforces and AtCoder builders so downstream tools can reuse the
+same I/O judging infrastructure.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import List
+
+from .schemas import KattisRecord
+from .split_manager import split_list
+from .version_lock import update_version
+
+
+@dataclass
+class IOPair:
+    input: str
+    output: str
+
+
+@dataclass
+class KattisTask:
+    task_id: str
+    prompt: str
+    tests: List[IOPair]
+    time_limit_ms: int = 2000
+    memory_limit_kb: int = 256000
+
+
+def load_tasks(path: Path) -> List[KattisTask]:
+    """Load tasks from a JSONL file using :class:`KattisRecord`."""
+
+    tasks: List[KattisTask] = []
+    with path.open() as fh:
+        for line in fh:
+            record = KattisRecord.model_validate_json(line)
+            tests = [
+                IOPair(input=io.input, output=io.output) for io in record.tests
+            ]
+            tasks.append(
+                KattisTask(
+                    task_id=record.task_id,
+                    prompt=record.prompt,
+                    tests=tests,
+                    time_limit_ms=record.time_limit_ms,
+                    memory_limit_kb=record.memory_limit_kb,
+                )
+            )
+    return tasks
+
+
+def write_task(task: KattisTask, dest: Path) -> None:
+    """Write ``task`` into ``dest`` directory."""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "prompt.txt").write_text(task.prompt)
+
+    tests_dir = dest / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    for idx, io in enumerate(task.tests):
+        (tests_dir / f"{idx}.in").write_text(io.input)
+        (tests_dir / f"{idx}.out").write_text(io.output)
+
+    meta = {
+        "time_limit_ms": task.time_limit_ms,
+        "memory_limit_kb": task.memory_limit_kb,
+    }
+    (dest / "meta.json").write_text(json.dumps(meta))
+
+
+DATASET_NAME = "kattis_micro"
+
+
+def build_dataset(
+    raw_path: str,
+    output_dir: str,
+    seed: int = 0,
+    versions_path: str | None = None,
+) -> None:
+    """Entry point for converting raw Kattis data into structured tasks."""
+    tasks = load_tasks(Path(raw_path))
+    splits = split_list(tasks, seed)
+
+    out_dir = Path(output_dir)
+    for split_name, subset in splits.items():
+        for task in subset:
+            write_task(task, out_dir / split_name / task.task_id)
+
+    if versions_path is not None:
+        update_version(DATASET_NAME, str(out_dir), versions_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI wrapper
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Build Kattis micro dataset"
+    )
+    parser.add_argument("raw_path", help="Path to raw JSONL dataset")
+    parser.add_argument(
+        "output_dir",
+        help="Output directory for processed dataset",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Random seed for splits"
+    )
+    parser.add_argument(
+        "--versions", help="Path to versions.yml for hash locking"
+    )
+    args = parser.parse_args()
+
+    build_dataset(
+        args.raw_path,
+        args.output_dir,
+        seed=args.seed,
+        versions_path=args.versions,
+    )

--- a/dataset/kattis_micro_loader.py
+++ b/dataset/kattis_micro_loader.py
@@ -1,0 +1,85 @@
+"""Loader for the processed Kattis micro dataset.
+
+This module reads a dataset directory produced by
+``build_kattis_micro_dataset.py`` and returns structured objects for each
+task.  It validates required files and uses ``pydantic`` models to enforce the
+schema.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+
+class IOPair(BaseModel):
+    """Container for a single input/output example."""
+
+    input: str
+    output: str
+
+
+class KattisRecord(BaseModel):
+    """Represents one Kattis micro task."""
+
+    task_id: str
+    prompt: str
+    tests: List[IOPair]
+    time_limit_ms: int
+    memory_limit_kb: int
+    split: str
+
+
+def _load_task(task_dir: Path, split: str) -> KattisRecord:
+    """Load a single task from ``task_dir``."""
+    prompt_path = task_dir / "prompt.txt"
+    tests_dir = task_dir / "tests"
+    meta_path = task_dir / "meta.json"
+    missing = [
+        p.name for p in [prompt_path, tests_dir, meta_path] if not p.exists()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"Missing required paths in {task_dir}: {', '.join(missing)}"
+        )
+
+    prompt = prompt_path.read_text()
+    meta = json.loads(meta_path.read_text())
+
+    tests: List[IOPair] = []
+    for in_file in sorted(tests_dir.glob("*.in")):
+        out_file = in_file.with_suffix(".out")
+        if not out_file.exists():
+            raise FileNotFoundError(f"Missing expected output file {out_file}")
+        tests.append(
+            IOPair(input=in_file.read_text(), output=out_file.read_text())
+        )
+
+    return KattisRecord(
+        task_id=task_dir.name,
+        prompt=prompt,
+        tests=tests,
+        time_limit_ms=meta.get("time_limit_ms", 2000),
+        memory_limit_kb=meta.get("memory_limit_kb", 256000),
+        split=split,
+    )
+
+
+def load_dataset(root: str | Path) -> Dict[str, List[KattisRecord]]:
+    """Load all tasks from a processed Kattis micro dataset."""
+    root_path = Path(root)
+    splits: Dict[str, List[KattisRecord]] = {
+        "train": [],
+        "val": [],
+        "test": [],
+    }
+    for split in splits:
+        split_dir = root_path / split
+        if not split_dir.exists():
+            continue
+        for task_dir in sorted(p for p in split_dir.iterdir() if p.is_dir()):
+            record = _load_task(task_dir, split)
+            splits[split].append(record)
+    return splits

--- a/dataset/schemas.py
+++ b/dataset/schemas.py
@@ -46,3 +46,13 @@ class AtCoderRecord(BaseModel):
     tests: List[IOPairRecord]
     time_limit_ms: int = Field(default=2000, ge=1)
     memory_limit_kb: int = Field(default=102_400, ge=1)
+
+
+class KattisRecord(BaseModel):
+    """Schema for a Kattis micro dataset record."""
+
+    task_id: str
+    prompt: str
+    tests: List[IOPairRecord]
+    time_limit_ms: int = Field(default=2000, ge=1)
+    memory_limit_kb: int = Field(default=256_000, ge=1)

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -46,9 +46,10 @@ Save new code files in: C:\repos\hrm-coder
     [X] Expose coverage summary endpoint and display on run page
 
 ** [ ] Phase 3: Deterministic Dataset Pipeline (C++)
-    [~] Implement HumanEval-CPP builder with harness generator and reference solutions
-    [~] Implement Codeforces-Intro builder (I/O testcases, constraints, per-problem time limits)
-    [~] Implement AtCoder ABC subset builder with normalized input/output cases
+    [X] Implement HumanEval-CPP builder with harness generator and reference solutions
+    [X] Implement Codeforces-Intro builder (I/O testcases, constraints, per-problem time limits)
+    [X] Implement AtCoder ABC subset builder with normalized input/output cases
+    [X] Implement Kattis micro-set builder for additional I/O tasks
     [X] Write determinism validator to re-run and hash equality of artifacts
     [~] Integrate DVC pipelines and data/versions.yml locking
     [X] Add dataset schema contracts and unit tests for loaders

--- a/tests/test_build_kattis_micro_dataset.py
+++ b/tests/test_build_kattis_micro_dataset.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from dataset.build_kattis_micro_dataset import build_dataset  # noqa: E402
+from dataset.determinism import validate_build_determinism  # noqa: E402
+
+
+def _write_sample_dataset(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "kt1",
+            "prompt": "Echo input",
+            "tests": [{"input": "1\n", "output": "1\n"}],
+            "time_limit_ms": 1000,
+            "memory_limit_kb": 65536,
+        },
+        {
+            "task_id": "kt2",
+            "prompt": "Add numbers",
+            "tests": [{"input": "1 2\n", "output": "3\n"}],
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_kattis_micro_build_is_deterministic(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+
+    assert validate_build_determinism(build_dataset, str(raw), seed=123)

--- a/tests/test_kattis_micro_loader.py
+++ b/tests/test_kattis_micro_loader.py
@@ -1,0 +1,61 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from dataset.build_kattis_micro_dataset import build_dataset  # noqa: E402
+from dataset.kattis_micro_loader import (  # noqa: E402
+    KattisRecord,
+    load_dataset,
+)
+
+
+def _write_sample_dataset(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "kt1",
+            "prompt": "Echo input",
+            "tests": [{"input": "1\n", "output": "1\n"}],
+            "time_limit_ms": 1000,
+            "memory_limit_kb": 65536,
+        },
+        {
+            "task_id": "kt2",
+            "prompt": "Add numbers",
+            "tests": [{"input": "1 2\n", "output": "3\n"}],
+        },
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_loader_round_trip(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    splits = load_dataset(out_dir)
+    assert set(splits.keys()) == {"train", "val", "test"}
+    all_tasks = [t for tasks in splits.values() for t in tasks]
+    assert len(all_tasks) == 2
+    first = next(t for t in all_tasks if t.task_id == "kt1")
+    assert isinstance(first, KattisRecord)
+    assert first.tests[0].output.strip() == "1"
+
+
+def test_loader_missing_meta(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    _write_sample_dataset(raw)
+    out_dir = tmp_path / "out"
+    build_dataset(str(raw), str(out_dir), seed=0)
+
+    # remove meta.json from one task to trigger error
+    task_dir = next((out_dir / "train").iterdir())
+    (task_dir / "meta.json").unlink()
+    with pytest.raises(FileNotFoundError):
+        load_dataset(out_dir)


### PR DESCRIPTION
## Summary
- add builder and loader for Kattis micro dataset
- wire new dataset into catalog build orchestration and schemas
- mark dataset checklist items as complete

## Testing
- `python -m pre_commit run --files dataset/schemas.py dataset/build_kattis_micro_dataset.py dataset/kattis_micro_loader.py dataset/build_from_catalog.py docs/hrmCoder_checklist.md tests/test_build_kattis_micro_dataset.py tests/test_kattis_micro_loader.py`
- `pytest tests/test_build_kattis_micro_dataset.py tests/test_kattis_micro_loader.py tests/test_build_from_catalog.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09254f19c8331b3b6dc28becb7fbe