### PR TITLE
Integrate MLflow artifacts into smoke evaluation CI

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -68,14 +68,25 @@ jobs:
           python-version: '3.10'
 
       - name: Install Python dependencies
-        run: pip install torch
+        run: pip install torch mlflow
 
       - name: Smoke evaluation
+        id: smoke-eval
         run: |
           python scripts/smoke_eval.py > smoke_eval.log
 
       - name: Upload smoke evaluation log
+        if: ${{ steps.smoke-eval.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: smoke-eval
           path: smoke_eval.log
+
+      - name: Upload smoke evaluation artifacts
+        if: ${{ steps.smoke-eval.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-eval-mlflow
+          path: |
+            mlruns
+            smoke_eval_summary.json

--- a/.github/workflows/nightly-eval.yml
+++ b/.github/workflows/nightly-eval.yml
@@ -60,17 +60,29 @@ jobs:
           python-version: '3.10'
 
       - name: Install Python dependencies
-        run: pip install torch
+        run: pip install torch mlflow
 
       - name: Full evaluation
+        id: full-eval
         run: |
           python scripts/smoke_eval.py > full_eval.log
 
       - name: Upload evaluation log
+        if: ${{ steps.full-eval.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: nightly-full-eval
           path: full_eval.log
+          retention-days: 7
+
+      - name: Upload evaluation artifacts
+        if: ${{ steps.full-eval.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-mlflow
+          path: |
+            mlruns
+            smoke_eval_summary.json
           retention-days: 7
 
       - name: Tag nightly run

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -91,11 +91,11 @@ Save new code files in: C:\repos\hrm-coder
 
 ** [ ] Phase 8: CI/CD and Automation
     [X] Create GitHub Actions workflow for C++ lint (clang-tidy/clang-format) and unit tests on PRs
-    [?] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
-    [~] Create nightly full evaluation job with retention and tagging
+    [X] Create CI smoke evaluation job on sample subset with artifacts (ctest + lcov upload)
+    [?] Create nightly full evaluation job with retention and tagging
     [X] Implement version stamping (git SHA, Docker digest, seeds) in runs
     [X] Configure GitHub Pages publish for latest report artifacts
-    [~] Bootstrap MLflow or W\&B project with tags and run summaries
+    [?] Bootstrap MLflow or W\&B project with tags and run summaries
 
 ** [ ] Phase 9: AST-Edit Action Space (v2)
     [X] Integrate Tree-sitter C++ grammar and bindings

--- a/scripts/smoke_eval.py
+++ b/scripts/smoke_eval.py
@@ -5,9 +5,11 @@ This script trains a tiny model on synthetic data and reports accuracy.
 It is intended for CI smoke tests to exercise the evaluation path.
 """
 
+import json
 import pathlib
 import sys
 
+import mlflow
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -67,6 +69,16 @@ def main() -> None:
     acc = correct / len(dataset)
     print(f"accuracy={acc:.2f}")
     log_metrics({"accuracy": acc})
+
+    # Record run metadata for CI artifacts
+    active = mlflow.active_run()
+    summary = {
+        "run_id": active.info.run_id if active else None,
+        "accuracy": acc,
+    }
+    with open("smoke_eval_summary.json", "w", encoding="utf-8") as fh:
+        json.dump(summary, fh)
+
     end_run()
 
 


### PR DESCRIPTION
## Summary
- capture MLflow run metadata and write `smoke_eval_summary.json`
- install MLflow and upload run artifacts in CI smoke and nightly workflows
- update documentation checklist for Phase 8 progress

## Testing
- `pre-commit run --files scripts/smoke_eval.py .github/workflows/cpp-ci.yml .github/workflows/nightly-eval.yml docs/hrmCoder_checklist.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0926716c083318a5ac470c282e36b