### PR TITLE
Add sandbox smoke testing utility

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -19,6 +19,7 @@ Save new code files in: C:\repos\hrm-coder
         - Added default sandbox selection helper to prefer isolate and fall back to nsjail or runsc
         - Integrated sandbox auto-selection into runner configuration
         - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
+        - Added sandbox smoke test script to verify basic command execution in available backends
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
         - Added dataset catalog utility with hash validation and unit tests
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)

--- a/scripts/sandbox_smoke.py
+++ b/scripts/sandbox_smoke.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run a simple command inside available sandbox backends.
+
+Phase 0 evaluates different sandbox adapters.  This script detects which
+sandboxes are present on the host and attempts to execute ``/bin/echo``
+inside each of them.  The outcome for every backend is reported as JSON
+so that developers can quickly gauge which runners are operational.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+import sys
+
+# Ensure repository root on module search path
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from runners import sandbox_detector  # noqa: E402
+from runners.isolate import IsolateRunner, SandboxError as IsolateError  # noqa: E402
+from runners.nsjail import NSJailRunner, SandboxError as NSJailError  # noqa: E402
+from runners.gvisor import GVisorRunner, SandboxError as GVisorError  # noqa: E402
+
+
+def _run_isolate(path: str) -> Dict[str, Any]:
+    runner = IsolateRunner(isolate_path=path)
+    try:
+        proc = runner.run(["/bin/echo", "hello"], stdout_limit=1024, stderr_limit=1024)
+        return {
+            "available": True,
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except Exception as exc:  # pragma: no cover - environment dependent
+        return {"available": True, "ok": False, "error": str(exc)}
+
+
+def _run_nsjail(path: str) -> Dict[str, Any]:
+    runner = NSJailRunner(nsjail_path=path)
+    try:
+        proc = runner.run(["/bin/echo", "hello"], stdout_limit=1024, stderr_limit=1024)
+        return {
+            "available": True,
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except Exception as exc:  # pragma: no cover - environment dependent
+        return {"available": True, "ok": False, "error": str(exc)}
+
+
+def _run_gvisor() -> Dict[str, Any]:
+    runner = GVisorRunner()
+    try:
+        proc = runner.run(["/bin/echo", "hello"])
+        return {
+            "available": True,
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except Exception as exc:  # pragma: no cover - environment dependent
+        return {"available": True, "ok": False, "error": str(exc)}
+
+
+def smoke_test() -> Dict[str, Any]:
+    info = sandbox_detector.detect_sandboxes()
+    results: Dict[str, Any] = {}
+
+    iso = info.get("isolate", {})
+    if iso.get("available") and iso.get("path"):
+        results["isolate"] = _run_isolate(iso["path"])
+    else:
+        results["isolate"] = {"available": False, "ok": None}
+
+    ns = info.get("nsjail", {})
+    if ns.get("available") and ns.get("path"):
+        results["nsjail"] = _run_nsjail(ns["path"])
+    else:
+        results["nsjail"] = {"available": False, "ok": None}
+
+    gv = info.get("runsc", {})
+    if gv.get("available"):
+        results["runsc"] = _run_gvisor()
+    else:
+        results["runsc"] = {"available": False, "ok": None}
+
+    return results
+
+
+def main() -> None:
+    print(json.dumps(smoke_test(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sandbox_smoke.py
+++ b/tests/test_sandbox_smoke.py
@@ -1,0 +1,22 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_sandbox_smoke_outputs_json(tmp_path):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "sandbox_smoke.py"
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo_root,
+    )
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    for name in ("isolate", "nsjail", "runsc"):
+        assert name in data
+        assert "available" in data[name]
+        assert "ok" in data[name]


### PR DESCRIPTION
## Summary
- add `sandbox_smoke.py` script to probe available sandbox backends by running a simple command inside each
- add unit test validating script output format
- note smoke test in Phase 0 checklist

## Testing
- `pytest tests/test_sandbox_smoke.py -q`
- `pytest tests/test_env_probe.py tests/test_sandbox_detector.py tests/test_toolchain_detector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1934a05388331b735a5fa4754ae90