### PR TITLE
Add nsjail runner tests and update sandbox checklist

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -69,7 +69,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement dataset split manager for train/val/test with fixed seeds
 
 ** [ ] Phase 4: Sandbox Executor
-    [~] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
+    [?] Implement isolate/nsjail adapter with CPU, RAM, wall time, and net-off policies
     [~] Implement C++ build-and-run pipeline (CMake/g++/clang++) with JUnit XML via GoogleTest
     [X] Add filesystem policy: temp working dir, RO mounts, stdout/stderr caps
     [X] Implement caching layer keyed by prompt+code+tests+limits hash

--- a/tests/test_nsjail_runner.py
+++ b/tests/test_nsjail_runner.py
@@ -1,0 +1,60 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from runners.nsjail import NSJailRunner
+
+
+def test_build_command_defaults():
+    runner = NSJailRunner(nsjail_path="nsjail")
+    cmd = runner.build_command([
+        "/bin/echo",
+        "hi",
+    ], time_limit=1, wall_time=2, memory=1024, processes=1)
+    assert cmd[0] == "nsjail"
+    assert "-Mo" in cmd
+    assert "--disable_clone_newnet" not in cmd
+    assert f"--time_limit=1" in cmd
+    assert f"--rlimit_as={1024 * 1024}" in cmd
+    assert f"--cgroup_pids_max=1" in cmd
+    assert cmd[-2:] == ["/bin/echo", "hi"]
+
+
+def test_build_command_with_options():
+    runner = NSJailRunner(nsjail_path="nsjail")
+    cmd = runner.build_command(
+        ["/bin/true"],
+        time_limit=1,
+        memory=2048,
+        processes=2,
+        network=True,
+        workdir="/tmp/work",
+        readonly_dirs=["/data"],
+        env={"FOO": "BAR"},
+        fsize=64,
+    )
+    assert "--disable_clone_newnet" in cmd
+    assert "--cwd" in cmd and "--bindmount" in cmd
+    assert f"/tmp/work:/tmp/work" in cmd
+    assert "--bindmount_ro" in cmd
+    assert f"/data:/data" in cmd
+    assert "--env" in cmd and "FOO=BAR" in cmd
+    assert "--rlimit_fsize=64" in cmd
+
+
+def test_run_truncates_output(monkeypatch):
+    runner = NSJailRunner(nsjail_path="nsjail")
+    monkeypatch.setattr("shutil.which", lambda p: "/usr/bin/nsjail")
+    Completed = subprocess.CompletedProcess
+
+    def fake_run(cmd, *args, **kwargs):
+        return Completed(cmd, 0, "A" * 100, "B" * 100)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    proc = runner.run(["/bin/echo", "hi"], stdout_limit=10, stderr_limit=10)
+    assert proc.stdout == "A" * 10
+    assert proc.stderr == "B" * 10


### PR DESCRIPTION
## Summary
- add unit tests for NSJailRunner covering command construction and output truncation
- note progress on sandbox adapter in Phase 4 checklist

## Testing
- `pytest tests/test_nsjail_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a198af0b1883318aa3e1d9a58de07e