### PR TITLE
feat: add JSON output to audit CLI

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -20,6 +20,7 @@ Save new code files in: C:\repos\hrm-coder
         - Integrated sandbox auto-selection into runner configuration
         - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
         - Added sandbox smoke test script to verify basic command execution in available backends
+        - Added audit CLI with optional JSON output for programmatic environment checks
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
         - Added dataset catalog utility with hash validation and unit tests
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)

--- a/hrm_coder/audit_cli.py
+++ b/hrm_coder/audit_cli.py
@@ -9,6 +9,7 @@ toolchain components.
 from __future__ import annotations
 
 import argparse
+import json
 from typing import Any, Dict
 
 from .inventory import inventory_package, find_injection_points
@@ -62,9 +63,17 @@ def main() -> None:  # pragma: no cover - exercised via tests
     parser.add_argument(
         "--package", default="hrm", help="Python package to inspect"
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of text",
+    )
     args = parser.parse_args()
     data = perform_audit(args.package)
-    _print_audit(data)
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        _print_audit(data)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/hrm_coder/tests/test_audit_cli.py
+++ b/hrm_coder/tests/test_audit_cli.py
@@ -1,3 +1,4 @@
+import json
 import sys
 
 import hrm_coder.audit_cli as audit_cli
@@ -59,3 +60,20 @@ def test_main_prints(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Injection points:" in out
     assert "a.b" in out
+
+
+def test_main_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        audit_cli,
+        "perform_audit",
+        lambda pkg: {
+            "injection_points": ["a.b"],
+            "sandboxes": {},
+            "toolchains": {},
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["audit_cli", "--json"])
+    audit_cli.main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["injection_points"] == ["a.b"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ omegaconf
 hydra-core
 huggingface_hub
 fastapi
+httpx
 uvicorn
 pytest
 tree_sitter


### PR DESCRIPTION
## Summary
- add optional JSON output to hrm-coder Phase 0 audit CLI
- document new audit capability in Phase 0 checklist
- include httpx dependency for FastAPI test client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1989e2bb08331a5609ec8c51bd4c3