### PR TITLE
docs: finalize initial adr set

### DIFF
--- a/docs/adr/0001-sandbox-choice.md
+++ b/docs/adr/0001-sandbox-choice.md
@@ -4,10 +4,22 @@
 Accepted
 
 ## Context
-HRM Coder needs a sandbox to execute untrusted C++ binaries safely. Options include `isolate`, `nsjail`, and `runsc` from gVisor.
+HRM Coder needs a sandbox to execute untrusted C++ binaries safely. We
+evaluated three mature options that provide process isolation with CPU and
+memory limits:
+
+* **isolate** – small C utility used in IOI/CMS with good documentation and low
+  overhead.
+* **nsjail** – feature rich, but requires more configuration and has a larger
+  surface area.
+* **runsc** (gVisor) – strongest isolation using a user-space kernel, but
+  heavier to integrate and slower for short‑lived jobs.
 
 ## Decision
-Use **isolate** as the default sandbox backend. Keep **nsjail** and gVisor's **runsc** available as fallbacks to aid portability and testing.
+Use **isolate** as the default sandbox backend. It offers the simplest
+integration while providing deterministic CPU, memory, and wall time limits. We
+will keep **nsjail** and gVisor's **runsc** adapters available as fallbacks to
+aid portability and benchmarking on platforms where isolate is unavailable.
 
 ## Consequences
 - `isolate` becomes a hard dependency for runner images.

--- a/docs/adr/0002-experiment-tracker.md
+++ b/docs/adr/0002-experiment-tracker.md
@@ -4,13 +4,23 @@
 Accepted
 
 ## Context
-Training runs must be reproducible and comparable. A lightweight experiment tracker will log metrics, parameters, and artifacts.
-Options considered were **Weights & Biases** (W&B) and **MLflow**.
+Training runs must be reproducible and comparable. A lightweight experiment
+tracker will log metrics, parameters, and artifacts. Two candidates were
+evaluated:
+
+* **Weights & Biases (W&B)** – excellent hosted UI and collaboration features
+  but requires external services for self‑hosting.
+* **MLflow** – open source with a simple local file backend and optional server
+  mode.
 
 ## Decision
-Adopt **MLflow** for the initial implementation. It is open-source, self-hostable, and integrates well with Python tooling used in HRM Coder.
+Adopt **MLflow** for the initial implementation. It is open-source,
+self-hostable, and integrates well with Python tooling and Hydra configs used in
+HRM Coder.
 
 ## Consequences
-- MLflow server will be bundled with development docker compose for easy startup.
+- MLflow server will be bundled with development docker compose for easy
+  startup.
 - Future work may add optional W&B integration for cloud-based tracking.
-- Artifacts such as coverage reports and reward logs are stored under the MLflow run directory.
+- Artifacts such as coverage reports and reward logs are stored under the MLflow
+  run directory.

--- a/docs/adr/0003-gui-stack.md
+++ b/docs/adr/0003-gui-stack.md
@@ -4,12 +4,19 @@
 Accepted
 
 ## Context
-A minimal web interface is required for launching runs and viewing artifacts. Options include full-featured frameworks or lightweight stacks.
+A minimal web interface is required for launching runs and viewing artifacts. We
+considered heavy single-page-app frameworks versus lighter, mostly
+server-rendered approaches.
 
 ## Decision
-Use **FastAPI** for the backend with a simple HTML/JavaScript frontend built with **htmx** and **Tailwind CSS**. This keeps the stack lightweight while enabling interactive pages and WebSocket log streaming.
+Use **FastAPI** for the backend with a simple HTML/JavaScript frontend built
+with **htmx** and **Tailwind CSS**. This keeps the stack lightweight while
+enabling interactive pages and WebSocket log streaming without a separate build
+step.
 
 ## Consequences
-- The GUI shares Python dependencies with the backend runner, simplifying development.
-- htmx keeps the frontend mostly server-rendered, avoiding a large SPA build toolchain.
+- The GUI shares Python dependencies with the backend runner, simplifying
+  development.
+- htmx keeps the frontend mostly server-rendered, avoiding a large SPA build
+  toolchain.
 - Tailwind CSS provides basic styling without hand-written CSS.

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -25,7 +25,10 @@ Save new code files in: C:\repos\hrm-coder
         - Added dataset catalog utility with hash validation and unit tests
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
     [~] Draft sandbox Threat Model and initial security requirements for native binaries
-    [~] Write ADRs for sandbox choice, experiment tracker, and GUI stack
+    [X] Write ADRs for sandbox choice, experiment tracker, and GUI stack
+        - Added ADR 0001 detailing isolate as default sandbox with nsjail/runsc fallbacks
+        - Added ADR 0002 selecting MLflow for experiment tracking
+        - Added ADR 0003 choosing FastAPI with htmx/Tailwind for the GUI stack
     [~] Create initial risk register and mitigation plan
 
 ** [ ] Phase 1: Repo Scaffold & Deterministic Environment


### PR DESCRIPTION
## Summary
- detail sandbox evaluation with isolate as default and nsjail/runsc fallbacks
- choose MLflow for experiment tracking with optional W&B future integration
- adopt FastAPI + htmx + Tailwind CSS GUI stack and mark ADR task complete

## Testing
- `pre-commit run --files docs/adr/0001-sandbox-choice.md docs/adr/0002-experiment-tracker.md docs/adr/0003-gui-stack.md docs/hrmCoder_checklist.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a19d51668883318dfc66c9d3e9f43e