### PR TITLE
Enforce sandbox filesystem policy for C++ tests

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -57,7 +57,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [ ] Phase 4: Sandbox Executor
     [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
-    [~] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
+    [X] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
     [~] Implement caching layer keyed by prompt+code+tests+limits hash
     [X] Implement standalone I/O judge with whitespace-normalized diff and caching
     [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -320,6 +320,8 @@ def run_binary(
     env: Optional[Mapping[str, str]] = None,
     sandbox: Optional[IsolateRunner] = None,
     cwd: Optional[Path] = None,
+    stdout_limit: int = 10_000,
+    stderr_limit: int = 10_000,
 ) -> Tuple[int, str, str]:
     """Execute a compiled ``binary`` with optional limits and environment.
 
@@ -349,6 +351,9 @@ def run_binary(
         Working directory for execution. Defaults to the directory of
         ``binary`` so that coverage artifacts are written alongside the
         executable.
+    stdout_limit, stderr_limit:
+        Maximum number of characters captured from ``stdout`` and ``stderr``
+        when executing inside the sandbox.
     """
 
     if cwd is None:
@@ -356,7 +361,7 @@ def run_binary(
 
     if sandbox is not None:
         memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
-        try:
+        with tempfile.TemporaryDirectory() as tmpdir:
             try:
                 proc = sandbox.run(
                     [str(binary)],
@@ -364,30 +369,15 @@ def run_binary(
                     wall_time=int(timeout),
                     memory=memory_kb,
                     stdin=input_data,
-                    workdir=str(cwd),
+                    workdir=tmpdir,
+                    readonly_dirs=[str(cwd)],
                     env=env,
+                    stdout_limit=stdout_limit,
+                    stderr_limit=stderr_limit,
                 )
-            except TypeError:
-                try:
-                    proc = sandbox.run(
-                        [str(binary)],
-                        time_limit=int(timeout),
-                        wall_time=int(timeout),
-                        memory=memory_kb,
-                        stdin=input_data,
-                        env=env,
-                    )
-                except TypeError:
-                    proc = sandbox.run(
-                        [str(binary)],
-                        time_limit=int(timeout),
-                        wall_time=int(timeout),
-                        memory=memory_kb,
-                        stdin=input_data,
-                    )
-        except SandboxError as exc:
-            return -1, "", str(exc)
-        return proc.returncode, proc.stdout, proc.stderr
+            except SandboxError as exc:
+                return -1, "", str(exc)
+            return proc.returncode, proc.stdout, proc.stderr
 
     def preexec() -> None:
         _set_limits(memory_limit)

--- a/runners/gtest_runner.py
+++ b/runners/gtest_runner.py
@@ -104,6 +104,8 @@ def run_gtests(
     cache: Optional[SandboxCache] = None,
     collect_coverage: bool = False,
     sources: Optional[Sequence[Path]] = None,
+    stdout_limit: int = 10_000,
+    stderr_limit: int = 10_000,
 ) -> Dict[str, object]:
     """Execute ``binary`` and return parsed GoogleTest results.
 
@@ -124,6 +126,9 @@ def run_gtests(
     sources:
         Sequence of source files corresponding to the compiled
         binary. Required when ``collect_coverage`` is ``True``.
+    stdout_limit, stderr_limit:
+        Maximum number of characters captured from ``stdout`` and ``stderr``
+        when executing inside the sandbox.
     """
 
     key: Optional[str] = None
@@ -146,8 +151,9 @@ def run_gtests(
             return cached
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        xml_path = Path(tmpdir) / "report.xml"
-        cmd = [str(binary), f"--gtest_output=xml:{xml_path}"]
+        workdir = Path(tmpdir)
+        xml_file = "report.xml"
+        cmd = [str(binary), f"--gtest_output=xml:{xml_file}"]
         if sandbox is not None:
             try:
                 proc = sandbox.run(
@@ -155,18 +161,27 @@ def run_gtests(
                     time_limit=time_limit,
                     wall_time=wall_time,
                     memory=memory,
+                    workdir=str(workdir),
+                    readonly_dirs=[str(binary.parent)],
+                    stdout_limit=stdout_limit,
+                    stderr_limit=stderr_limit,
                 )
             except SandboxError as exc:  # pragma: no cover - defensive
                 raise GTestExecutionError("sandbox execution failed") from exc
         else:
             proc = subprocess.run(
-                cmd, capture_output=True, text=True, check=False
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=str(workdir),
             )
 
         if proc.returncode != 0:
             raise GTestExecutionError(
                 f"gtest binary exited with code {proc.returncode}"
             )
+        xml_path = workdir / xml_file
         if not xml_path.exists():  # pragma: no cover - defensive
             raise GTestExecutionError("gtest did not produce XML output")
         xml = xml_path.read_text()

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -229,6 +229,7 @@ int main(){std::cout<<times_two(7);}
                 text=True,
                 check=False,
                 env=self.env,
+                cwd=kwargs.get("workdir"),
             )
 
     runner = EnvRunner()
@@ -245,15 +246,18 @@ int main(){std::cout<<times_two(7);}
 class SpyRunner:
     def __init__(self) -> None:
         self.calls = 0
+        self.kwargs = None
 
     def run(self, cmd, **kwargs):
         self.calls += 1
+        self.kwargs = kwargs
         return subprocess.run(
             cmd,
             input=kwargs.get("stdin"),
             capture_output=True,
             text=True,
             check=False,
+            cwd=kwargs.get("workdir"),
         )
 
 

--- a/tests/test_gtest_runner.py
+++ b/tests/test_gtest_runner.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from pathlib import Path
 import sys
 import subprocess
 import shutil
@@ -52,13 +53,30 @@ def test_run_gtests(tmp_path):
     assert result["cases"][0]["passed"]
 
 
+def test_run_gtests_sandbox(tmp_path):
+    binary, _ = build_sample_test(tmp_path)
+    runner = SpyRunner()
+    run_gtests(binary, sandbox=runner)
+    assert runner.kwargs is not None
+    assert runner.kwargs["readonly_dirs"] == [str(binary.parent)]
+    assert runner.kwargs["workdir"] is not None
+
+
 class SpyRunner:
     def __init__(self) -> None:
         self.calls = 0
+        self.kwargs = None
 
     def run(self, cmd, **kwargs):
         self.calls += 1
-        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        self.kwargs = kwargs
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=kwargs.get("workdir"),
+        )
 
 
 def test_run_gtests_cache(tmp_path):


### PR DESCRIPTION
## Summary
- Isolate gtest execution with a temporary workdir, read-only binary mounts, and capped output
- Run C++ binaries in a sandbox that enforces the same filesystem policy
- Mark Phase 4 filesystem policy item complete and add tests for sandbox behavior

## Testing
- `pytest tests/test_gtest_runner.py tests/test_cpp_runner.py tests/test_io_judge.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0925a6df88331b2a9c89d4e75e22b