### PR TITLE
feat: add output limits for C++ sandbox

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -320,6 +320,8 @@ def run_binary(
     env: Optional[Mapping[str, str]] = None,
     sandbox: Optional[IsolateRunner] = None,
     cwd: Optional[Path] = None,
+    stdout_limit: Optional[int] = None,
+    stderr_limit: Optional[int] = None,
 ) -> Tuple[int, str, str]:
     """Execute a compiled ``binary`` with optional limits and environment.
 
@@ -349,6 +351,10 @@ def run_binary(
         Working directory for execution. Defaults to the directory of
         ``binary`` so that coverage artifacts are written alongside the
         executable.
+    stdout_limit, stderr_limit:
+        Optional maximum sizes for captured stdout and stderr.  When a
+        sandbox runner is used the limits are forwarded to it.  Otherwise the
+        captured output is truncated locally.
     """
 
     if cwd is None:
@@ -366,6 +372,8 @@ def run_binary(
                     stdin=input_data,
                     workdir=str(cwd),
                     env=env,
+                    stdout_limit=stdout_limit,
+                    stderr_limit=stderr_limit,
                 )
             except TypeError:
                 try:
@@ -376,6 +384,8 @@ def run_binary(
                         memory=memory_kb,
                         stdin=input_data,
                         env=env,
+                        stdout_limit=stdout_limit,
+                        stderr_limit=stderr_limit,
                     )
                 except TypeError:
                     proc = sandbox.run(
@@ -384,6 +394,8 @@ def run_binary(
                         wall_time=int(timeout),
                         memory=memory_kb,
                         stdin=input_data,
+                        stdout_limit=stdout_limit,
+                        stderr_limit=stderr_limit,
                     )
         except SandboxError as exc:
             return -1, "", str(exc)
@@ -404,7 +416,13 @@ def run_binary(
         env={**os.environ, **env} if env is not None else None,
         cwd=str(cwd),
     )
-    return proc.returncode, proc.stdout, proc.stderr
+    stdout = proc.stdout
+    stderr = proc.stderr
+    if stdout_limit is not None:
+        stdout = stdout[:stdout_limit]
+    if stderr_limit is not None:
+        stderr = stderr[:stderr_limit]
+    return proc.returncode, stdout, stderr
 
 
 def _parse_gcov_file(path: Path) -> float:
@@ -469,6 +487,8 @@ def run_codeforces_tests(
     env: Optional[Mapping[str, str]] = None,
     sandbox: Optional[IsolateRunner] = None,
     cache: Optional[SandboxCache] = None,
+    stdout_limit: Optional[int] = None,
+    stderr_limit: Optional[int] = None,
     collect_coverage: bool = False,
     shared_libs: Optional[Mapping[str, Sequence[Path]]] = None,
     static_libs: Optional[Mapping[str, Sequence[Path]]] = None,
@@ -482,6 +502,13 @@ def run_codeforces_tests(
     with error classifications. When ``collect_coverage`` is ``True`` the
     program is instrumented with ``--coverage`` and ``gcov`` is used to compute
     a line coverage ratio.
+
+    Parameters
+    ----------
+    stdout_limit, stderr_limit:
+        Optional maximum sizes for captured stdout and stderr from each test
+        case. Limits are forwarded to the sandbox runner or applied locally
+        when no sandbox is used.
     """
 
     key: Optional[str] = None
@@ -501,6 +528,10 @@ def run_codeforces_tests(
         parts.append(str(timeout).encode())
         if memory_limit is not None:
             parts.append(str(memory_limit).encode())
+        if stdout_limit is not None:
+            parts.append(f"out{stdout_limit}".encode())
+        if stderr_limit is not None:
+            parts.append(f"err{stderr_limit}".encode())
         if collect_coverage:
             parts.append(b"coverage")
         key = cache.hash_parts(parts)
@@ -636,6 +667,8 @@ def run_codeforces_tests(
             memory_limit=memory_limit,
             env=env,
             sandbox=sandbox,
+            stdout_limit=stdout_limit,
+            stderr_limit=stderr_limit,
         )
         coverage_ratio = 0.0
         if collect_coverage:

--- a/runners/io_judge.py
+++ b/runners/io_judge.py
@@ -30,6 +30,8 @@ def run_io_tests(
     env: Optional[Mapping[str, str]] = None,
     sandbox: Optional[IsolateRunner] = None,
     cache: Optional[SandboxCache] = None,
+    stdout_limit: Optional[int] = None,
+    stderr_limit: Optional[int] = None,
 ) -> Dict[str, object]:
     """Run ``binary`` against I/O testcases in ``tests_dir``.
 
@@ -49,6 +51,10 @@ def run_io_tests(
         Optional :class:`IsolateRunner` enforcing resource limits.
     cache:
         Optional :class:`SandboxCache` to memoize results.
+    stdout_limit, stderr_limit:
+        Optional maximum sizes for captured stdout and stderr per test case.
+        When provided these limits are forwarded to the sandbox runner or
+        applied locally to the captured output.
 
     Returns
     -------
@@ -61,6 +67,10 @@ def run_io_tests(
         parts: List[bytes] = [binary.read_bytes(), str(timeout).encode()]
         if memory_limit is not None:
             parts.append(str(memory_limit).encode())
+        if stdout_limit is not None:
+            parts.append(f"out{stdout_limit}".encode())
+        if stderr_limit is not None:
+            parts.append(f"err{stderr_limit}".encode())
         for f in sorted(Path(tests_dir).glob("*")):
             if f.is_file():
                 parts.append(f.read_bytes())
@@ -83,6 +93,8 @@ def run_io_tests(
                 memory_limit=memory_limit,
                 env=env,
                 sandbox=sandbox,
+                stdout_limit=stdout_limit,
+                stderr_limit=stderr_limit,
             )
             timed_out = False
         except subprocess.TimeoutExpired:

--- a/tests/test_io_judge.py
+++ b/tests/test_io_judge.py
@@ -1,5 +1,8 @@
 import pathlib
+import sys
 import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from runners.cpp_runner import compile_cpp_sources
 from runners.io_judge import run_io_tests
@@ -63,3 +66,21 @@ def test_run_io_tests_cache(
     )
     assert first == second
     assert calls["run"] == 1
+
+
+def test_run_io_tests_stdout_limit(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        "#include <iostream>\nint main(){for(int i=0;i<100;i++) std::cout<<'A';}"
+    )
+    res = compile_cpp_sources([src])
+    assert res.success and res.binary is not None
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("\n")
+    (tests_dir / "a.out").write_text("".join(["A" * 100, "\n"]))
+
+    results = run_io_tests(res.binary, tests_dir, stdout_limit=10)
+    out = results["results"][0]["stdout"]
+    assert out == "A" * 10


### PR DESCRIPTION
## Summary
- add stdout/stderr size limits to C++ sandbox runner
- propagate limits through I/O judge and Codeforces harness
- test truncated output handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0925a6df88331b2a9c89d4e75e22b