### PR TITLE
feat: extend nsjail adapter with fs policies

### DIFF
--- a/runners/nsjail.py
+++ b/runners/nsjail.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
-from typing import List, Optional, Mapping
+import tempfile
+from typing import Iterable, List, Mapping, Optional
 
 
 class SandboxError(RuntimeError):
@@ -28,7 +29,10 @@ class NSJailRunner:
         memory: int = 256 * 1024,
         processes: int = 1,
         network: bool = False,
+        workdir: Optional[str] = None,
+        readonly_dirs: Optional[Iterable[str]] = None,
         env: Optional[Mapping[str, str]] = None,
+        fsize: Optional[int] = None,
     ) -> List[str]:
         """Construct an ``nsjail`` invocation.
 
@@ -47,9 +51,17 @@ class NSJailRunner:
             Maximum number of processes.
         network:
             Allow network access if ``True``.
+        workdir:
+            Path inside the sandbox to use as the working directory. The
+            same host path is bind-mounted read-write.
+        readonly_dirs:
+            Optional collection of host directories to bind read-only inside
+            the sandbox.
         env:
             Optional mapping of environment variables to set inside the
             sandbox.
+        fsize:
+            Optional limit for files created by the process in bytes.
         """
         nsjail_cmd = [
             self.nsjail_path,
@@ -60,9 +72,16 @@ class NSJailRunner:
         ]
         if network:
             nsjail_cmd.append("--disable_clone_newnet")
+        if workdir is not None:
+            nsjail_cmd.extend(["--cwd", workdir, "--bindmount", f"{workdir}:{workdir}"])
+        if readonly_dirs is not None:
+            for path in readonly_dirs:
+                nsjail_cmd.extend(["--bindmount_ro", f"{path}:{path}"])
         if env is not None:
             for key, value in env.items():
                 nsjail_cmd.extend(["--env", f"{key}={value}"])
+        if fsize is not None:
+            nsjail_cmd.append(f"--rlimit_fsize={fsize}")
         nsjail_cmd.append("--")
         nsjail_cmd.extend(command)
         return nsjail_cmd
@@ -76,8 +95,12 @@ class NSJailRunner:
         memory: int = 256 * 1024,
         processes: int = 1,
         network: bool = False,
+        workdir: Optional[str] = None,
+        readonly_dirs: Optional[Iterable[str]] = None,
         stdin: Optional[bytes] = None,
         env: Optional[Mapping[str, str]] = None,
+        stdout_limit: Optional[int] = None,
+        stderr_limit: Optional[int] = None,
     ) -> subprocess.CompletedProcess:
         """Execute a command within ``nsjail``.
 
@@ -88,6 +111,15 @@ class NSJailRunner:
             raise SandboxError(
                 f"nsjail executable not found: {self.nsjail_path}"
             )
+
+        tmpdir_ctx: Optional[tempfile.TemporaryDirectory[str]] = None
+        if workdir is None:
+            tmpdir_ctx = tempfile.TemporaryDirectory()
+            workdir = tmpdir_ctx.name
+
+        max_limit = max(stdout_limit or 0, stderr_limit or 0)
+        fsize = max_limit if max_limit else None
+
         cmd = self.build_command(
             command,
             time_limit=time_limit,
@@ -95,12 +127,26 @@ class NSJailRunner:
             memory=memory,
             processes=processes,
             network=network,
+            workdir=workdir,
+            readonly_dirs=readonly_dirs,
             env=env,
+            fsize=fsize,
         )
-        return subprocess.run(
+        proc = subprocess.run(
             cmd,
             input=stdin,
             capture_output=True,
             text=True,
             check=False,
         )
+        stdout_data = proc.stdout
+        stderr_data = proc.stderr
+        if stdout_limit is not None:
+            stdout_data = stdout_data[:stdout_limit]
+        if stderr_limit is not None:
+            stderr_data = stderr_data[:stderr_limit]
+
+        if tmpdir_ctx is not None:
+            tmpdir_ctx.cleanup()
+
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout_data, stderr_data)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 
@@ -34,3 +33,38 @@ def test_build_command_with_env():
     assert "--env" in cmd
     env_idx = cmd.index("--env")
     assert cmd[env_idx + 1] == "LD_LIBRARY_PATH=/libs"
+
+
+def test_build_command_with_workdir_and_readonly_dirs(tmp_path):
+    runner = NSJailRunner(nsjail_path="nsjail")
+    cmd = runner.build_command(
+        ["/bin/echo", "hi"],
+        workdir="/work",
+        readonly_dirs=["/data"],
+    )
+    assert "--cwd" in cmd
+    assert "--bindmount" in cmd
+    assert "--bindmount_ro" in cmd
+
+
+def test_run_enforces_output_limits(tmp_path):
+    fake = tmp_path / "nsjail"
+    fake.write_text(
+        """#!/usr/bin/env python3
+import sys, subprocess
+args = sys.argv[1:]
+idx = args.index('--')
+cmd = args[idx + 1:]
+res = subprocess.run(cmd)
+sys.exit(res.returncode)
+"""
+    )
+    fake.chmod(0o755)
+    runner = NSJailRunner(nsjail_path=str(fake))
+    proc = runner.run(
+        ["/bin/sh", "-c", "printf 'abcdef' && printf 'ghij' >&2"],
+        stdout_limit=3,
+        stderr_limit=2,
+    )
+    assert proc.stdout == "abc"
+    assert proc.stderr == "gh"


### PR DESCRIPTION
## Summary
- enhance nsjail runner with workdir mounts, read-only dirs, and stdout/stderr caps
- cover new behavior with targeted unit tests

## Testing
- `pytest tests/test_nsjail.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0925a6df88331b2a9c89d4e75e22b