### PR TITLE
Add Phase 0 environment audit CLI

### DIFF
--- a/hrm_coder/audit_cli.py
+++ b/hrm_coder/audit_cli.py
@@ -1,0 +1,71 @@
+"""Phase 0 environment audit CLI.
+
+This lightweight command line interface inspects the current
+environment and prints information useful during Phase 0 of the
+hrm-coder project.  It reports potential injection points in the
+``hrm`` package as well as available sandbox backends and C++
+toolchain components.
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict
+
+from .inventory import inventory_package, find_injection_points
+from runners import sandbox_detector, toolchain_detector
+
+
+def perform_audit(package: str = "hrm") -> Dict[str, Any]:
+    """Collect audit information for ``package``.
+
+    Returns a dictionary containing injection points, sandbox detection
+    results and toolchain detection results.  The function is separated
+    from the CLI to facilitate unit testing.
+    """
+
+    inventory = inventory_package(package)
+    injection_points = find_injection_points(inventory)
+    sandboxes = sandbox_detector.detect_sandboxes()
+    toolchains = toolchain_detector.detect_toolchains()
+    return {
+        "injection_points": injection_points,
+        "sandboxes": sandboxes,
+        "toolchains": toolchains,
+    }
+
+
+def _format_available(info: Dict[str, Any]) -> str:
+    return "available" if info.get("available") else "missing"
+
+
+def _print_audit(data: Dict[str, Any]) -> None:
+    print("Injection points:")
+    for point in data["injection_points"]:
+        print(f" - {point}")
+
+    print("\nSandboxes:")
+    for name, info in data["sandboxes"].items():
+        status = _format_available(info)
+        ver = f" ({info['version']})" if info.get("version") else ""
+        print(f" - {name}: {status}{ver}")
+
+    print("\nToolchains:")
+    for name, info in data["toolchains"].items():
+        status = _format_available(info)
+        meets = " (meets requirement)" if info.get("meets_requirement") else ""
+        ver = f" ({info['version']})" if info.get("version") else ""
+        print(f" - {name}: {status}{meets}{ver}")
+
+
+def main() -> None:  # pragma: no cover - exercised via tests
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package", default="hrm", help="Python package to inspect"
+    )
+    args = parser.parse_args()
+    data = perform_audit(args.package)
+    _print_audit(data)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/hrm_coder/tests/test_audit_cli.py
+++ b/hrm_coder/tests/test_audit_cli.py
@@ -1,0 +1,61 @@
+import sys
+
+import hrm_coder.audit_cli as audit_cli
+from hrm_coder.inventory import ModuleInventory
+
+
+def test_perform_audit(monkeypatch):
+    def fake_inventory_package(pkg):
+        return {"mod": ModuleInventory("mod", ["CodeEncoder"], [])}
+
+    def fake_find_injection_points(inv):
+        return ["mod.CodeEncoder"]
+
+    monkeypatch.setattr(audit_cli, "inventory_package", fake_inventory_package)
+    monkeypatch.setattr(
+        audit_cli, "find_injection_points", fake_find_injection_points
+    )
+    monkeypatch.setattr(
+        audit_cli.sandbox_detector,
+        "detect_sandboxes",
+        lambda: {
+            "isolate": {
+                "available": True,
+                "version": "1.0",
+                "path": "/bin/isolate",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        audit_cli.toolchain_detector,
+        "detect_toolchains",
+        lambda: {
+            "g++": {
+                "available": True,
+                "version": "13.1",
+                "path": "/bin/g++",
+                "meets_requirement": True,
+            }
+        },
+    )
+    data = audit_cli.perform_audit("fake")
+    assert data["injection_points"] == ["mod.CodeEncoder"]
+    assert data["sandboxes"]["isolate"]["available"] is True
+    assert data["toolchains"]["g++"]["meets_requirement"] is True
+
+
+def test_main_prints(monkeypatch, capsys):
+    monkeypatch.setattr(
+        audit_cli,
+        "perform_audit",
+        lambda pkg: {
+            "injection_points": ["a.b"],
+            "sandboxes": {},
+            "toolchains": {},
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["audit_cli"])
+    audit_cli.main()
+    out = capsys.readouterr().out
+    assert "Injection points:" in out
+    assert "a.b" in out


### PR DESCRIPTION
## Summary
- add CLI to audit sandbox and toolchain availability and list HRM injection points
- cover audit CLI with unit tests

## Testing
- `pre-commit run --files hrm_coder/audit_cli.py hrm_coder/tests/test_audit_cli.py`
- `pytest hrm_coder/tests/test_audit_cli.py hrm_coder/tests/test_inventory.py hrm_coder/tests/test_runner_utils.py tests/test_sandbox_detector.py tests/test_toolchain_detector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec1860948331adb22ef89516aeac