### PR TITLE
feat: extend gVisor runner for env and output caps

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -21,6 +21,10 @@ Save new code files in: C:\repos\hrm-coder
         - Added toolchain detection utility for g++, clang++, lcov, llvm-cov, and gcov
         - Added sandbox smoke test script to verify basic command execution in available backends
         - Added audit CLI with optional JSON output for programmatic environment checks
+        - Added environment variable and output limit support to gVisor runner
+        ~ Document feature parity matrix for isolate, nsjail, and gVisor adapters
+        ~ Add integration tests verifying resource limit enforcement across adapters
+        ~ Investigate file size limit enforcement support in gVisor runner
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
         - Added dataset catalog utility with hash validation and unit tests
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)

--- a/runners/gvisor.py
+++ b/runners/gvisor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Mapping, Optional
 
 
 class SandboxError(RuntimeError):
@@ -12,7 +12,7 @@ class SandboxError(RuntimeError):
 
 
 class GVisorRunner:
-    """Adapter that runs commands inside a Docker container with gVisor runtime.
+    """Adapter that runs commands inside a Docker container using gVisor.
 
     This runner constructs ``docker run`` invocations that leverage the
     ``runsc`` runtime provided by gVisor.  Only a subset of Docker's resource
@@ -22,7 +22,9 @@ class GVisorRunner:
     without a full container environment.
     """
 
-    def __init__(self, *, docker_path: str = "docker", image: str = "ubuntu:latest") -> None:
+    def __init__(
+        self, *, docker_path: str = "docker", image: str = "ubuntu:latest"
+    ) -> None:
         self.docker_path = docker_path
         self.image = image
 
@@ -36,8 +38,10 @@ class GVisorRunner:
         network: bool = False,
         workdir: Optional[str] = None,
         readonly_dirs: Optional[Iterable[str]] = None,
+        env: Optional[Mapping[str, str]] = None,
     ) -> List[str]:
-        """Build a ``docker run`` command that executes ``command`` under gVisor.
+        """Build a ``docker run`` command that executes ``command`` under
+        gVisor.
 
         Parameters
         ----------
@@ -56,13 +60,16 @@ class GVisorRunner:
         readonly_dirs:
             Iterable of host paths to mount read-only inside the container at
             the same paths.
+        env:
+            Optional mapping of environment variables to define inside the
+            container.
         """
         docker_cmd = [
             self.docker_path,
             "run",
             "--rm",
             "--runtime=runsc",
-            f"--cpus=1",
+            "--cpus=1",
             f"--pids-limit={processes}",
             f"--memory={memory}k",
         ]
@@ -73,6 +80,9 @@ class GVisorRunner:
         if readonly_dirs is not None:
             for path in readonly_dirs:
                 docker_cmd.extend(["-v", f"{path}:{path}:ro"])
+        if env is not None:
+            for key, value in env.items():
+                docker_cmd.extend(["-e", f"{key}={value}"])
         docker_cmd.append(self.image)
         docker_cmd.extend(command)
         return docker_cmd
@@ -87,11 +97,16 @@ class GVisorRunner:
         network: bool = False,
         workdir: Optional[str] = None,
         readonly_dirs: Optional[Iterable[str]] = None,
+        env: Optional[Mapping[str, str]] = None,
         stdin: Optional[bytes] = None,
+        stdout_limit: Optional[int] = None,
+        stderr_limit: Optional[int] = None,
     ) -> subprocess.CompletedProcess:
         """Execute ``command`` inside a gVisor-backed Docker container."""
         if shutil.which(self.docker_path) is None:
-            raise SandboxError(f"docker executable not found: {self.docker_path}")
+            raise SandboxError(
+                f"docker executable not found: {self.docker_path}"
+            )
         cmd = self.build_command(
             command,
             time_limit=time_limit,
@@ -100,11 +115,21 @@ class GVisorRunner:
             network=network,
             workdir=workdir,
             readonly_dirs=readonly_dirs,
+            env=env,
         )
-        return subprocess.run(
+        proc = subprocess.run(
             cmd,
             input=stdin,
             capture_output=True,
             text=True,
             check=False,
+        )
+        stdout_data = proc.stdout
+        stderr_data = proc.stderr
+        if stdout_limit is not None:
+            stdout_data = stdout_data[:stdout_limit]
+        if stderr_limit is not None:
+            stderr_data = stderr_data[:stderr_limit]
+        return subprocess.CompletedProcess(
+            cmd, proc.returncode, stdout_data, stderr_data
         )

--- a/tests/test_gvisor.py
+++ b/tests/test_gvisor.py
@@ -1,9 +1,10 @@
 import os
 import sys
+import shutil
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from runners.gvisor import GVisorRunner
+from runners.gvisor import GVisorRunner  # noqa: E402
 
 
 def test_build_command_network_off_by_default():
@@ -11,7 +12,7 @@ def test_build_command_network_off_by_default():
     cmd = runner.build_command(["/bin/echo", "hello"], processes=2)
     assert cmd[:4] == ["docker", "run", "--rm", "--runtime=runsc"]
     assert "--network=none" in cmd
-    assert f"--pids-limit=2" in cmd
+    assert "--pids-limit=2" in cmd
     assert cmd[-2:] == ["/bin/echo", "hello"]
 
 
@@ -23,6 +24,33 @@ def test_build_command_with_mounts_and_workdir():
         readonly_dirs=["/data"],
     )
     assert "-w" in cmd and cmd[cmd.index("-w") + 1] == "/workspace"
-    mount_flag = f"/data:/data:ro"
+    mount_flag = "/data:/data:ro"
     assert any(part.endswith(mount_flag) for part in cmd)
     assert "--network=none" in cmd
+
+
+def test_build_command_with_env():
+    runner = GVisorRunner(docker_path="docker", image="ubuntu:latest")
+    cmd = runner.build_command(["/bin/true"], env={"FOO": "BAR", "BAZ": "QUX"})
+    assert "-e" in cmd
+    assert "FOO=BAR" in cmd
+    assert "BAZ=QUX" in cmd
+
+
+def test_run_truncates_output(monkeypatch):
+    runner = GVisorRunner(docker_path="docker", image="ubuntu:latest")
+
+    monkeypatch.setattr(shutil, "which", lambda p: "/usr/bin/docker")
+
+    import subprocess
+
+    Completed = subprocess.CompletedProcess
+
+    def fake_run(cmd, *args, **kwargs):
+        return Completed(cmd, 0, "A" * 100, "B" * 100)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    proc = runner.run(["/bin/echo", "hi"], stdout_limit=10, stderr_limit=5)
+    assert proc.stdout == "A" * 10
+    assert proc.stderr == "B" * 5


### PR DESCRIPTION
## Summary
- add env var injection and output limit handling to gVisor runner
- test gVisor env and truncation behaviors
- track sandbox evaluation gaps and remaining tasks in checklist

## Testing
- `pre-commit run --files runners/gvisor.py tests/test_gvisor.py docs/hrmCoder_checklist.md`
- `pytest tests/test_gvisor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a19d2ce11c833195a3a3a0f6438dba