### PR TITLE
Add sandbox file-write test and refine C++ runner error handling

### DIFF
--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -363,21 +363,8 @@ def run_binary(
 
     if sandbox is not None:
         memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
-        with tempfile.TemporaryDirectory() as tmpdir:
-            try:
-                proc = sandbox.run(
-                    [str(binary)],
-                    time_limit=int(timeout),
-                    wall_time=int(timeout),
-                    memory=memory_kb,
-                    stdin=input_data,
-                    workdir=tmpdir,
-                    readonly_dirs=[str(cwd)],
-                    env=env,
-                    stdout_limit=stdout_limit,
-                    stderr_limit=stderr_limit,
-                )
-            except TypeError:
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
                 try:
                     proc = sandbox.run(
                         [str(binary)],
@@ -385,20 +372,34 @@ def run_binary(
                         wall_time=int(timeout),
                         memory=memory_kb,
                         stdin=input_data,
+                        workdir=tmpdir,
+                        readonly_dirs=[str(cwd)],
                         env=env,
                         stdout_limit=stdout_limit,
                         stderr_limit=stderr_limit,
                     )
                 except TypeError:
-                    proc = sandbox.run(
-                        [str(binary)],
-                        time_limit=int(timeout),
-                        wall_time=int(timeout),
-                        memory=memory_kb,
-                        stdin=input_data,
-                        stdout_limit=stdout_limit,
-                        stderr_limit=stderr_limit,
-                    )
+                    try:
+                        proc = sandbox.run(
+                            [str(binary)],
+                            time_limit=int(timeout),
+                            wall_time=int(timeout),
+                            memory=memory_kb,
+                            stdin=input_data,
+                            env=env,
+                            stdout_limit=stdout_limit,
+                            stderr_limit=stderr_limit,
+                        )
+                    except TypeError:
+                        proc = sandbox.run(
+                            [str(binary)],
+                            time_limit=int(timeout),
+                            wall_time=int(timeout),
+                            memory=memory_kb,
+                            stdin=input_data,
+                            stdout_limit=stdout_limit,
+                            stderr_limit=stderr_limit,
+                        )
         except SandboxError as exc:
             return -1, "", str(exc)
         return proc.returncode, proc.stdout, proc.stderr

--- a/tests/test_sandbox_malicious.py
+++ b/tests/test_sandbox_malicious.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -7,9 +6,9 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from runners.cpp_runner import compile_cpp, run_binary
-from runners.error_taxonomy import classify_runtime
-from runners.isolate import IsolateRunner
+from runners.cpp_runner import compile_cpp, run_binary  # noqa: E402
+from runners.error_taxonomy import classify_runtime  # noqa: E402
+from runners.isolate import IsolateRunner  # noqa: E402
 
 pytestmark = pytest.mark.skipif(
     shutil.which("isolate") is None, reason="isolate not available"
@@ -40,6 +39,31 @@ int main() {
     if (fd == -1) {
         perror("open");
         return 1;
+    }
+    close(fd);
+    return 0;
+}
+"""
+    binary = _compile(code, tmp_path)
+    rc, _out, err = _run(binary)
+    assert rc != 0
+    assert classify_runtime(rc, err) == "policy_violation"
+
+
+def test_file_write_denied(tmp_path):
+    code = r"""
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    int fd = open("/etc/passwd", O_WRONLY|O_CREAT, 0644);
+    if (fd == -1) {
+        perror("open");
+        return 1;
+    }
+    if (write(fd, "hi", 2) == -1) {
+        perror("write");
     }
     close(fd);
     return 0;
@@ -110,4 +134,3 @@ int main() {
     rc, _out, err = _run(binary)
     assert rc != 0
     assert classify_runtime(rc, err) in {"policy_violation", "runtime_error"}
-


### PR DESCRIPTION
## Summary
- add malicious sample test ensuring sandbox blocks file write attempts
- fix `run_binary` SandboxError handling in C++ runner

## Testing
- `pre-commit run --files tests/test_sandbox_malicious.py runners/cpp_runner.py`
- `pytest tests/test_sandbox_malicious.py -k test_file_write_denied -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0a779ab34833189362dea8da32e26