### PR TITLE
feat: add test tooling make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,45 @@
-.PHONY: data build_runner build_trainer train eval report lint smoke cpp-build cpp-test
+.PHONY: data build_runner build_trainer train eval report lint smoke cpp-build cpp-test test tooling
 
 # Phase 1 scaffold targets
 
 DATA_OUT ?= data/processed
 
 data:
-        python scripts/build_data.py --output $(DATA_OUT) $(ARGS)
+	python scripts/build_data.py --output $(DATA_OUT) $(ARGS)
 
 build_runner:
-        docker build -f runner.Dockerfile -t hrm-runner .
+	docker build -f runner.Dockerfile -t hrm-runner .
 
 build_trainer:
-        docker build -f trainer.Dockerfile -t hrm-trainer .
+	docker build -f trainer.Dockerfile -t hrm-trainer .
 
 train:
 	python -m hrm_coder.train $(ARGS)
 
 eval:
-        python -m hrm_coder.eval_cli $(ARGS)
+	python -m hrm_coder.eval_cli $(ARGS)
 
 report:
-       python scripts/report.py $(ARGS)
+	python scripts/report.py $(ARGS)
 
 lint:
-        pre-commit run --all-files
+	pre-commit run --all-files
 
 smoke:
-        python scripts/smoke_train.py
+	python scripts/smoke_train.py
+
+# Run Python and C++ tests
+test: cpp-test
+	pytest $(ARGS)
+
+# Convenience target aggregating lint and tests
+tooling: lint test
 
 # Basic C++ build and test targets for Phase 1 scaffolding
 CPP_PRESET ?= sanitized
 
 cpp-build:
-	cmake --preset $(CPP_PRESET) -S hrm_coder/cpp
+	cmake --preset $(CPP_PRESET)
 	cmake --build build/$(CPP_PRESET)
 
 cpp-test: cpp-build

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -38,6 +38,10 @@ Save new code files in: C:\repos\hrm-coder
         - Added lint target invoking pre-commit hooks
         - Wired data target to dataset.build_from_catalog for deterministic builds
         - Added report target generating Markdown/HTML summaries from evaluation results
+        - Added test target running pytest and ctest suites
+        - Added tooling target combining lint and test
+        ~ Document train and eval target usage examples
+        ~ Add coverage target aggregating ctest and pytest results
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
         - Added helper to instantiate sandbox runners from configuration


### PR DESCRIPTION
## Summary
- add `test` and `tooling` make targets
- document new build/test items in hrmCoder checklist
- switch cpp build to use cmake presets

## Testing
- `pre-commit run --files Makefile docs/hrmCoder_checklist.md`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a19dd2d7c08331b5f305ab9bca71e8