### PR TITLE
Add dataset version verification CLI

### DIFF
--- a/scripts/verify_data_versions.py
+++ b/scripts/verify_data_versions.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Verify processed dataset hashes against the recorded versions file."""
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.version_lock import verify_catalog_versions  # noqa: E402
+
+DEFAULT_CATALOG = Path("docs/dataset_catalog.json")
+DEFAULT_DATA = Path("data/processed")
+DEFAULT_VERSIONS = Path("data/versions.yml")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify dataset hashes match entries in versions.yml",
+    )
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        default=DEFAULT_CATALOG,
+        help="Path to dataset_catalog.json",
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=DEFAULT_DATA,
+        help="Root directory containing processed datasets",
+    )
+    parser.add_argument(
+        "--versions",
+        type=Path,
+        default=DEFAULT_VERSIONS,
+        help="Path to versions.yml with recorded hashes",
+    )
+    args = parser.parse_args()
+
+    ok = verify_catalog_versions(
+        str(args.catalog), str(args.data), str(args.versions)
+    )
+    if not ok:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_verify_data_versions_script.py
+++ b/tests/test_verify_data_versions_script.py
@@ -1,0 +1,71 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.build_from_catalog import build_from_catalog  # noqa: E402
+
+
+def _write_sample_humaneval(path: Path) -> None:
+    tasks = [
+        {
+            "task_id": "task1",
+            "prompt": "int add(int a,int b){return a+b;}\n",
+            "test": "#include <cassert>\nint main(){assert(add(1,2)==3);}\n",
+        }
+    ]
+    with path.open("w") as fh:
+        for t in tasks:
+            json.dump(t, fh)
+            fh.write("\n")
+
+
+def test_verify_data_versions_script(tmp_path):
+    raw = tmp_path / "humaneval.jsonl"
+    _write_sample_humaneval(raw)
+
+    catalog = [{"name": "HumanEval-CPP", "path": str(raw), "license": "MIT"}]
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(json.dumps(catalog))
+
+    out_dir = tmp_path / "out"
+    versions_file = tmp_path / "versions.yml"
+
+    build_from_catalog(str(catalog_path), str(out_dir), str(versions_file))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/verify_data_versions.py",
+            "--catalog",
+            str(catalog_path),
+            "--data",
+            str(out_dir),
+            "--versions",
+            str(versions_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    prompt = out_dir / "HumanEval-CPP" / "train" / "task1" / "prompt.cpp"
+    prompt.write_text("// modified\n")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/verify_data_versions.py",
+            "--catalog",
+            str(catalog_path),
+            "--data",
+            str(out_dir),
+            "--versions",
+            str(versions_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- add `verify_data_versions.py` helper to check processed datasets against `versions.yml`
- cover helper with unit test ensuring failure when hashes mismatch

## Testing
- `pre-commit run --files scripts/verify_data_versions.py tests/test_verify_data_versions_script.py`
- `pytest tests/test_verify_data_versions_script.py tests/test_catalog_version_check.py tests/test_dvc_yaml.py tests/test_dvc_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1935bab4c83318246e3d198e33603