### PR TITLE
Add automatic compiler detection and reporting

### DIFF
--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -8,7 +8,7 @@ from typing import Sequence
 from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
 
-from runners import sandbox_detector
+from runners import sandbox_detector, toolchain_detector
 
 
 @dataclass
@@ -45,6 +45,10 @@ class RunnerConfig:
     first available backend from :mod:`runners.sandbox_detector` in the
     order ``isolate`` → ``nsjail`` → ``runsc``. When no sandbox is
     detected the value ``"none"`` is used.
+
+    ``compiler`` likewise accepts ``"auto"`` to pick the first available
+    C++ compiler from :mod:`runners.toolchain_detector` in the order
+    ``g++`` → ``clang++``.
     """
 
     compiler: str = "g++"
@@ -108,6 +112,9 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
     if runner_cfg.sandbox == "auto":
         selected, _ = sandbox_detector.select_sandbox()
         runner_cfg.sandbox = selected or "none"
+    if runner_cfg.compiler == "auto":
+        comp, _ = toolchain_detector.select_compiler()
+        runner_cfg.compiler = comp or "g++"
 
     return AppConfig(
         model=ModelConfig(**cfg_dict["model"]),

--- a/runners/__init__.py
+++ b/runners/__init__.py
@@ -5,7 +5,7 @@ from .io_judge import run_io_tests
 from .isolate import IsolateRunner
 from .nsjail import NSJailRunner
 from .error_taxonomy import classify_compile, classify_runtime
-from . import sandbox_detector
+from . import sandbox_detector, toolchain_detector
 
 __all__ = [
     "GVisorRunner",
@@ -15,4 +15,5 @@ __all__ = [
     "classify_runtime",
     "run_io_tests",
     "sandbox_detector",
+    "toolchain_detector",
 ]

--- a/runners/toolchain_detector.py
+++ b/runners/toolchain_detector.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 
 class ToolInfo(Dict[str, Optional[str]]):
@@ -61,4 +61,47 @@ def detect_toolchains() -> Dict[str, ToolInfo]:
     return results
 
 
-__all__ = ["detect_toolchains", "ToolInfo"]
+def _select_tool(
+    names: Tuple[str, ...], info: Optional[Dict[str, ToolInfo]] = None
+) -> Tuple[Optional[str], Optional[ToolInfo]]:
+    """Return first available tool from ``names``.
+
+    This helper mirrors the sandbox selection logic used elsewhere in
+    Phase 0.  ``names`` is a tuple of tool identifiers in priority order.
+    ``info`` allows callers to pass precomputed detection results to
+    avoid repeated ``PATH`` scans.
+    """
+
+    if info is None:
+        info = detect_toolchains()
+    for name in names:
+        details = info.get(name)
+        if details and details.get("available"):
+            return name, details
+    return None, None
+
+
+def select_compiler(
+    preference: Tuple[str, ...] = ("g++", "clang++"),
+    info: Optional[Dict[str, ToolInfo]] = None,
+) -> Tuple[Optional[str], Optional[ToolInfo]]:
+    """Choose the first available C++ compiler from ``preference``."""
+
+    return _select_tool(preference, info)
+
+
+def select_coverage_tool(
+    preference: Tuple[str, ...] = ("llvm-cov", "gcov", "lcov"),
+    info: Optional[Dict[str, ToolInfo]] = None,
+) -> Tuple[Optional[str], Optional[ToolInfo]]:
+    """Choose the first available coverage tool from ``preference``."""
+
+    return _select_tool(preference, info)
+
+
+__all__ = [
+    "detect_toolchains",
+    "select_compiler",
+    "select_coverage_tool",
+    "ToolInfo",
+]

--- a/scripts/env_probe.py
+++ b/scripts/env_probe.py
@@ -27,12 +27,15 @@ from runners import sandbox_detector, toolchain_detector  # noqa: E402
 def build_report() -> Dict[str, Any]:
     """Collect sandbox and toolchain availability information."""
     sandboxes = sandbox_detector.detect_sandboxes()
-    selected, _ = sandbox_detector.select_sandbox(info=sandboxes)
+    selected_sandbox, _ = sandbox_detector.select_sandbox(info=sandboxes)
+    toolchains = toolchain_detector.detect_toolchains()
+    selected_compiler, _ = toolchain_detector.select_compiler(info=toolchains)
     return {
         "python": platform.python_version(),
         "sandboxes": sandboxes,
-        "default_sandbox": selected,
-        "toolchains": toolchain_detector.detect_toolchains(),
+        "default_sandbox": selected_sandbox,
+        "toolchains": toolchains,
+        "default_compiler": selected_compiler,
     }
 
 

--- a/tests/test_config_auto_sandbox.py
+++ b/tests/test_config_auto_sandbox.py
@@ -1,12 +1,11 @@
 import os
 import sys
 
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
 from hrm_coder import config as cfg  # noqa: E402
-from runners import sandbox_detector  # noqa: E402
+from runners import sandbox_detector, toolchain_detector  # noqa: E402
 
 
 def test_load_config_auto_selects_available(monkeypatch):
@@ -27,4 +26,24 @@ def test_load_config_auto_handles_missing(monkeypatch):
     )
     conf = cfg.load_config(overrides=["runner.sandbox=auto"])
     assert conf.runner.sandbox == "none"
+
+
+def test_load_config_auto_selects_compiler(monkeypatch):
+    monkeypatch.setattr(
+        toolchain_detector,
+        "select_compiler",
+        lambda info=None, preference=("g++", "clang++"): ("clang++", {}),
+    )
+    conf = cfg.load_config(overrides=["runner.compiler=auto"])
+    assert conf.runner.compiler == "clang++"
+
+
+def test_load_config_auto_compiler_handles_missing(monkeypatch):
+    monkeypatch.setattr(
+        toolchain_detector,
+        "select_compiler",
+        lambda info=None, preference=("g++", "clang++"): (None, None),
+    )
+    conf = cfg.load_config(overrides=["runner.compiler=auto"])
+    assert conf.runner.compiler == "g++"
 

--- a/tests/test_env_probe.py
+++ b/tests/test_env_probe.py
@@ -20,3 +20,4 @@ def test_env_probe_outputs_json(tmp_path):
     assert "toolchains" in data
     assert "python" in data
     assert "default_sandbox" in data
+    assert "default_compiler" in data

--- a/tests/test_toolchain_detector.py
+++ b/tests/test_toolchain_detector.py
@@ -26,3 +26,28 @@ def test_detect_toolchains_reports_version(monkeypatch):
     result = toolchain_detector.detect_toolchains()
     assert all(info["available"] for info in result.values())
     assert all(info["version"].endswith("1.2") for info in result.values())
+
+
+def test_select_compiler_prefers_first_available(monkeypatch):
+    def fake_detect():
+        return {
+            "g++": {"available": False},
+            "clang++": {"available": True},
+        }
+
+    monkeypatch.setattr(toolchain_detector, "detect_toolchains", fake_detect)
+    name, info = toolchain_detector.select_compiler()
+    assert name == "clang++"
+    assert info["available"]
+
+
+def test_select_compiler_handles_missing(monkeypatch):
+    def fake_detect():
+        return {
+            "g++": {"available": False},
+            "clang++": {"available": False},
+        }
+
+    monkeypatch.setattr(toolchain_detector, "detect_toolchains", fake_detect)
+    name, info = toolchain_detector.select_compiler()
+    assert name is None and info is None


### PR DESCRIPTION
## Summary
- support choosing the first available C++ compiler or coverage tool
- allow RunnerConfig to auto-select a compiler and expose it in env probe output
- add tests for auto compiler selection and update env probe tests

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed; SyntaxError in runners/cpp_runner.py)*
- `pytest tests/test_env_probe.py tests/test_toolchain_detector.py tests/test_config_auto_sandbox.py tests/test_sandbox_detector.py tests/test_gvisor.py hrm_coder/tests/test_runner_utils.py hrm_coder/tests/test_inventory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0a768eb0083318c93b39874b9d483