### PR TITLE
feat: check toolchain minimum versions

### DIFF
--- a/runners/toolchain_detector.py
+++ b/runners/toolchain_detector.py
@@ -9,12 +9,13 @@ system.
 """
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 
-class ToolInfo(Dict[str, Optional[str]]):
+class ToolInfo(Dict[str, Any]):
     """Dictionary describing an installed tool.
 
     Keys
@@ -25,6 +26,8 @@ class ToolInfo(Dict[str, Optional[str]]):
         First line of ``--version`` output (``None`` if unavailable).
     path:
         Resolved path to the binary (``None`` if missing).
+    meets_requirement:
+        ``True`` if the parsed version meets the Phase 0 minimum.
     """
 
 
@@ -40,6 +43,29 @@ def _probe_version(cmd: list[str]) -> Optional[str]:
     return line[0] if line else None
 
 
+def _parse_version(line: str) -> Optional[Tuple[int, int]]:
+    """Extract ``(major, minor)`` version tuple from ``line``.
+
+    The function searches for the first ``X.Y`` pattern and returns the
+    corresponding integers.  ``None`` is returned when no version pattern
+    can be found.
+    """
+
+    match = re.search(r"(\d+)\.(\d+)", line)
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+MIN_VERSIONS: Dict[str, Tuple[int, int]] = {
+    "g++": (13, 0),
+    "clang++": (17, 0),
+    "llvm-cov": (17, 0),
+    "gcov": (13, 0),
+    "lcov": (1, 15),
+}
+
+
 def detect_toolchains() -> Dict[str, ToolInfo]:
     """Detect availability of common compiler and coverage utilities."""
     tools = {
@@ -52,11 +78,21 @@ def detect_toolchains() -> Dict[str, ToolInfo]:
     results: Dict[str, ToolInfo] = {}
     for name, cmd in tools.items():
         path = shutil.which(cmd[0])
-        info: ToolInfo = ToolInfo(available=False, version=None, path=None)
+        info: ToolInfo = ToolInfo(
+            available=False,
+            version=None,
+            path=None,
+            meets_requirement=False,
+        )
         if path:
             info["available"] = True
             info["path"] = path
-            info["version"] = _probe_version(cmd)
+            ver = _probe_version(cmd)
+            info["version"] = ver
+            min_ver = MIN_VERSIONS.get(name)
+            parsed = _parse_version(ver) if ver else None
+            if parsed and min_ver:
+                info["meets_requirement"] = parsed >= min_ver
         results[name] = info
     return results
 
@@ -76,7 +112,11 @@ def _select_tool(
         info = detect_toolchains()
     for name in names:
         details = info.get(name)
-        if details and details.get("available"):
+        if (
+            details
+            and details.get("available")
+            and details.get("meets_requirement", True)
+        ):
             return name, details
     return None, None
 

--- a/tests/test_toolchain_detector.py
+++ b/tests/test_toolchain_detector.py
@@ -12,27 +12,43 @@ def test_detect_toolchains_all_missing(monkeypatch):
     expected = {"g++", "clang++", "lcov", "llvm-cov", "gcov"}
     assert set(result.keys()) == expected
     assert all(not info["available"] for info in result.values())
+    assert all(not info["meets_requirement"] for info in result.values())
 
 
-def test_detect_toolchains_reports_version(monkeypatch):
+def test_detect_toolchains_reports_version_and_requirement(monkeypatch):
     def fake_which(cmd: str):
         return f"/usr/bin/{cmd}"
 
     def fake_run(cmd, capture_output, text):
-        return SimpleNamespace(returncode=0, stdout=f"{cmd[0]} version 1.2\n")
+        return SimpleNamespace(returncode=0, stdout=f"{cmd[0]} 99.0\n")
 
     monkeypatch.setattr(toolchain_detector.shutil, "which", fake_which)
     monkeypatch.setattr(toolchain_detector.subprocess, "run", fake_run)
     result = toolchain_detector.detect_toolchains()
     assert all(info["available"] for info in result.values())
-    assert all(info["version"].endswith("1.2") for info in result.values())
+    assert all(info["version"].endswith("99.0") for info in result.values())
+    assert all(info["meets_requirement"] for info in result.values())
+
+
+def test_detect_toolchains_flags_old_version(monkeypatch):
+    def fake_which(cmd: str):
+        return f"/usr/bin/{cmd}"
+
+    def fake_run(cmd, capture_output, text):
+        return SimpleNamespace(returncode=0, stdout=f"{cmd[0]} 1.0\n")
+
+    monkeypatch.setattr(toolchain_detector.shutil, "which", fake_which)
+    monkeypatch.setattr(toolchain_detector.subprocess, "run", fake_run)
+    result = toolchain_detector.detect_toolchains()
+    assert all(info["available"] for info in result.values())
+    assert all(not info["meets_requirement"] for info in result.values())
 
 
 def test_select_compiler_prefers_first_available(monkeypatch):
     def fake_detect():
         return {
-            "g++": {"available": False},
-            "clang++": {"available": True},
+            "g++": {"available": True, "meets_requirement": False},
+            "clang++": {"available": True, "meets_requirement": True},
         }
 
     monkeypatch.setattr(toolchain_detector, "detect_toolchains", fake_detect)


### PR DESCRIPTION
## Summary
- track minimum versions for g++, clang++, and coverage tools
- prefer newer compilers during auto-selection
- test toolchain detection and version gating

## Testing
- `pre-commit run --files runners/toolchain_detector.py tests/test_toolchain_detector.py`
- `pytest tests/test_toolchain_detector.py tests/test_env_probe.py tests/test_config_auto_sandbox.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b460f45083319d4788ee7c763b3c