### PR TITLE
feat: memoize sandbox runs

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -68,7 +68,7 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
     [X] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
-    [?] Implement caching layer keyed by prompt+code+tests+limits hash
+    [X] Implement caching layer keyed by prompt+code+tests+limits hash
     [X] Implement standalone I/O judge with whitespace-normalized diff and caching
     [X] Implement error taxonomy parser for compile, link, runtime, timeout, and policy violations
     [~] Create malicious sample integration tests (file read, fork bomb, excessive forks, socket open)

--- a/hrm_coder/runner.py
+++ b/hrm_coder/runner.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 from typing import List, Optional
 import subprocess
 
-from runners import GVisorRunner, IsolateRunner, NSJailRunner, sandbox_detector
+from runners import (
+    GVisorRunner,
+    IsolateRunner,
+    NSJailRunner,
+    sandbox_detector,
+)
+from runners.sandbox_cache import SandboxCache
 from .config import RunnerConfig
 
 
@@ -37,12 +43,38 @@ def run_in_sandbox(
     *,
     network: Optional[bool] = None,
     stdin: Optional[bytes] = None,
+    cache: Optional[SandboxCache] = None,
 ) -> subprocess.CompletedProcess:
-    """Execute ``command`` inside the sandbox described by ``config``."""
+    """Execute ``command`` inside the sandbox described by ``config``.
+
+    When ``cache`` is provided the output of identical invocations is
+    memoized. The cache key is derived from the command, runner limits, and
+    ``stdin`` payload.
+    """
 
     runner = create_sandbox_runner(config)
     memory_kb = config.memory_limit * 1024
     network = config.network if network is None else network
+
+    key: Optional[str] = None
+    if cache is not None:
+        parts = [p.encode() for p in command]
+        parts.append(str(config.timeout).encode())
+        parts.append(str(config.memory_limit).encode())
+        parts.append(str(config.cpus).encode())
+        parts.append(b"net_on" if network else b"net_off")
+        if stdin is not None:
+            parts.append(stdin)
+        key = cache.hash_parts(parts)
+        cached = cache.load(key)
+        if cached is not None:
+            return subprocess.CompletedProcess(
+                command,
+                cached["returncode"],
+                cached.get("stdout", ""),
+                cached.get("stderr", ""),
+            )
+
     common_kwargs = dict(
         time_limit=config.timeout,
         wall_time=config.timeout,
@@ -52,14 +84,26 @@ def run_in_sandbox(
         stdin=stdin,
     )
     if isinstance(runner, IsolateRunner):
-        return runner.run(command, **common_kwargs)
-    if isinstance(runner, NSJailRunner):
-        return runner.run(command, **common_kwargs)
-    if isinstance(runner, GVisorRunner):
+        proc = runner.run(command, **common_kwargs)
+    elif isinstance(runner, NSJailRunner):
+        proc = runner.run(command, **common_kwargs)
+    elif isinstance(runner, GVisorRunner):
         # gVisor's runner does not support wall_time; ignore it
         common_kwargs.pop("wall_time", None)
-        return runner.run(command, **common_kwargs)
-    raise TypeError(f"Unsupported runner type: {type(runner).__name__}")
+        proc = runner.run(command, **common_kwargs)
+    else:
+        raise TypeError(f"Unsupported runner type: {type(runner).__name__}")
+
+    if cache is not None and key is not None:
+        cache.store(
+            key,
+            {
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            },
+        )
+    return proc
 
 
 __all__ = ["create_sandbox_runner", "run_in_sandbox"]

--- a/hrm_coder/tests/test_runner_utils.py
+++ b/hrm_coder/tests/test_runner_utils.py
@@ -1,8 +1,9 @@
 import subprocess
 
+from runners import IsolateRunner, NSJailRunner, sandbox_detector
+from runners.sandbox_cache import SandboxCache
 from hrm_coder.config import RunnerConfig
 from hrm_coder.runner import create_sandbox_runner, run_in_sandbox
-from runners import IsolateRunner, NSJailRunner, sandbox_detector
 
 
 def test_create_sandbox_runner_explicit():
@@ -53,3 +54,28 @@ def test_run_in_sandbox_override_network(monkeypatch):
     monkeypatch.setattr(IsolateRunner, "run", fake_run)
     run_in_sandbox(["/bin/true"], cfg, network=True)
     assert called["network"] is True
+
+
+def test_run_in_sandbox_cache(monkeypatch, tmp_path):
+    cfg = RunnerConfig(sandbox="isolate")
+    cache = SandboxCache(tmp_path / "cache")
+
+    class SpyRunner(IsolateRunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def run(self, command, **kwargs):
+            self.calls += 1
+            return subprocess.CompletedProcess(command, 0, "OUT", "ERR")
+
+    spy = SpyRunner()
+    import hrm_coder.runner as runner_mod
+
+    monkeypatch.setattr(runner_mod, "create_sandbox_runner", lambda _cfg: spy)
+    cmd = ["/bin/echo", "hi"]
+    first = run_in_sandbox(cmd, cfg, cache=cache)
+    assert spy.calls == 1
+    second = run_in_sandbox(cmd, cfg, cache=cache)
+    assert spy.calls == 1
+    assert first.stdout == second.stdout == "OUT"


### PR DESCRIPTION
## Summary
- add optional SandboxCache to `run_in_sandbox` so repeated commands reuse prior outputs
- cover cached execution with unit test
- mark sandbox caching task complete in checklist

## Testing
- `pre-commit run --files hrm_coder/runner.py hrm_coder/tests/test_runner_utils.py docs/hrmCoder_checklist.md`
- `pytest hrm_coder/tests/test_runner_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec2e64f883319d43b350fbe02eae