### PR TITLE
feat: allow configuring network access in runner

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -34,6 +34,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
         - Added helper to instantiate sandbox runners from configuration
+        - Added network access toggle to runner config defaults
     [?] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
     [X] Implement environment pinning and seed/tz/locale normalization module
     [X] Add minimal CMake build helper for C++ harnesses

--- a/hrm_coder/conf/runner/default.yaml
+++ b/hrm_coder/conf/runner/default.yaml
@@ -3,3 +3,4 @@ sandbox: auto
 timeout: 5
 memory_limit: 256
 cpus: 1
+network: false

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -45,6 +45,10 @@ class RunnerConfig:
     first available backend from :mod:`runners.sandbox_detector` in the
     order ``isolate`` → ``nsjail`` → ``runsc``. When no sandbox is
     detected the value ``"none"`` is used.
+
+    ``network`` controls whether sandboxed processes may access the
+    network. For deterministic and safe execution the default disables
+    networking.
     """
 
     compiler: str = "g++"
@@ -52,6 +56,7 @@ class RunnerConfig:
     timeout: int = 5
     memory_limit: int = 256  # in megabytes
     cpus: int = 1
+    network: bool = False
 
 
 @dataclass

--- a/hrm_coder/runner.py
+++ b/hrm_coder/runner.py
@@ -35,13 +35,14 @@ def run_in_sandbox(
     command: List[str],
     config: RunnerConfig,
     *,
-    network: bool = False,
+    network: Optional[bool] = None,
     stdin: Optional[bytes] = None,
 ) -> subprocess.CompletedProcess:
     """Execute ``command`` inside the sandbox described by ``config``."""
 
     runner = create_sandbox_runner(config)
     memory_kb = config.memory_limit * 1024
+    network = config.network if network is None else network
     common_kwargs = dict(
         time_limit=config.timeout,
         wall_time=config.timeout,

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -9,6 +9,7 @@ def test_load_config_defaults():
     assert cfg.runner.timeout == 5
     assert cfg.runner.memory_limit == 256
     assert cfg.runner.cpus == 1
+    assert cfg.runner.network is False
     assert cfg.acceptance.pass_at_1 == 0.5
     assert cfg.acceptance.max_timeout_rate == 0.05
     assert cfg.training.baseline_coef == 0.5
@@ -23,6 +24,7 @@ def test_load_config_override():
         "runner.timeout=10",
         "runner.memory_limit=512",
         "runner.cpus=2",
+        "runner.network=true",
         "acceptance.pass_at_1=0.9",
         "training.baseline_coef=0.7",
         "training.curriculum_stage=hidden",
@@ -32,6 +34,7 @@ def test_load_config_override():
     assert cfg.runner.timeout == 10
     assert cfg.runner.memory_limit == 512
     assert cfg.runner.cpus == 2
+    assert cfg.runner.network is True
     assert cfg.acceptance.pass_at_1 == 0.9
     assert cfg.training.baseline_coef == 0.7
     assert cfg.training.curriculum_stage == "hidden"

--- a/hrm_coder/tests/test_runner_utils.py
+++ b/hrm_coder/tests/test_runner_utils.py
@@ -23,7 +23,9 @@ def test_create_sandbox_runner_auto(monkeypatch):
 
 
 def test_run_in_sandbox_passes_limits(monkeypatch):
-    cfg = RunnerConfig(sandbox="isolate", timeout=3, memory_limit=128, cpus=2)
+    cfg = RunnerConfig(
+        sandbox="isolate", timeout=3, memory_limit=128, cpus=2, network=False
+    )
 
     called = {}
 
@@ -37,3 +39,17 @@ def test_run_in_sandbox_passes_limits(monkeypatch):
     assert called["wall_time"] == 3
     assert called["memory"] == 128 * 1024
     assert called["processes"] == 2
+    assert called["network"] is False
+
+
+def test_run_in_sandbox_override_network(monkeypatch):
+    cfg = RunnerConfig(sandbox="isolate", network=False)
+    called = {}
+
+    def fake_run(self, command, **kwargs):
+        called.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(IsolateRunner, "run", fake_run)
+    run_in_sandbox(["/bin/true"], cfg, network=True)
+    assert called["network"] is True


### PR DESCRIPTION
## Summary
- add network toggle to Hydra runner configuration
- default to sandboxed network-off execution and expose override in utilities
- document checklist update and expand tests

## Testing
- `pre-commit run --files hrm_coder/config.py hrm_coder/runner.py hrm_coder/conf/runner/default.yaml hrm_coder/tests/test_runner_utils.py hrm_coder/tests/test_config.py docs/hrmCoder_checklist.md`
- `pytest hrm_coder/tests/test_runner_utils.py hrm_coder/tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a76e7c448331ac994a9bea50f8ad