### PR TITLE
Add explicit resource policies to nsjail adapter

### DIFF
--- a/runners/nsjail.py
+++ b/runners/nsjail.py
@@ -43,8 +43,7 @@ class NSJailRunner:
         time_limit:
             CPU time limit in seconds.
         wall_time:
-            Wall clock limit in seconds (``nsjail`` uses the same flag for
-            both CPU and wall limits).
+            Wall clock limit in seconds.
         memory:
             Memory limit in kilobytes.
         processes:
@@ -63,17 +62,22 @@ class NSJailRunner:
         fsize:
             Optional limit for files created by the process in bytes.
         """
+        bytes_limit = memory * 1024
         nsjail_cmd = [
             self.nsjail_path,
             "-Mo",
-            f"--time_limit={time_limit}",
-            f"--rlimit_as={memory * 1024}",
+            f"--time_limit={wall_time}",
+            f"--rlimit_cpu={time_limit}",
+            f"--cgroup_mem_max={bytes_limit}",
+            f"--rlimit_as={bytes_limit}",
             f"--cgroup_pids_max={processes}",
         ]
         if network:
             nsjail_cmd.append("--disable_clone_newnet")
         if workdir is not None:
-            nsjail_cmd.extend(["--cwd", workdir, "--bindmount", f"{workdir}:{workdir}"])
+            nsjail_cmd.extend(
+                ["--cwd", workdir, "--bindmount", f"{workdir}:{workdir}"]
+            )
         if readonly_dirs is not None:
             for path in readonly_dirs:
                 nsjail_cmd.extend(["--bindmount_ro", f"{path}:{path}"])
@@ -149,4 +153,9 @@ class NSJailRunner:
         if tmpdir_ctx is not None:
             tmpdir_ctx.cleanup()
 
-        return subprocess.CompletedProcess(cmd, proc.returncode, stdout_data, stderr_data)
+        return subprocess.CompletedProcess(
+            cmd,
+            proc.returncode,
+            stdout_data,
+            stderr_data,
+        )

--- a/tests/test_isolate.py
+++ b/tests/test_isolate.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 import subprocess
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from runners.isolate import IsolateRunner
 
@@ -19,6 +16,10 @@ def test_build_command_has_no_network_by_default():
     assert cmd[0] == "isolate"
     assert f"--box-id={runner.box_id}" in cmd
     assert "--net=none" in cmd
+    assert "--time=1" in cmd
+    assert "--wall=2" in cmd
+    assert "--mem=1024" in cmd
+    assert "--processes=1" in cmd
     assert "--run" in cmd
     run_idx = cmd.index("--run")
     assert cmd[run_idx + 1] == "--"
@@ -43,7 +44,10 @@ def test_build_command_with_filesystem_options():
 
 def test_build_command_with_env():
     runner = IsolateRunner(isolate_path="isolate", box_id=2)
-    cmd = runner.build_command(["/bin/true"], env={"LD_LIBRARY_PATH": "/libs", "FOO": "BAR"})
+    cmd = runner.build_command(
+        ["/bin/true"],
+        env={"LD_LIBRARY_PATH": "/libs", "FOO": "BAR"},
+    )
     assert "--env=LD_LIBRARY_PATH=/libs" in cmd
     assert "--env=FOO=BAR" in cmd
 
@@ -51,7 +55,10 @@ def test_build_command_with_env():
 def test_build_command_with_output_limits():
     runner = IsolateRunner(isolate_path="isolate", box_id=3)
     cmd = runner.build_command(
-        ["/bin/true"], stdout="out.txt", stderr="err.txt", fsize=64
+        ["/bin/true"],
+        stdout="out.txt",
+        stderr="err.txt",
+        fsize=64,
     )
     assert "--stdout=out.txt" in cmd
     assert "--stderr=err.txt" in cmd
@@ -86,4 +93,3 @@ def test_run_truncates_output(monkeypatch, tmp_path):
     assert proc.stdout == "A" * 10
     assert proc.stderr == "B" * 10
     assert captured["workdir"] is not None
-

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -1,8 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from runners.nsjail import NSJailRunner
 
 
@@ -17,6 +12,11 @@ def test_build_command_network_off_by_default():
     )
     assert cmd[0] == "nsjail"
     assert "--disable_clone_newnet" not in cmd
+    assert "--time_limit=2" in cmd
+    assert "--rlimit_cpu=1" in cmd
+    assert f"--cgroup_mem_max={1024 * 1024}" in cmd
+    assert f"--rlimit_as={1024 * 1024}" in cmd
+    assert "--cgroup_pids_max=1" in cmd
     assert "--" in cmd
     assert cmd[-2:] == ["/bin/echo", "hello"]
 

--- a/tests/test_nsjail_runner.py
+++ b/tests/test_nsjail_runner.py
@@ -1,10 +1,4 @@
 import subprocess
-import sys
-from pathlib import Path
-
-import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from runners.nsjail import NSJailRunner
 
@@ -18,9 +12,11 @@ def test_build_command_defaults():
     assert cmd[0] == "nsjail"
     assert "-Mo" in cmd
     assert "--disable_clone_newnet" not in cmd
-    assert f"--time_limit=1" in cmd
+    assert "--time_limit=2" in cmd
+    assert "--rlimit_cpu=1" in cmd
+    assert f"--cgroup_mem_max={1024 * 1024}" in cmd
     assert f"--rlimit_as={1024 * 1024}" in cmd
-    assert f"--cgroup_pids_max=1" in cmd
+    assert "--cgroup_pids_max=1" in cmd
     assert cmd[-2:] == ["/bin/echo", "hi"]
 
 
@@ -29,6 +25,7 @@ def test_build_command_with_options():
     cmd = runner.build_command(
         ["/bin/true"],
         time_limit=1,
+        wall_time=3,
         memory=2048,
         processes=2,
         network=True,
@@ -38,10 +35,14 @@ def test_build_command_with_options():
         fsize=64,
     )
     assert "--disable_clone_newnet" in cmd
+    assert "--time_limit=3" in cmd
+    assert "--rlimit_cpu=1" in cmd
+    assert f"--cgroup_mem_max={2048 * 1024}" in cmd
+    assert f"--rlimit_as={2048 * 1024}" in cmd
     assert "--cwd" in cmd and "--bindmount" in cmd
-    assert f"/tmp/work:/tmp/work" in cmd
+    assert "/tmp/work:/tmp/work" in cmd
     assert "--bindmount_ro" in cmd
-    assert f"/data:/data" in cmd
+    assert "/data:/data" in cmd
     assert "--env" in cmd and "FOO=BAR" in cmd
     assert "--rlimit_fsize=64" in cmd
 


### PR DESCRIPTION
## Summary
- enforce CPU, wall time and memory limits in nsjail runner
- expand nsjail and isolate tests for resource and network policies

## Testing
- `pre-commit run --files runners/nsjail.py tests/test_nsjail_runner.py tests/test_nsjail.py tests/test_isolate.py`
- `pytest tests/test_nsjail.py tests/test_nsjail_runner.py tests/test_isolate.py hrm_coder/tests/test_runner_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a19e3391608331b5315621b603352b