### PR TITLE
Add dataset build script and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .PHONY: data build_runner build_trainer train eval report lint smoke cpp-build cpp-test
 
-# Placeholder targets for Phase 1 scaffold
+# Phase 1 scaffold targets
+
+DATA_OUT ?= data/processed
 
 data:
-	@echo "Data pipeline not implemented yet"
+        python scripts/build_data.py --output $(DATA_OUT) $(ARGS)
 
 build_runner:
         docker build -f runner.Dockerfile -t hrm-runner .

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -33,6 +33,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Create Makefile targets for data, train, eval, report, and tooling (CMake + ctest integration)
         - Added build_trainer target for trainer Docker image
         - Added lint target invoking pre-commit hooks
+        - Wired data target to dataset.build_from_catalog for deterministic builds
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
         - Added helper to instantiate sandbox runners from configuration

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Build processed datasets from the repository catalog."""
+
+import argparse
+from pathlib import Path
+
+from dataset.build_from_catalog import build_from_catalog
+
+DEFAULT_CATALOG = Path("docs/dataset_catalog.json")
+DEFAULT_OUTPUT = Path("data/processed")
+DEFAULT_VERSIONS = Path("data/versions.yml")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build datasets defined in docs/dataset_catalog.json",
+    )
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        default=DEFAULT_CATALOG,
+        help="Path to the dataset catalog JSON file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Directory to write processed datasets into",
+    )
+    parser.add_argument(
+        "--versions",
+        type=Path,
+        default=DEFAULT_VERSIONS,
+        help="Path to versions.yml for hash locking",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed forwarded to dataset builders",
+    )
+    parser.add_argument(
+        "--no-check",
+        action="store_true",
+        help="Skip deterministic build validation",
+    )
+    args = parser.parse_args()
+
+    build_from_catalog(
+        str(args.catalog),
+        str(args.output),
+        str(args.versions),
+        seed=args.seed,
+        check_determinism=not args.no_check,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add `build_data.py` CLI to create processed datasets from `docs/dataset_catalog.json`
- wire `make data` target to the new script for deterministic builds
- document Phase 1 progress in hrmCoder checklist

## Testing
- `pre-commit run --files Makefile scripts/build_data.py docs/hrmCoder_checklist.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0ec1d2c7c8331819726de18992ce6