### PR TITLE
Handle missing tree-sitter dependency gracefully

### DIFF
--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -10,14 +10,14 @@ on code tasks.
 
 from .code_tokenizer import CppTokenizer
 from .code_encoder import CodeEncoder
-from .ast_encoder import ASTEncoder, NodeTypeSchema
 from .training_loop import HRMTrainer, HRMTrainingConfig
 
-__all__ = [
-    "CppTokenizer",
-    "CodeEncoder",
-    "ASTEncoder",
-    "NodeTypeSchema",
-    "HRMTrainer",
-    "HRMTrainingConfig",
-]
+try:  # pragma: no cover - optional AST dependency
+    from .ast_encoder import ASTEncoder, NodeTypeSchema
+except Exception:  # pragma: no cover
+    ASTEncoder = None  # type: ignore[assignment]
+    NodeTypeSchema = None  # type: ignore[assignment]
+
+__all__ = ["CppTokenizer", "CodeEncoder", "HRMTrainer", "HRMTrainingConfig"]
+if ASTEncoder is not None:
+    __all__ += ["ASTEncoder", "NodeTypeSchema"]

--- a/hrm/ast_encoder.py
+++ b/hrm/ast_encoder.py
@@ -14,13 +14,14 @@ this to richer embeddings (e.g. parent chains or typed edges).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
-
-from tree_sitter import Node, Parser, Tree
+from typing import Any, Dict, List, Tuple
 
 try:  # pragma: no cover - optional dependency may be missing
+    from tree_sitter import Node, Parser, Tree
     from tree_sitter_languages import get_parser
-except Exception as exc:  # pragma: no cover
+    _PARSER_ERROR = None
+except Exception as exc:  # pragma: no cover - Tree-sitter not installed
+    Node = Parser = Tree = Any  # type: ignore[assignment]
     get_parser = None  # type: ignore[assignment]
     _PARSER_ERROR = exc
 

--- a/utils/ast_actions.py
+++ b/utils/ast_actions.py
@@ -10,7 +10,12 @@ space" for Phase 9 of the HRM Coder roadmap.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from tree_sitter import Node
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from tree_sitter import Node
+except Exception:  # pragma: no cover - Tree-sitter not installed
+    Node = Any  # type: ignore[assignment]
 
 from utils.ast_edit import CppAst, EditResult
 

--- a/utils/ast_cursor.py
+++ b/utils/ast_cursor.py
@@ -16,9 +16,12 @@ future learned cursor module.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, Optional, Protocol
+from typing import Any, Callable, Iterable, Optional, Protocol
 
-from tree_sitter import Node, Tree
+try:  # pragma: no cover - optional dependency
+    from tree_sitter import Node, Tree
+except Exception:  # pragma: no cover - Tree-sitter not installed
+    Node = Tree = Any  # type: ignore[assignment]
 
 
 Predicate = Callable[[Node], bool]

--- a/utils/ast_edit.py
+++ b/utils/ast_edit.py
@@ -19,12 +19,14 @@ on top with node embeddings and higher level edit policies.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
-from tree_sitter import Node, Tree
-try:  # pragma: no cover - import guard
+try:  # pragma: no cover - optional dependency
+    from tree_sitter import Node, Tree
     from tree_sitter_languages import get_parser
-except Exception as exc:  # pragma: no cover - runtime environment may lack compiled grammars
+    _PARSER_ERROR = None
+except Exception as exc:  # pragma: no cover - Tree-sitter not installed
+    Node = Tree = Any  # type: ignore[assignment]
     get_parser = None  # type: ignore[assignment]
     _PARSER_ERROR = exc
 


### PR DESCRIPTION
## Summary
- Guard tree-sitter imports across AST modules and only export AST utilities when tree-sitter is available
- Allow HRM package to import without tree-sitter so smoke tests can run in minimal environments

## Testing
- `python scripts/smoke_eval.py > smoke_eval.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ebcfd0bc83319d917b58067d4462