### PR TITLE
Add dataset version verification

### DIFF
--- a/dataset/build_from_catalog.py
+++ b/dataset/build_from_catalog.py
@@ -10,20 +10,35 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Callable, Dict
+from typing import Callable, Dict, Tuple
 
-from .build_atcoder_abc_dataset import build_dataset as build_atcoder
-from .build_codeforces_intro_dataset import build_dataset as build_codeforces
-from .build_humaneval_cpp_dataset import build_dataset as build_humaneval
-from .build_kattis_micro_dataset import build_dataset as build_kattis
+from .build_atcoder_abc_dataset import (
+    build_dataset as build_atcoder,
+    DATASET_NAME as ATCODER_NAME,
+)
+from .build_codeforces_intro_dataset import (
+    build_dataset as build_codeforces,
+    DATASET_NAME as CODEFORCES_NAME,
+)
+from .build_humaneval_cpp_dataset import (
+    build_dataset as build_humaneval,
+    DATASET_NAME as HUMANEVAL_NAME,
+)
+from .build_kattis_micro_dataset import (
+    build_dataset as build_kattis,
+    DATASET_NAME as KATTIS_NAME,
+)
 from .determinism import validate_build_determinism
+from .version_lock import verify_version
 
-# Map human-friendly dataset names to their builder functions.
-BUILDERS: Dict[str, Callable[[str, str, int, str | None], None]] = {
-    "HumanEval-CPP": build_humaneval,
-    "Codeforces-Intro": build_codeforces,
-    "AtCoder-ABC": build_atcoder,
-    "Kattis-micro": build_kattis,
+# Map human-friendly dataset names to their builder functions and version keys.
+BUILDERS: Dict[
+    str, Tuple[Callable[[str, str, int, str | None], None], str]
+] = {
+    "HumanEval-CPP": (build_humaneval, HUMANEVAL_NAME),
+    "Codeforces-Intro": (build_codeforces, CODEFORCES_NAME),
+    "AtCoder-ABC": (build_atcoder, ATCODER_NAME),
+    "Kattis-micro": (build_kattis, KATTIS_NAME),
 }
 
 
@@ -61,12 +76,13 @@ def build_from_catalog(
     for entry in catalog:
         name = entry.get("name")
         raw_path = entry.get("path")
-        build_fn = BUILDERS.get(name)
+        builder_entry = BUILDERS.get(name)
 
-        if not build_fn or raw_path is None:
+        if not builder_entry or raw_path is None:
             # Unknown dataset or missing path; skip silently for now.
             continue
 
+        build_fn, version_key = builder_entry
         dataset_dir = out_root / name
 
         if check_determinism:
@@ -80,6 +96,10 @@ def build_from_catalog(
             seed=seed,
             versions_path=versions_file,
         )
+
+        # Ensure the recorded hash matches the freshly built dataset.
+        if not verify_version(version_key, str(dataset_dir), versions_file):
+            raise RuntimeError(f"Hash mismatch for dataset {name}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI wrapper

--- a/dataset/version_lock.py
+++ b/dataset/version_lock.py
@@ -25,7 +25,9 @@ def compute_dataset_hash(dataset_dir: Path) -> str:
     return hashlib.sha256(serialized).hexdigest()
 
 
-def update_version(dataset_name: str, dataset_dir: str, versions_file: str) -> str:
+def update_version(
+    dataset_name: str, dataset_dir: str, versions_file: str
+) -> str:
     """Update *versions_file* with the hash of *dataset_dir*.
 
     Parameters
@@ -59,3 +61,39 @@ def update_version(dataset_name: str, dataset_dir: str, versions_file: str) -> s
         json.dumps(versions, indent=2, sort_keys=True), encoding="utf-8"
     )
     return digest
+
+
+def verify_version(
+    dataset_name: str, dataset_dir: str, versions_file: str
+) -> bool:
+    """Check that *dataset_dir* matches the hash in *versions_file*.
+
+    Parameters
+    ----------
+    dataset_name:
+        Name of the dataset entry in the versions file.
+    dataset_dir:
+        Directory containing the processed dataset to verify.
+    versions_file:
+        Path to the versions file previously written by
+        :func:`update_version`.
+
+    Returns
+    -------
+    bool
+        ``True`` if the dataset's current hash equals the recorded hash,
+        ``False`` otherwise. ``False`` is also returned when the versions
+        file or dataset entry does not exist.
+    """
+
+    versions_path = Path(versions_file)
+    if not versions_path.exists():
+        return False
+
+    versions = json.loads(versions_path.read_text() or "{}")
+    recorded = versions.get(dataset_name)
+    if recorded is None:
+        return False
+
+    current = compute_dataset_hash(Path(dataset_dir))
+    return current == recorded

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -55,6 +55,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement Kattis micro-set builder for additional I/O tasks
     [X] Write determinism validator to re-run and hash equality of artifacts
     [~] Integrate DVC pipelines and data/versions.yml locking
+        - Added version verification utility and catalog build check
     [X] Add dataset schema contracts and unit tests for loaders
     [X] Implement dataset split manager for train/val/test with fixed seeds
 

--- a/tests/test_version_lock.py
+++ b/tests/test_version_lock.py
@@ -3,7 +3,11 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from dataset.version_lock import compute_dataset_hash, update_version  # noqa: E402
+from dataset.version_lock import (  # noqa: E402
+    compute_dataset_hash,
+    update_version,
+    verify_version,
+)
 
 
 def test_update_version_writes_hash(tmp_path):
@@ -32,3 +36,14 @@ def test_compute_dataset_hash_matches_update(tmp_path):
     versions_file = tmp_path / "versions.yml"
     digest2 = update_version("sample", str(ds), str(versions_file))
     assert digest == digest2
+
+
+def test_verify_version(tmp_path):
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    (ds / "f.txt").write_text("hello")
+    versions_file = tmp_path / "versions.yml"
+    update_version("demo", str(ds), str(versions_file))
+    assert verify_version("demo", str(ds), str(versions_file))
+    (ds / "f.txt").write_text("world")
+    assert not verify_version("demo", str(ds), str(versions_file))


### PR DESCRIPTION
## Summary
- add dataset version verification utility and integrate into catalog builder
- document dataset version locking progress in checklist
- test version verification and catalog build

## Testing
- `pre-commit run --files dataset/version_lock.py dataset/build_from_catalog.py tests/test_version_lock.py`
- `pre-commit run --files docs/hrmCoder_checklist.md`
- `pytest tests/test_version_lock.py tests/test_build_from_catalog.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a774accc8331880eae0b41495ffb