### PR TITLE
Add DVC stage generator and update Phase 3 docs

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -55,16 +55,17 @@ Save new code files in: C:\repos\hrm-coder
     [X] Provide GUI quickstart docs and sample configs
     [X] Expose coverage summary endpoint and display on run page
 
-** [ ] Phase 3: Deterministic Dataset Pipeline (C++)
+** [X] Phase 3: Deterministic Dataset Pipeline (C++)
     [X] Implement HumanEval-CPP builder with harness generator and reference solutions
     [X] Implement Codeforces-Intro builder (I/O testcases, constraints, per-problem time limits)
     [X] Implement AtCoder ABC subset builder with normalized input/output cases
     [X] Implement Kattis micro-set builder for additional I/O tasks
     [X] Write determinism validator to re-run and hash equality of artifacts
-    [~] Integrate DVC pipelines and data/versions.yml locking
+    [X] Integrate DVC pipelines and data/versions.yml locking
         - Added version verification utility and catalog build check
         - Added catalog-wide version verification script
         - Added CLI for generating DVC pipeline stage YAML
+        - Added convenience script `generate_dvc_yaml.py` for stage creation
     [X] Add dataset schema contracts and unit tests for loaders
     [X] Implement dataset split manager for train/val/test with fixed seeds
 

--- a/docs/hrmCoder_plan.md
+++ b/docs/hrmCoder_plan.md
@@ -171,6 +171,8 @@ Stubbed early with mock run objects and static artifact samples.
 * **AtCoder ABC** builder: normalized I/O harness.
 * Determinism validator: re-run → identical verdicts/hashes; record toolchain.
 * DVC pipelines; schema contracts & unit tests; seeded splits.
+  `scripts/generate_dvc_yaml.py` emits the DVC stage tying the catalog to
+  `build_from_catalog` with `versions.yml` locks.
 
 ### P4 – Sandbox Executor (C++)
 

--- a/scripts/generate_dvc_yaml.py
+++ b/scripts/generate_dvc_yaml.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Generate a dvc.yaml stage for dataset builds."""
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset.dvc import write_dvc_yaml  # noqa: E402
+
+DEFAULT_CATALOG = Path("docs/dataset_catalog.json")
+DEFAULT_OUTPUT = Path("data/processed")
+DEFAULT_VERSIONS = Path("data/versions.yml")
+DEFAULT_DVC_YAML = Path("dvc.yaml")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a dvc.yaml stage for building datasets",
+    )
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        default=DEFAULT_CATALOG,
+        help="Path to dataset_catalog.json",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Directory for processed datasets",
+    )
+    parser.add_argument(
+        "--versions",
+        type=Path,
+        default=DEFAULT_VERSIONS,
+        help="Path to versions.yml with dataset hashes",
+    )
+    parser.add_argument(
+        "--yaml",
+        type=Path,
+        default=DEFAULT_DVC_YAML,
+        help="Where to write the generated dvc.yaml",
+    )
+    parser.add_argument(
+        "--stage-name",
+        default="build-datasets",
+        help="Name of the generated DVC stage",
+    )
+    args = parser.parse_args()
+
+    write_dvc_yaml(
+        str(args.catalog),
+        str(args.output),
+        str(args.versions),
+        yaml_path=str(args.yaml),
+        stage_name=args.stage_name,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add `generate_dvc_yaml.py` helper script for creating DVC stages tied to dataset builds
- mark dataset pipeline phase complete and document the new script

## Testing
- `pytest tests/test_dvc_yaml.py tests/test_dvc_cli.py tests/test_verify_data_versions_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a198a9c5dc8331a6f009531ce6e0ca