### PR TITLE
Expand sandbox cache key to include build configuration

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -62,7 +62,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
     [X] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
-    [~] Implement caching layer keyed by prompt+code+tests+limits hash
+    [?] Implement caching layer keyed by prompt+code+tests+limits hash
     [X] Implement standalone I/O judge with whitespace-normalized diff and caching
     [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
     [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -399,9 +399,9 @@ def run_binary(
                         stdout_limit=stdout_limit,
                         stderr_limit=stderr_limit,
                     )
-        except SandboxError as exc:
-            return -1, "", str(exc)
-        return proc.returncode, proc.stdout, proc.stderr
+            except SandboxError as exc:
+                return -1, "", str(exc)
+            return proc.returncode, proc.stdout, proc.stderr
 
     def preexec() -> None:
         _set_limits(memory_limit)
@@ -527,6 +527,21 @@ def run_codeforces_tests(
         for f in sorted(Path(tests_dir).glob("*")):
             if f.is_file():
                 parts.append(f.read_bytes())
+        parts.append(compiler.encode())
+        for f in sorted(flags or []):
+            parts.append(f.encode())
+        parts.append(b"sanitize" if sanitize else b"no_sanitize")
+        parts.append(b"static" if static else b"dynamic")
+        for d in sorted(str(p) for p in library_dirs or []):
+            parts.append(d.encode())
+        for lib in sorted(libraries or []):
+            parts.append(lib.encode())
+        for rp in sorted(str(p) for p in rpath or []):
+            parts.append(rp.encode())
+        parts.append(b"ccache" if use_ccache else b"no_ccache")
+        if env:
+            for k, v in sorted(env.items()):
+                parts.append(f"{k}={v}".encode())
         parts.append(str(timeout).encode())
         if memory_limit is not None:
             parts.append(str(memory_limit).encode())
@@ -669,6 +684,7 @@ def run_codeforces_tests(
             memory_limit=memory_limit,
             env=env,
             sandbox=sandbox,
+            cache=cache,
             stdout_limit=stdout_limit,
             stderr_limit=stderr_limit,
         )

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -294,6 +294,56 @@ def test_run_codeforces_tests_cache(tmp_path: Path, monkeypatch):
     assert first == second
 
 
+def test_run_codeforces_tests_cache_includes_flags(tmp_path: Path, monkeypatch):
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        "#include <iostream>\nint main(){std::cout<<1;}"
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("\n")
+    (tests_dir / "a.out").write_text("1\n")
+
+    cache = SandboxCache(tmp_path / "cache_flags")
+    calls = {"compile": 0}
+    original_compile = cpp_runner.compile_cpp_sources
+
+    def wrapped_compile(*args, **kwargs):
+        calls["compile"] += 1
+        return original_compile(*args, **kwargs)
+
+    monkeypatch.setattr(cpp_runner, "compile_cpp_sources", wrapped_compile)
+
+    run_codeforces_tests([src], tests_dir, cache=cache, flags=["-DFOO=1"])
+    run_codeforces_tests([src], tests_dir, cache=cache, flags=["-DFOO=2"])
+    assert calls["compile"] == 2
+
+
+def test_run_codeforces_tests_cache_includes_env(tmp_path: Path, monkeypatch):
+    src = tmp_path / "main.cpp"
+    src.write_text(
+        "#include <iostream>\nint main(){std::cout<<1;}"
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("\n")
+    (tests_dir / "a.out").write_text("1\n")
+
+    cache = SandboxCache(tmp_path / "cache_env")
+    calls = {"compile": 0}
+    original_compile = cpp_runner.compile_cpp_sources
+
+    def wrapped_compile(*args, **kwargs):
+        calls["compile"] += 1
+        return original_compile(*args, **kwargs)
+
+    monkeypatch.setattr(cpp_runner, "compile_cpp_sources", wrapped_compile)
+
+    run_codeforces_tests([src], tests_dir, cache=cache, env={"A": "1"})
+    run_codeforces_tests([src], tests_dir, cache=cache, env={"A": "2"})
+    assert calls["compile"] == 2
+
+
 def test_run_codeforces_tests_coverage(tmp_path: Path) -> None:
     """Ensure coverage metrics are returned when requested."""
     src = tmp_path / "main.cpp"


### PR DESCRIPTION
## Summary
- broaden sandbox execution cache to hash compiler flags, linking options, env vars, and resource limits
- forward cache to `run_io_tests` for reuse and import missing `shutil` in nsjail runner
- document Phase 4 progress and add tests covering cache invalidation on flag/env changes

## Testing
- `pytest tests/test_cpp_runner.py::test_run_codeforces_tests_cache tests/test_cpp_runner.py::test_run_codeforces_tests_cache_includes_flags tests/test_cpp_runner.py::test_run_codeforces_tests_cache_includes_env -q`
- `pytest tests/test_nsjail.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a779ab34833189362dea8da32e26