### PR TITLE
feat: add composite cursor policy

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -101,11 +101,11 @@ Save new code files in: C:\repos\hrm-coder
     [X] Configure GitHub Pages publish for latest report artifacts
     [?] Bootstrap MLflow or W\&B project with tags and run summaries
 
-** [ ] Phase 9: AST-Edit Action Space (v2)
+** [~] Phase 9: AST-Edit Action Space (v2)
     [X] Integrate Tree-sitter C++ grammar and bindings
     [X] Implement node type schema and AST embedding encoder for C++
     [X] Define edit action space for insert, replace, and delete operations
-    [?] Implement cursor policy module for region selection by HRM high-level
+    [X] Implement cursor policy module for region selection by HRM high-level
     [X] Implement decoder constraint checker to avoid invalid AST states
     [X] Add ablation job configs and comparison report against token baseline
 

--- a/tests/test_ast_cursor.py
+++ b/tests/test_ast_cursor.py
@@ -8,6 +8,7 @@ from utils.ast_edit import CppAst  # noqa: E402
 from utils.ast_cursor import (  # noqa: E402
     CursorPolicy,
     ScoredCursorPolicy,
+    CompositeCursorPolicy,
     find_node_by_type,
 )
 
@@ -53,6 +54,19 @@ def test_scored_cursor_policy_prefers_high_score():
         return 1.0 if node.type == "return_statement" else 0.0
 
     policy = ScoredCursorPolicy(scorer)
+    node = policy.select(tree)
+    assert node is not None
+    assert node.type == "return_statement"
+
+
+@pytest.mark.skipif(not _parser_available(), reason=REASON)
+def test_composite_cursor_policy_falls_back():
+    ast = CppAst()
+    tree = ast.parse(CPP_SNIPPET)
+
+    missing = CursorPolicy(lambda n: n.type == "for_statement")
+    fallback = CursorPolicy(lambda n: n.type == "return_statement")
+    policy = CompositeCursorPolicy([missing, fallback])
     node = policy.select(tree)
     assert node is not None
     assert node.type == "return_statement"

--- a/utils/ast_cursor.py
+++ b/utils/ast_cursor.py
@@ -16,13 +16,20 @@ future learned cursor module.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional, Protocol
 
 from tree_sitter import Node, Tree
 
 
 Predicate = Callable[[Node], bool]
 ScoreFn = Callable[[Node], float]
+
+
+class _Selectable(Protocol):
+    """Protocol for policies exposing a ``select`` method."""
+
+    def select(self, tree: Tree) -> Optional[Node]:
+        ...
 
 
 @dataclass
@@ -77,6 +84,25 @@ class ScoredCursorPolicy:
                     best_node = node
             queue.extend(node.children)
         return best_node
+
+
+@dataclass
+class CompositeCursorPolicy:
+    """Chain multiple cursor policies with fallbacks.
+
+    The policies are evaluated in order and the first non-``None`` match is
+    returned.  This allows callers to provide coarse-to-fine strategies where
+    simpler heuristics run before more expensive scoring functions.
+    """
+
+    policies: Iterable[_Selectable]
+
+    def select(self, tree: Tree) -> Optional[Node]:
+        for policy in self.policies:
+            node = policy.select(tree)
+            if node is not None:
+                return node
+        return None
 
 
 def find_node_by_type(tree: Tree, node_type: str) -> Optional[Node]:


### PR DESCRIPTION
## Summary
- add CompositeCursorPolicy to chain cursor strategies with fallbacks
- test composite cursor selection and update checklist for phase 9 progress

## Testing
- `pre-commit run --files utils/ast_cursor.py tests/test_ast_cursor.py docs/hrmCoder_checklist.md`
- `pytest tests/test_ast_cursor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a78d61e88331bf73f93b9f7adf21