### PR TITLE
Add sandbox command runner utility

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -14,6 +14,7 @@ Save new code files in: C:\repos\hrm-coder
 ** [~] Phase 0: Discovery & Reuse Audit
     [X] Inventory HRM repo APIs and identify injection points for C++ token/AST decoders
     [~] Setup project operation within isolate/gVisor runner images
+        - Added run_in_sandbox utility script for executing arbitrary commands in the selected sandbox backend
     [~] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
         - Added sandbox detection utility for isolate, nsjail, and gVisor runsc runtime
         - Added default sandbox selection helper to prefer isolate and fall back to nsjail or runsc

--- a/scripts/run_in_sandbox.py
+++ b/scripts/run_in_sandbox.py
@@ -1,0 +1,81 @@
+"""Execute a command inside the configured sandbox.
+
+This small utility wraps :func:`hrm_coder.runner.run_in_sandbox` so that
+developers can quickly invoke commands inside the first available
+sandbox backend (``isolate``, ``nsjail`` or gVisor's ``runsc`` runtime).
+
+Example::
+
+    python scripts/run_in_sandbox.py -- echo "hello"
+
+The command after ``--`` is executed in the sandbox.  By default the
+script auto-selects the sandbox backend, but a specific one can be chosen
+via ``--sandbox``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List
+
+from hrm_coder.config import RunnerConfig
+from hrm_coder.runner import run_in_sandbox
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a command in a sandbox")
+    parser.add_argument(
+        "--sandbox",
+        default="auto",
+        help="Sandbox backend (isolate, nsjail, runsc, auto)",
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=5, help="CPU time limit in seconds"
+    )
+    parser.add_argument(
+        "--memory",
+        type=int,
+        default=256,
+        help="Memory limit in megabytes",
+    )
+    parser.add_argument(
+        "--cpus", type=int, default=1, help="Number of allowed processes"
+    )
+    parser.add_argument(
+        "--network",
+        action="store_true",
+        help="Allow network access inside the sandbox",
+    )
+    parser.add_argument(
+        "cmd",
+        nargs=argparse.REMAINDER,
+        help="Command to run (use -- to separate)",
+    )
+    args = parser.parse_args(argv)
+    if not args.cmd:
+        parser.error("no command provided")
+    if args.cmd[0] == "--":
+        args.cmd = args.cmd[1:]
+    return args
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    config = RunnerConfig(
+        sandbox=args.sandbox,
+        timeout=args.timeout,
+        memory_limit=args.memory,
+        cpus=args.cpus,
+        network=args.network,
+    )
+    proc = run_in_sandbox(args.cmd, config)
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+    return proc.returncode
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_run_in_sandbox_script.py
+++ b/tests/test_run_in_sandbox_script.py
@@ -1,0 +1,30 @@
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_run_in_sandbox_script(monkeypatch, capsys):
+    script = (
+        Path(__file__).resolve().parents[1] / "scripts" / "run_in_sandbox.py"
+    )
+
+    import hrm_coder.runner as runner_mod
+
+    def fake_run(cmd, cfg):
+        assert cfg.timeout == 7
+        assert cmd == ["echo", "hi"]
+        return subprocess.CompletedProcess(cmd, 0, "OUT", "")
+
+    monkeypatch.setattr(runner_mod, "run_in_sandbox", fake_run)
+    monkeypatch.setattr(
+        sys, "argv", [str(script), "--timeout", "7", "--", "echo", "hi"]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(script, run_name="__main__")
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == "OUT"


### PR DESCRIPTION
## Summary
- add `run_in_sandbox.py` helper to execute commands inside isolate, nsjail or gVisor
- document new sandbox runner utility in Phase 0 checklist
- test new command runner script

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md scripts/run_in_sandbox.py tests/test_run_in_sandbox_script.py`
- `pytest tests/test_run_in_sandbox_script.py tests/test_gvisor.py tests/test_config_auto_sandbox.py hrm_coder/tests/test_runner_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68a19d182d9883318a17e7004e4242e4