### PR TITLE
chore: inject sanitizer env into cpp runner

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -120,6 +120,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)
     [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
     [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
+        - Injected default ASAN_OPTIONS and UBSAN_OPTIONS in run_binary for deterministic sanitized runs
     [?] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
     [~] Configure static versus dynamic linking inside jail with rpath handling and ccache
         - Added compile wrapper support for include paths, library directories, rpath, optional static builds, and ccache

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -33,6 +33,16 @@ SANITIZER_FLAGS: List[str] = [
     "-fno-omit-frame-pointer",
 ]
 
+# Default sanitizer environment ensuring deterministic behaviour when
+# AddressSanitizer or UndefinedBehaviorSanitizer are enabled.  These
+# settings disable leak detection (which can introduce nondeterminism)
+# and force the sanitizers to terminate immediately on failure without
+# coloured output that would pollute logs in some sandboxes.
+SANITIZER_ENV: Mapping[str, str] = {
+    "ASAN_OPTIONS": "detect_leaks=0:halt_on_error=1:color=never",
+    "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1:color=never",
+}
+
 
 @dataclass
 class CompileResult:
@@ -319,6 +329,7 @@ def run_binary(
     timeout: float = 2.0,
     memory_limit: Optional[int] = None,
     env: Optional[Mapping[str, str]] = None,
+    sanitize_env: bool = True,
     sandbox: Optional[IsolateRunner] = None,
     cwd: Optional[Path] = None,
     stdout_limit: Optional[int] = None,
@@ -345,6 +356,10 @@ def run_binary(
         Extra environment variables to inject. When a sandbox is provided
         the variables are forwarded to it, otherwise they are passed to
         :func:`subprocess.run` directly.
+    sanitize_env:
+        When ``True`` injects default ``ASAN_OPTIONS`` and ``UBSAN_OPTIONS``
+        values via :data:`SANITIZER_ENV`.  Callers may set this to ``False``
+        to disable injection or override variables via ``env``.
     sandbox:
         Optional :class:`~runners.isolate.IsolateRunner` used to enforce
         resource limits and disable networking.
@@ -361,6 +376,14 @@ def run_binary(
     if cwd is None:
         cwd = binary.parent
 
+    if sanitize_env:
+        env_combined: Optional[Mapping[str, str]] = {
+            **SANITIZER_ENV,
+            **(env or {}),
+        }
+    else:
+        env_combined = dict(env) if env is not None else None
+
     if sandbox is not None:
         memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -373,7 +396,7 @@ def run_binary(
                     stdin=input_data,
                     workdir=tmpdir,
                     readonly_dirs=[str(cwd)],
-                    env=env,
+                    env=env_combined,
                     stdout_limit=stdout_limit,
                     stderr_limit=stderr_limit,
                 )
@@ -385,7 +408,7 @@ def run_binary(
                         wall_time=int(timeout),
                         memory=memory_kb,
                         stdin=input_data,
-                        env=env,
+                        env=env_combined,
                         stdout_limit=stdout_limit,
                         stderr_limit=stderr_limit,
                     )
@@ -396,6 +419,7 @@ def run_binary(
                         wall_time=int(timeout),
                         memory=memory_kb,
                         stdin=input_data,
+                        env=env_combined,
                         stdout_limit=stdout_limit,
                         stderr_limit=stderr_limit,
                     )
@@ -415,7 +439,11 @@ def run_binary(
         errors="replace",
         timeout=timeout,
         preexec_fn=preexec,
-        env={**os.environ, **env} if env is not None else None,
+        env=(
+            {**os.environ, **env_combined}
+            if env_combined is not None
+            else None
+        ),
         cwd=str(cwd),
     )
     stdout = proc.stdout

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -242,7 +242,10 @@ int main(){std::cout<<times_two(7);}
     )
     assert code == 0
     assert stdout.strip() == "14"
-    assert runner.env == {"LD_LIBRARY_PATH": str(tmp_path)}
+    assert runner.env is not None
+    assert runner.env["LD_LIBRARY_PATH"] == str(tmp_path)
+    assert "ASAN_OPTIONS" in runner.env
+    assert "UBSAN_OPTIONS" in runner.env
 
 
 class SpyRunner:
@@ -294,7 +297,9 @@ def test_run_codeforces_tests_cache(tmp_path: Path, monkeypatch):
     assert first == second
 
 
-def test_run_codeforces_tests_cache_includes_flags(tmp_path: Path, monkeypatch):
+def test_run_codeforces_tests_cache_includes_flags(
+    tmp_path: Path, monkeypatch
+) -> None:
     src = tmp_path / "main.cpp"
     src.write_text(
         "#include <iostream>\nint main(){std::cout<<1;}"
@@ -410,3 +415,29 @@ int main(){std::this_thread::sleep_for(std::chrono::milliseconds(100));}
 
     res = run_codeforces_task([src], task_dir, sanitize=False)
     assert res["results"][0]["error_type"] == "timeout"
+
+
+def test_run_binary_injects_sanitizer_env(tmp_path: Path, monkeypatch) -> None:
+    """``run_binary`` should inject sanitizer env variables by default."""
+    src = tmp_path / "main.cpp"
+    src.write_text("int main(){return 0;}")
+
+    res = compile_cpp_sources([src], sanitize=False)
+    assert res.success and res.binary is not None
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+
+        class P:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return P()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    run_binary(res.binary)
+    assert "ASAN_OPTIONS" in captured["env"]
+    assert "UBSAN_OPTIONS" in captured["env"]


### PR DESCRIPTION
## Summary
- inject default ASAN/UBSAN environment variables when executing C++ binaries
- document Phase 10 progress for sanitizer-aware sandbox execution
- add regression test ensuring sanitizer env vars are applied

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py docs/hrmCoder_checklist.md`
- `pytest tests/test_cpp_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1936eae888331823831822d2f2332