### PR TITLE
feat: add linking options for C++ builds

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -116,5 +116,6 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
     [?] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
     [~] Configure static versus dynamic linking inside jail with rpath handling and ccache
+        - Added compile wrapper support for include paths, library directories, rpath, optional static builds, and ccache
     [ ] Create C++ security test suite for resource abuse and restricted syscalls
     [ ] Integrate C++ metrics and outcomes into common evaluator and reports

--- a/hrm_coder/cpp_compile.py
+++ b/hrm_coder/cpp_compile.py
@@ -10,6 +10,7 @@ warning and error counts into reward shaping or reporting pipelines.
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Sequence
+import shutil
 import subprocess
 
 # Default compile flags aimed at reasonably optimized yet deterministic
@@ -42,6 +43,12 @@ def compile_cpp(
     *,
     compiler: str = "g++",
     flags: Iterable[str] | None = None,
+    include_dirs: Iterable[Path] | None = None,
+    lib_dirs: Iterable[Path] | None = None,
+    libs: Iterable[str] | None = None,
+    rpaths: Iterable[Path] | None = None,
+    static: bool = False,
+    use_ccache: bool = False,
 ) -> CompileResult:
     """Compile C++ ``sources`` into ``output`` using ``compiler``.
 
@@ -56,13 +63,43 @@ def compile_cpp(
     flags:
         Additional flags to pass to the compiler. ``DEFAULT_FLAGS`` are
         prepended automatically.
+    include_dirs:
+        Optional include directories passed as ``-I``.
+    lib_dirs:
+        Optional library search paths passed as ``-L``.
+    libs:
+        Optional libraries to link against (``-l<name>``).
+    rpaths:
+        Runtime library search paths encoded via ``-Wl,-rpath``.
+    static:
+        If ``True``, add ``-static`` to request a fully static binary.
+    use_ccache:
+        If ``True`` and ``ccache`` is available, prefix the compile command
+        with it to leverage caching.
     """
 
     src_args = [str(Path(s)) for s in sources]
-    cmd: List[str] = [compiler, *DEFAULT_FLAGS]
+    cmd: List[str] = []
+    if use_ccache and shutil.which("ccache"):
+        cmd.append("ccache")
+    cmd.extend([compiler, *DEFAULT_FLAGS])
+    if static:
+        cmd.append("-static")
     if flags:
         cmd.extend(list(flags))
+    if include_dirs:
+        for d in include_dirs:
+            cmd.extend(["-I", str(d)])
+    if lib_dirs:
+        for d in lib_dirs:
+            cmd.extend(["-L", str(d)])
     cmd.extend(src_args)
+    if libs:
+        for lib in libs:
+            cmd.append(f"-l{lib}")
+    if rpaths:
+        for rp in rpaths:
+            cmd.append(f"-Wl,-rpath,{rp}")
     cmd.extend(["-o", str(output)])
 
     proc = subprocess.run(cmd, capture_output=True, text=True)

--- a/hrm_coder/tests/test_cpp_compile.py
+++ b/hrm_coder/tests/test_cpp_compile.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import subprocess
 
 from hrm_coder.cpp_compile import compile_cpp
 
@@ -29,3 +30,40 @@ def test_compile_with_warning(tmp_path: Path) -> None:
     result = compile_cpp([src], out, flags=["-Wall"])
     assert result.success
     assert result.warnings  # unused variable x should trigger warning
+
+
+def test_compile_with_include_and_lib(tmp_path: Path) -> None:
+    inc = tmp_path / "inc"
+    libdir = tmp_path / "lib"
+    inc.mkdir()
+    libdir.mkdir()
+
+    # Create a simple library
+    (inc / "foo.h").write_text("int foo();\n")
+    lib_src = tmp_path / "foo.cc"
+    lib_src.write_text("int foo() { return 0; }\n")
+    obj = tmp_path / "foo.o"
+    subprocess.run(["g++", "-c", str(lib_src), "-o", str(obj)], check=True)
+    liba = libdir / "libfoo.a"
+    subprocess.run(["ar", "rcs", str(liba), str(obj)], check=True)
+
+    # Main program using the library
+    main = tmp_path / "main.cc"
+    main.write_text("#include \"foo.h\"\nint main(){return foo();}\n")
+    out = tmp_path / "a.out"
+
+    result = compile_cpp(
+        [main],
+        out,
+        include_dirs=[inc],
+        lib_dirs=[libdir],
+        libs=["foo"],
+        rpaths=[libdir],
+    )
+
+    assert result.success
+    cmd_str = " ".join(result.cmd)
+    assert "-I" in result.cmd and str(inc) in result.cmd
+    assert "-L" in result.cmd and str(libdir) in result.cmd
+    assert "-lfoo" in result.cmd
+    assert f"-Wl,-rpath,{libdir}" in result.cmd


### PR DESCRIPTION
## Summary
- allow compile_cpp to handle include and library paths, rpath, optional static builds, and ccache
- cover linking and rpath support in unit tests
- note progress on linking configuration in Phase 10 checklist

## Testing
- `pip install httpx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b47d52f0833182bfe21c18bf260b