### PR TITLE
Add Makefile targets for trainer build and lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: data build_runner train eval report smoke cpp-build cpp-test
+.PHONY: data build_runner build_trainer train eval report lint smoke cpp-build cpp-test
 
 # Placeholder targets for Phase 1 scaffold
 
@@ -6,7 +6,10 @@ data:
 	@echo "Data pipeline not implemented yet"
 
 build_runner:
-	docker build -f runner.Dockerfile -t hrm-runner .
+        docker build -f runner.Dockerfile -t hrm-runner .
+
+build_trainer:
+        docker build -f trainer.Dockerfile -t hrm-trainer .
 
 train:
 	python -m hrm_coder.train $(ARGS)
@@ -15,10 +18,13 @@ eval:
 	python -m hrm_coder.eval_cli $(ARGS)
 
 report:
-	@echo "Report generation not implemented yet"
+        @echo "Report generation not implemented yet"
+
+lint:
+        pre-commit run --all-files
 
 smoke:
-	python scripts/smoke_train.py
+        python scripts/smoke_train.py
 
 # Basic C++ build and test targets for Phase 1 scaffolding
 CPP_PRESET ?= sanitized

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -30,12 +30,15 @@ Save new code files in: C:\repos\hrm-coder
     [X] Generate project layout scaffold script for hrm-coder directory tree
     [?] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
     [~] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
-    [~] Create Makefile targets for data, train, eval, and report (CMake + ctest integration)
+    [~] Create Makefile targets for data, train, eval, report, and tooling (CMake + ctest integration)
+        - Added build_trainer target for trainer Docker image
+        - Added lint target invoking pre-commit hooks
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
         - Added helper to instantiate sandbox runners from configuration
         - Added network access toggle to runner config defaults
-    [?] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
+    [X] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
+        - Added Makefile lint target to run pre-commit
     [X] Implement environment pinning and seed/tz/locale normalization module
     [X] Add minimal CMake build helper for C++ harnesses
 


### PR DESCRIPTION
## Summary
- add build_trainer target for trainer Docker image
- add lint target running pre-commit
- document new Makefile targets in Phase 1 checklist

## Testing
- `pre-commit run --files Makefile docs/hrmCoder_checklist.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b466ae148331a744be49df02181e