### PR TITLE
Add Phase 1 report generation scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ train:
 	python -m hrm_coder.train $(ARGS)
 
 eval:
-	python -m hrm_coder.eval_cli $(ARGS)
+        python -m hrm_coder.eval_cli $(ARGS)
 
 report:
-        @echo "Report generation not implemented yet"
+       python scripts/report.py $(ARGS)
 
 lint:
         pre-commit run --all-files

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -34,6 +34,7 @@ Save new code files in: C:\repos\hrm-coder
         - Added build_trainer target for trainer Docker image
         - Added lint target invoking pre-commit hooks
         - Wired data target to dataset.build_from_catalog for deterministic builds
+        - Added report target generating Markdown/HTML summaries from evaluation results
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
         - Added helper to instantiate sandbox runners from configuration

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Generate evaluation reports from results JSON.
+
+This lightweight wrapper feeds the Phase 7 reporting utilities so that
+Phase 1 scaffolding can produce basic Markdown/HTML summaries.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from hrm_coder.evaluation import generate_reports
+
+
+def main() -> None:  # pragma: no cover - simple CLI
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "results",
+        type=Path,
+        help="JSON file mapping task id to a list of attempt outcomes",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Directory to write generated reports",
+    )
+    parser.add_argument(
+        "--k",
+        dest="ks",
+        type=int,
+        nargs="*",
+        default=[1, 10],
+        help="k values for pass@k computation",
+    )
+    args = parser.parse_args()
+    generate_reports(
+        results_path=args.results,
+        output_dir=args.output,
+        ks=args.ks,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add CLI wrapper to produce Markdown/HTML evaluation reports
- wire `make report` target to new script
- note report target progress in Phase 1 checklist

## Testing
- `pre-commit run --files Makefile docs/hrmCoder_checklist.md scripts/report.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a193535cc48331ab3dd61f6a451619