### PR TITLE
Add Codeforces task harness with metadata limits

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -108,7 +108,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)
     [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
     [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
-    [~] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
+    [?] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
     [~] Configure static versus dynamic linking inside jail with rpath handling and ccache
     [ ] Create C++ security test suite for resource abuse and restricted syscalls
     [ ] Integrate C++ metrics and outcomes into common evaluator and reports

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -11,6 +11,7 @@ counts, advancing the Phase 10 goal of richer feedback from the build step.
 from __future__ import annotations
 
 import os
+import json
 import resource
 import shutil
 import subprocess
@@ -655,3 +656,38 @@ def run_codeforces_tests(
         if cache is not None and key is not None:
             cache.store(key, data)
         return data
+
+
+def run_codeforces_task(
+    sources: Sequence[Path],
+    task_dir: Path,
+    **kwargs,
+) -> dict:
+    """Compile ``sources`` and run them against a Codeforces task directory.
+
+    The ``task_dir`` is expected to contain a ``tests`` subdirectory with
+    ``*.in``/``*.out`` pairs and a ``meta.json`` file providing time and memory
+    limits.  The limits are forwarded to :func:`run_codeforces_tests` unless
+    explicitly overridden via ``kwargs``.
+    """
+
+    meta_path = task_dir / "meta.json"
+    timeout = None
+    memory_limit = None
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text())
+            timeout = meta.get("time_limit_ms", 2000) / 1000.0
+            memory_limit = meta.get("memory_limit_kb", 256_000) * 1024
+        except Exception:
+            timeout = None
+            memory_limit = None
+
+    params = dict(kwargs)
+    if timeout is not None:
+        params.setdefault("timeout", timeout)
+    if memory_limit is not None:
+        params.setdefault("memory_limit", memory_limit)
+
+    tests_dir = task_dir / "tests"
+    return run_codeforces_tests(sources, tests_dir, **params)

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import re
 import subprocess
 import sys
@@ -14,6 +15,7 @@ from runners.cpp_runner import (  # noqa: E402
     compile_static_library,
     run_binary,
     run_codeforces_tests,
+    run_codeforces_task,
 )
 from runners.sandbox_cache import SandboxCache  # noqa: E402
 
@@ -332,3 +334,25 @@ int main(){int x; if(!(std::cin>>x)) return 0; std::cout<<times_two(x);}
         [main], tests_dir, shared_libs={"double": [lib_src]}
     )
     assert res["results"][0]["passed"]
+
+
+def test_run_codeforces_task_meta(tmp_path: Path) -> None:
+    """Read TL/ML from meta.json when executing a task directory."""
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        """
+#include <thread>
+#include <chrono>
+int main(){std::this_thread::sleep_for(std::chrono::milliseconds(100));}
+"""
+    )
+    task_dir = tmp_path / "task"
+    tests_dir = task_dir / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "a.in").write_text("\n")
+    (tests_dir / "a.out").write_text("")
+    meta = {"time_limit_ms": 50}
+    (task_dir / "meta.json").write_text(json.dumps(meta))
+
+    res = run_codeforces_task([src], task_dir, sanitize=False)
+    assert res["results"][0]["error_type"] == "timeout"


### PR DESCRIPTION
## Summary
- add `run_codeforces_task` helper to compile sources and execute Codeforces tasks using `meta.json` time/memory limits
- mark Codeforces I/O harness item in checklist as ready for review
- test harness reads TL/ML from metadata

## Testing
- `pre-commit run --files runners/cpp_runner.py docs/hrmCoder_checklist.md tests/test_cpp_runner.py`
- `pytest tests/test_cpp_runner.py::test_run_codeforces_task_meta -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0926b119483319602d0cfc0beaf2b