### PR TITLE
docs: refine sandbox threat model and risk register

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -24,9 +24,9 @@ Save new code files in: C:\repos\hrm-coder
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
         - Added dataset catalog utility with hash validation and unit tests
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
-    [~] Draft sandbox Threat Model and initial security requirements for native binaries
-    [~] Write ADRs for sandbox choice, experiment tracker, and GUI stack
-    [~] Create initial risk register and mitigation plan
+    [?] Draft sandbox Threat Model and initial security requirements for native binaries
+    [?] Write ADRs for sandbox choice, experiment tracker, and GUI stack
+    [?] Create initial risk register and mitigation plan
 
 ** [ ] Phase 1: Repo Scaffold & Deterministic Environment
     [X] Generate project layout scaffold script for hrm-coder directory tree

--- a/docs/risk_register.md
+++ b/docs/risk_register.md
@@ -2,11 +2,24 @@
 
 This register tracks early risks for Phase 0 of HRM Coder and proposed mitigations.
 
-| ID | Risk | Impact | Likelihood | Mitigation |
-|----|------|--------|------------|------------|
-| R1 | Sandbox escape leading to host compromise | High | Medium | Use `isolate` with strict seccomp and run integration tests with malicious code |
-| R2 | Missing toolchain components delaying development | Medium | Medium | Provide `env_probe.py` utility and document required packages |
-| R3 | Dataset licensing conflicts | High | Low | Maintain dataset catalog with source URLs and license details |
-| R4 | Loss of determinism in builds or tests | Medium | Medium | Pin toolchain versions and enforce fixed seeds |
+| ID | Risk | Impact | Likelihood | Mitigation | Status |
+|----|------|--------|------------|------------|--------|
+| R1 | Sandbox escape leading to host compromise | High | Medium | Use `isolate` with strict seccomp and run integration tests with malicious code | Open |
+| R2 | Missing toolchain components delaying development | Medium | Medium | Provide `env_probe.py` utility and document required packages | Mitigating |
+| R3 | Dataset licensing conflicts | High | Low | Maintain dataset catalog with source URLs and license details | Open |
+| R4 | Loss of determinism in builds or tests | Medium | Medium | Pin toolchain versions and enforce fixed seeds | Open |
+| R5 | Experiment tracker exposes credentials or metrics | Medium | Low | Restrict access, require auth, run tracker behind VPN | Planned |
+| R6 | GUI stack vulnerable to XSS or CSRF | Medium | Low | Use server-side templating, validate inputs, enable CSRF tokens | Planned |
+| R7 | Unpatched dependency vulnerabilities in runner images | High | Medium | Maintain SBOM and rebuild images with security updates | Planned |
+
+## Mitigation Plan
+
+- **R1**: add CI security tests using known escape techniques; review isolate profiles quarterly.
+- **R2**: keep `env_probe.py` as a pre-flight check in developer setup guides.
+- **R3**: verify licenses before adding datasets and track provenance in `dataset_catalog.json`.
+- **R4**: lock compiler versions in Dockerfiles and record `gcc --version` in run logs.
+- **R5**: configure MLflow with per-user tokens and restrict network exposure.
+- **R6**: adopt content-security policies and run dynamic analysis with OWASP ZAP.
+- **R7**: enable Dependabot alerts and monthly base-image rebuilds.
 
 This document will be updated as new risks are identified.

--- a/docs/sandbox_threat_model.md
+++ b/docs/sandbox_threat_model.md
@@ -3,9 +3,10 @@
 This document outlines potential threats when executing untrusted native binaries during HRM Coder development.
 
 ## Assets
-- Host operating system and other processes
-- Dataset integrity and evaluation results
-- Credentials and network isolation guarantees
+- Host operating system, kernel, and hardware resources
+- Build toolchain, compiler caches, and temporary artifacts
+- Dataset integrity, evaluation results, and MLflow tracking data
+- Credentials, secrets, and network isolation guarantees
 
 ## Assumptions
 - Attackers can supply arbitrary C++ code snippets that are compiled and executed.
@@ -13,18 +14,20 @@ This document outlines potential threats when executing untrusted native binarie
 - Network access inside the sandbox is disabled.
 
 ## Threats
-1. **Escaping the sandbox** via kernel vulnerabilities or misconfiguration.
-2. **Resource exhaustion** such as fork bombs or excessive memory use.
-3. **Filesystem access** beyond the working directory, including `/proc` or host mounts.
-4. **Network access** attempts despite policy to remain offline.
-5. **Abuse of privileged syscalls** leading to privilege escalation.
+1. **Escaping the sandbox** via kernel vulnerabilities, misconfiguration, or symlink/mount tricks.
+2. **Resource exhaustion** such as fork bombs, uncontrolled threads, or excessive memory use.
+3. **Filesystem access** beyond the working directory, including `/proc`, device nodes, or host mounts.
+4. **Network access** attempts despite policy to remain offline or to exfiltrate data.
+5. **Abuse of privileged syscalls** leading to privilege escalation or capability leakage.
+6. **Compiler or linker manipulation** to inject malicious build scripts or preload shared objects.
 
-## Security Requirements
-- Enforce strict CPU, memory, and wall-clock limits.
-- Run binaries as a non-root user with minimal capabilities.
-- Mount only a temporary working directory with read-only source files.
-- Apply seccomp or similar syscall filters restricting networking and dangerous operations.
-- Ensure repeatability: sandbox configuration is declarative and version controlled.
+## Security Requirements for Native Binaries
+- Enforce strict CPU, memory, and wall-clock limits for each run.
+- Execute as a non-root user with dropped capabilities and a separate mount namespace.
+- Provide only a temporary working directory with read-only source and toolchain files.
+- Apply seccomp or similar syscall filters restricting networking, filesystem, and process-control operations.
+- Validate compiler and linker inputs; allow linking only against approved libraries.
+- Ensure reproducibility: sandbox configuration and limits are version controlled.
 
 ## Mitigations
 - Prefer `isolate` as the default sandbox; fall back to `nsjail` or `runsc` if available.


### PR DESCRIPTION
## Summary
- expand sandbox threat model with native binary requirements
- draft risk register with mitigation plan
- update phase 0 checklist statuses

## Testing
- `pre-commit run --files docs/sandbox_threat_model.md docs/risk_register.md docs/hrmCoder_checklist.md`


------
https://chatgpt.com/codex/tasks/task_e_68a19d469fbc8331b3083fa81ae7e2b6