### PR TITLE
feat: add DVC pipeline generator

### DIFF
--- a/dataset/dvc.py
+++ b/dataset/dvc.py
@@ -1,0 +1,66 @@
+"""Helpers for generating DVC pipeline files for dataset builds.
+
+This module provides a tiny utility for writing a ``dvc.yaml`` stage
+that invokes :mod:`dataset.build_from_catalog`.  It is part of Phase 3
+work toward a deterministic dataset pipeline with data version locks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def generate_stage_yaml(
+    catalog_path: str,
+    output_dir: str,
+    versions_file: str,
+    *,
+    stage_name: str = "build-datasets",
+) -> str:
+    """Return YAML for a DVC stage building datasets from a catalog.
+
+    Parameters
+    ----------
+    catalog_path:
+        Path to ``dataset_catalog.json``.
+    output_dir:
+        Directory where processed datasets will be written.
+    versions_file:
+        Path to ``versions.yml`` recording dataset hashes.
+    stage_name:
+        Name for the generated DVC stage. Defaults to ``"build-datasets"``.
+    """
+    cmd = (
+        f"python -m dataset.build_from_catalog {catalog_path} "
+        f"{output_dir} --versions {versions_file}"
+    )
+
+    lines: List[str] = [
+        "stages:",
+        f"  {stage_name}:",
+        f"    cmd: {cmd}",
+        "    deps:",
+        f"      - {catalog_path}",
+        "      - dataset/build_from_catalog.py",
+        "    outs:",
+        f"      - {output_dir}",
+        f"      - {versions_file}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_dvc_yaml(
+    catalog_path: str,
+    output_dir: str,
+    versions_file: str,
+    *,
+    yaml_path: str = "dvc.yaml",
+    stage_name: str = "build-datasets",
+) -> None:
+    """Write a ``dvc.yaml`` file with a single dataset build stage."""
+    content = generate_stage_yaml(
+        catalog_path, output_dir, versions_file, stage_name=stage_name
+    )
+    path = Path(yaml_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")

--- a/tests/test_dvc_yaml.py
+++ b/tests/test_dvc_yaml.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from dataset.dvc import write_dvc_yaml  # noqa: E402
+
+
+def test_write_dvc_yaml(tmp_path):
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text("[]")
+    out_dir = tmp_path / "out"
+    versions = tmp_path / "versions.yml"
+    yaml_path = tmp_path / "dvc.yaml"
+
+    write_dvc_yaml(
+        str(catalog),
+        str(out_dir),
+        str(versions),
+        yaml_path=str(yaml_path),
+    )
+
+    cmd = (
+        "python -m dataset.build_from_catalog "
+        f"{catalog} {out_dir} --versions {versions}"
+    )
+    expected = (
+        "stages:\n"
+        "  build-datasets:\n"
+        f"    cmd: {cmd}\n"
+        "    deps:\n"
+        f"      - {catalog}\n"
+        "      - dataset/build_from_catalog.py\n"
+        "    outs:\n"
+        f"      - {out_dir}\n"
+        f"      - {versions}\n"
+    )
+    assert yaml_path.read_text() == expected


### PR DESCRIPTION
## Summary
- add helper to generate dvc.yaml stages for dataset builds
- test DVC stage generator for expected YAML output

## Testing
- `pre-commit run --files dataset/dvc.py tests/test_dvc_yaml.py`
- `pytest tests/test_dvc_yaml.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a774accc8331880eae0b41495ffb