### PR TITLE
Add NSJail sandbox security tests

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -67,7 +67,7 @@ Save new code files in: C:\repos\hrm-coder
     [?] Implement caching layer keyed by prompt+code+tests+limits hash
     [X] Implement standalone I/O judge with whitespace-normalized diff and caching
     [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
-    [ ] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)
+    [~] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)
 
 ** [?] Phase 5: Reward Shaping and Safety Gates
     [X] Implement reward aggregator with weighted compile/link status, tests, and coverage signals

--- a/tests/test_sandbox_malicious_nsjail.py
+++ b/tests/test_sandbox_malicious_nsjail.py
@@ -1,0 +1,112 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from runners.cpp_runner import compile_cpp, run_binary
+from runners.error_taxonomy import classify_runtime
+from runners.nsjail import NSJailRunner
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("nsjail") is None, reason="nsjail not available"
+)
+
+
+def _compile(code: str, tmp_path: Path) -> Path:
+    src = tmp_path / "prog.cpp"
+    src.write_text(code)
+    res = compile_cpp(src)
+    assert res.success and res.binary is not None
+    return res.binary
+
+
+def _run(binary: Path):
+    runner = NSJailRunner(nsjail_path="nsjail")
+    return run_binary(binary, sandbox=runner)
+
+
+def test_file_read_denied(tmp_path):
+    code = r"""
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    int fd = open("/proc/self/mem", O_RDONLY);
+    if (fd == -1) {
+        perror("open");
+        return 1;
+    }
+    close(fd);
+    return 0;
+}
+"""
+    binary = _compile(code, tmp_path)
+    rc, _out, err = _run(binary)
+    assert rc != 0
+    assert classify_runtime(rc, err) == "policy_violation"
+
+
+def test_socket_open_denied(tmp_path):
+    code = r"""
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+int main() {
+    int s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s == -1) {
+        perror("socket");
+        return 1;
+    }
+    close(s);
+    return 0;
+}
+"""
+    binary = _compile(code, tmp_path)
+    rc, _out, err = _run(binary)
+    assert rc != 0
+    assert classify_runtime(rc, err) == "policy_violation"
+
+
+def test_fork_bomb_blocked(tmp_path):
+    code = r"""
+#include <unistd.h>
+
+int main() {
+    while (1) {
+        if (fork() == 0) {
+            // child sleeps to keep process alive
+            sleep(10);
+        }
+    }
+    return 0;
+}
+"""
+    binary = _compile(code, tmp_path)
+    rc, _out, err = _run(binary)
+    assert rc != 0
+    assert classify_runtime(rc, err) in {"policy_violation", "runtime_error"}
+
+
+def test_excessive_forks_blocked(tmp_path):
+    code = r"""
+#include <unistd.h>
+
+int main() {
+    for (int i = 0; i < 5; ++i) {
+        if (fork() == 0) {
+            sleep(10);
+        }
+    }
+    return 0;
+}
+"""
+    binary = _compile(code, tmp_path)
+    rc, _out, err = _run(binary)
+    assert rc != 0
+    assert classify_runtime(rc, err) in {"policy_violation", "runtime_error"}


### PR DESCRIPTION
## Summary
- test NSJail sandbox against malicious file access, socket opens, and fork bombs
- note progress on Phase 4 malicious integration tests in checklist

## Testing
- `pytest tests/test_sandbox_malicious.py tests/test_sandbox_malicious_nsjail.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0b4728e4883318000e99374184b58