### PR TITLE
Add catalog-wide dataset version verification utility

### DIFF
--- a/dataset/version_lock.py
+++ b/dataset/version_lock.py
@@ -97,3 +97,72 @@ def verify_version(
 
     current = compute_dataset_hash(Path(dataset_dir))
     return current == recorded
+
+
+def verify_catalog_versions(
+    catalog_path: str, datasets_root: str, versions_file: str
+) -> bool:
+    """Verify that all datasets in *catalog_path* match recorded hashes.
+
+    This helper loads a dataset catalog (same format as
+    ``docs/dataset_catalog.json``) and ensures that each listed dataset has a
+    corresponding entry in ``versions_file`` that matches the current contents
+    of ``datasets_root/<name>``. Unknown catalog entries are ignored.
+
+    Parameters
+    ----------
+    catalog_path:
+        Path to the dataset catalog JSON file.
+    datasets_root:
+        Directory containing one subdirectory per dataset as produced by
+        :mod:`dataset.build_from_catalog`.
+    versions_file:
+        Path to the versions file previously written by
+        :func:`update_version`.
+
+    Returns
+    -------
+    bool
+        ``True`` if all datasets verify successfully, ``False`` otherwise.
+    """
+
+    from .build_from_catalog import BUILDERS  # local import to avoid cycle
+
+    catalog = json.loads(Path(catalog_path).read_text() or "[]")
+    root = Path(datasets_root)
+
+    all_ok = True
+    for entry in catalog:
+        name = entry.get("name")
+        builder_entry = BUILDERS.get(name)
+        if not builder_entry:
+            continue
+
+        _, version_key = builder_entry
+        ds_dir = root / name
+        if not verify_version(version_key, str(ds_dir), versions_file):
+            all_ok = False
+
+    return all_ok
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience CLI
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Verify dataset versions for all entries in a catalog"
+    )
+    parser.add_argument("catalog", help="Path to dataset_catalog.json")
+    parser.add_argument(
+        "datasets_root", help="Directory containing built datasets"
+    )
+    parser.add_argument(
+        "--versions", required=True, help="Path to versions.yml file"
+    )
+    args = parser.parse_args()
+
+    ok = verify_catalog_versions(
+        args.catalog, args.datasets_root, args.versions
+    )
+    sys.exit(0 if ok else 1)

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -57,6 +57,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Write determinism validator to re-run and hash equality of artifacts
     [~] Integrate DVC pipelines and data/versions.yml locking
         - Added version verification utility and catalog build check
+        - Added catalog-wide version verification script
     [X] Add dataset schema contracts and unit tests for loaders
     [X] Implement dataset split manager for train/val/test with fixed seeds
 

--- a/tests/test_catalog_version_check.py
+++ b/tests/test_catalog_version_check.py
@@ -1,0 +1,50 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.build_from_catalog import build_from_catalog  # noqa: E402
+from dataset.version_lock import verify_catalog_versions  # noqa: E402
+
+
+def _write_sample_humaneval(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "task1",
+            "prompt": "int add(int a,int b){return a+b;}\n",
+            "test": "#include <cassert>\nint main(){assert(add(1,2)==3);}\n",
+        }
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_verify_catalog_versions(tmp_path):
+    raw = tmp_path / "humaneval.jsonl"
+    _write_sample_humaneval(raw)
+
+    catalog = [
+        {"name": "HumanEval-CPP", "path": str(raw), "license": "MIT"}
+    ]
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(json.dumps(catalog))
+
+    out_dir = tmp_path / "out"
+    versions_file = tmp_path / "versions.yml"
+
+    build_from_catalog(str(catalog_path), str(out_dir), str(versions_file))
+
+    assert verify_catalog_versions(
+        str(catalog_path), str(out_dir), str(versions_file)
+    )
+
+    # Corrupt the dataset and expect verification to fail
+    prompt = out_dir / "HumanEval-CPP" / "train" / "task1" / "prompt.cpp"
+    prompt.write_text("// modified\n")
+
+    assert not verify_catalog_versions(
+        str(catalog_path), str(out_dir), str(versions_file)
+    )


### PR DESCRIPTION
## Summary
- add `verify_catalog_versions` helper and CLI to check dataset hashes against `versions.yml`
- document progress on dataset version locking in Phase 3 checklist
- test catalog-wide version verification

## Testing
- `pytest tests/test_version_lock.py tests/test_build_from_catalog.py tests/test_catalog_version_check.py tests/test_dvc_yaml.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b46e5830833187d26789452fd69c