### PR TITLE
Add DVC pipeline CLI for Phase 3 dataset workflow

### DIFF
--- a/dataset/dvc.py
+++ b/dataset/dvc.py
@@ -64,3 +64,42 @@ def write_dvc_yaml(
     path = Path(yaml_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience CLI
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate a dvc.yaml stage for dataset builds",
+    )
+    parser.add_argument(
+        "catalog", help="Path to dataset_catalog.json describing datasets"
+    )
+    parser.add_argument(
+        "output_dir", help="Directory where processed datasets will be written"
+    )
+    parser.add_argument(
+        "--versions",
+        required=True,
+        help="Path to versions.yml recording dataset hashes",
+    )
+    parser.add_argument(
+        "--yaml",
+        default="dvc.yaml",
+        help="Path to write generated dvc.yaml file",
+    )
+    parser.add_argument(
+        "--stage-name",
+        default="build-datasets",
+        help="Name of the generated DVC stage",
+    )
+
+    args = parser.parse_args()
+
+    write_dvc_yaml(
+        args.catalog,
+        args.output_dir,
+        args.versions,
+        yaml_path=args.yaml,
+        stage_name=args.stage_name,
+    )

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -61,6 +61,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Integrate DVC pipelines and data/versions.yml locking
         - Added version verification utility and catalog build check
         - Added catalog-wide version verification script
+        - Added CLI for generating DVC pipeline stage YAML
     [X] Add dataset schema contracts and unit tests for loaders
     [X] Implement dataset split manager for train/val/test with fixed seeds
 

--- a/tests/test_dvc_cli.py
+++ b/tests/test_dvc_cli.py
@@ -1,0 +1,59 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from dataset.dvc import generate_stage_yaml  # noqa: E402
+
+
+def test_generate_stage_yaml_basic():
+    yaml = generate_stage_yaml(
+        "catalog.json", "out", "versions.yml", stage_name="stage"
+    )
+    assert "stages:" in yaml
+    assert "stage:" in yaml
+    cmd_line = (
+        "cmd: python -m dataset.build_from_catalog "
+        "catalog.json out --versions versions.yml"
+    )
+    assert cmd_line in yaml
+    assert "- catalog.json" in yaml
+    assert "- dataset/build_from_catalog.py" in yaml
+    assert "- out" in yaml
+    assert "- versions.yml" in yaml
+
+
+def test_cli_writes_dvc_yaml(tmp_path: Path):
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text("[]")
+    out_dir = tmp_path / "out"
+    versions = tmp_path / "versions.yml"
+    dvc_yaml = tmp_path / "generated.yaml"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "dataset.dvc",
+        str(catalog),
+        str(out_dir),
+        "--versions",
+        str(versions),
+        "--yaml",
+        str(dvc_yaml),
+        "--stage-name",
+        "stage",
+    ]
+    subprocess.run(cmd, check=True)
+
+    assert dvc_yaml.exists()
+    content = dvc_yaml.read_text()
+    expected_cmd = (
+        f"cmd: python -m dataset.build_from_catalog {catalog} "
+        f"{out_dir} --versions {versions}"
+    )
+    assert expected_cmd in content
+    assert "  stage:" in content
+    assert f"- {catalog}" in content
+    assert f"- {out_dir}" in content
+    assert f"- {versions}" in content


### PR DESCRIPTION
## Summary
- add command line interface to generate DVC stage YAML for dataset builds
- document Phase 3 progress in hrmCoder checklist
- test DVC YAML generation and CLI invocation

## Testing
- `pre-commit run --files tests/test_dvc_cli.py dataset/dvc.py docs/hrmCoder_checklist.md`
- `pytest tests/test_dvc_cli.py tests/test_dvc_yaml.py tests/test_catalog_version_check.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0ec27713c83318ff77ed7b9acbc5e