### PR TITLE
Add sandbox adapter for sanitized binary execution

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -126,6 +126,9 @@ Save new code files in: C:\repos\hrm-coder
     [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
     [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
         - Injected default ASAN_OPTIONS and UBSAN_OPTIONS in run_binary for deterministic sanitized runs
+        - Added BinarySandboxAdapter to route compiled binaries through sandbox with sanitizer environment
+        ~ Add integration tests exercising BinarySandboxAdapter with nsjail and gVisor backends
+        ~ Document adapter usage and sanitizer configuration in developer docs
     [?] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
     [~] Configure static versus dynamic linking inside jail with rpath handling and ccache
         - Added compile wrapper support for include paths, library directories, rpath, optional static builds, and ccache

--- a/runners/__init__.py
+++ b/runners/__init__.py
@@ -5,12 +5,15 @@ from .io_judge import run_io_tests
 from .isolate import IsolateRunner
 from .nsjail import NSJailRunner
 from .error_taxonomy import classify_compile, classify_runtime
+from .binary_adapter import BinarySandboxAdapter, SANITIZER_ENV
 from . import sandbox_detector, toolchain_detector
 
 __all__ = [
     "GVisorRunner",
     "IsolateRunner",
     "NSJailRunner",
+    "BinarySandboxAdapter",
+    "SANITIZER_ENV",
     "classify_compile",
     "classify_runtime",
     "run_io_tests",

--- a/runners/binary_adapter.py
+++ b/runners/binary_adapter.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+"""Adapter to execute compiled binaries inside sandbox runners.
+
+This module provides :class:`BinarySandboxAdapter` which wraps a sandbox
+runner such as :class:`~runners.isolate.IsolateRunner` or
+:class:`~runners.nsjail.NSJailRunner`. It normalizes environment variables
+for AddressSanitizer and UndefinedBehaviorSanitizer to ensure deterministic
+behaviour across backends.
+"""
+
+import tempfile
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+from .isolate import SandboxError
+
+SANITIZER_ENV: Mapping[str, str] = {
+    "ASAN_OPTIONS": "detect_leaks=0:halt_on_error=1:color=never",
+    "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1:color=never",
+}
+
+
+class BinarySandboxAdapter:
+    """Run compiled binaries within a sandbox runner with sanitizer
+    injection."""
+
+    def __init__(
+        self,
+        sandbox,
+        *,
+        sanitizer_env: Mapping[str, str] | None = None,
+    ) -> None:
+        self.sandbox = sandbox
+        self.sanitizer_env = dict(sanitizer_env or SANITIZER_ENV)
+
+    def run(
+        self,
+        binary: Path,
+        *,
+        input_data: str = "",
+        timeout: float = 2.0,
+        memory_limit: Optional[int] = None,
+        env: Optional[Mapping[str, str]] = None,
+        sanitize_env: bool = True,
+        cwd: Optional[Path] = None,
+        stdout_limit: Optional[int] = None,
+        stderr_limit: Optional[int] = None,
+    ) -> Tuple[int, str, str]:
+        """Execute ``binary`` inside the sandbox and return
+        ``(code, stdout, stderr)``."""
+
+        if cwd is None:
+            cwd = binary.parent
+
+        env_combined = dict(env or {})
+        if sanitize_env:
+            env_combined = {**self.sanitizer_env, **env_combined}
+
+        memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                proc = self.sandbox.run(
+                    [str(binary)],
+                    time_limit=int(timeout),
+                    wall_time=int(timeout),
+                    memory=memory_kb,
+                    stdin=input_data,
+                    workdir=tmpdir,
+                    readonly_dirs=[str(cwd)],
+                    env=env_combined,
+                    stdout_limit=stdout_limit,
+                    stderr_limit=stderr_limit,
+                )
+            except TypeError:
+                try:
+                    proc = self.sandbox.run(
+                        [str(binary)],
+                        time_limit=int(timeout),
+                        wall_time=int(timeout),
+                        memory=memory_kb,
+                        stdin=input_data,
+                        env=env_combined,
+                        stdout_limit=stdout_limit,
+                        stderr_limit=stderr_limit,
+                    )
+                except TypeError:
+                    proc = self.sandbox.run(
+                        [str(binary)],
+                        time_limit=int(timeout),
+                        wall_time=int(timeout),
+                        memory=memory_kb,
+                        stdin=input_data,
+                        env=env_combined,
+                        stdout_limit=stdout_limit,
+                        stderr_limit=stderr_limit,
+                    )
+            except SandboxError as exc:
+                return -1, "", str(exc)
+
+        return proc.returncode, proc.stdout, proc.stderr

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -22,8 +22,9 @@ from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from .error_taxonomy import classify_compile
 from .io_judge import run_io_tests
-from .isolate import IsolateRunner, SandboxError
+from .isolate import IsolateRunner
 from .sandbox_cache import SandboxCache
+from .binary_adapter import BinarySandboxAdapter, SANITIZER_ENV
 from utils.diagnostics import compiler_diagnostics
 
 
@@ -32,16 +33,6 @@ SANITIZER_FLAGS: List[str] = [
     "-fsanitize=address,undefined",
     "-fno-omit-frame-pointer",
 ]
-
-# Default sanitizer environment ensuring deterministic behaviour when
-# AddressSanitizer or UndefinedBehaviorSanitizer are enabled.  These
-# settings disable leak detection (which can introduce nondeterminism)
-# and force the sanitizers to terminate immediately on failure without
-# coloured output that would pollute logs in some sandboxes.
-SANITIZER_ENV: Mapping[str, str] = {
-    "ASAN_OPTIONS": "detect_leaks=0:halt_on_error=1:color=never",
-    "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1:color=never",
-}
 
 
 @dataclass
@@ -376,6 +367,20 @@ def run_binary(
     if cwd is None:
         cwd = binary.parent
 
+    if sandbox is not None:
+        adapter = BinarySandboxAdapter(sandbox)
+        return adapter.run(
+            binary,
+            input_data=input_data,
+            timeout=timeout,
+            memory_limit=memory_limit,
+            env=env,
+            sanitize_env=sanitize_env,
+            cwd=cwd,
+            stdout_limit=stdout_limit,
+            stderr_limit=stderr_limit,
+        )
+
     if sanitize_env:
         env_combined: Optional[Mapping[str, str]] = {
             **SANITIZER_ENV,
@@ -383,49 +388,6 @@ def run_binary(
         }
     else:
         env_combined = dict(env) if env is not None else None
-
-    if sandbox is not None:
-        memory_kb = (memory_limit or 256 * 1024 * 1024) // 1024
-        with tempfile.TemporaryDirectory() as tmpdir:
-            try:
-                proc = sandbox.run(
-                    [str(binary)],
-                    time_limit=int(timeout),
-                    wall_time=int(timeout),
-                    memory=memory_kb,
-                    stdin=input_data,
-                    workdir=tmpdir,
-                    readonly_dirs=[str(cwd)],
-                    env=env_combined,
-                    stdout_limit=stdout_limit,
-                    stderr_limit=stderr_limit,
-                )
-            except TypeError:
-                try:
-                    proc = sandbox.run(
-                        [str(binary)],
-                        time_limit=int(timeout),
-                        wall_time=int(timeout),
-                        memory=memory_kb,
-                        stdin=input_data,
-                        env=env_combined,
-                        stdout_limit=stdout_limit,
-                        stderr_limit=stderr_limit,
-                    )
-                except TypeError:
-                    proc = sandbox.run(
-                        [str(binary)],
-                        time_limit=int(timeout),
-                        wall_time=int(timeout),
-                        memory=memory_kb,
-                        stdin=input_data,
-                        env=env_combined,
-                        stdout_limit=stdout_limit,
-                        stderr_limit=stderr_limit,
-                    )
-            except SandboxError as exc:
-                return -1, "", str(exc)
-            return proc.returncode, proc.stdout, proc.stderr
 
     def preexec() -> None:
         _set_limits(memory_limit)

--- a/tests/test_binary_adapter.py
+++ b/tests/test_binary_adapter.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import subprocess
+
+from runners.binary_adapter import BinarySandboxAdapter, SANITIZER_ENV
+from runners.cpp_runner import compile_cpp
+
+
+def test_binary_adapter_injects_sanitizers(tmp_path: Path) -> None:
+    src = tmp_path / "main.cpp"
+    src.write_text("int main(){return 0;}")
+    res = compile_cpp(src)
+    assert res.success and res.binary is not None
+
+    class CaptureEnvRunner:
+        def __init__(self) -> None:
+            self.env = None
+
+        def run(self, cmd, **kwargs):
+            self.env = kwargs.get("env")
+            return subprocess.run(
+                cmd,
+                input=kwargs.get("stdin"),
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=kwargs.get("workdir"),
+            )
+
+    runner = CaptureEnvRunner()
+    adapter = BinarySandboxAdapter(runner)
+    code, _, _ = adapter.run(res.binary)
+    assert code == 0
+    assert runner.env is not None
+    assert runner.env["ASAN_OPTIONS"] == SANITIZER_ENV["ASAN_OPTIONS"]
+    assert runner.env["UBSAN_OPTIONS"] == SANITIZER_ENV["UBSAN_OPTIONS"]


### PR DESCRIPTION
## Summary
- add `BinarySandboxAdapter` to run compiled binaries inside sandboxes with deterministic ASan/UBSan env
- route `run_binary` through adapter and expose via runners package
- note remaining tasks in Phase 10 checklist for cross-backend tests and docs

## Testing
- `pre-commit run --files runners/binary_adapter.py runners/cpp_runner.py runners/__init__.py tests/test_binary_adapter.py docs/hrmCoder_checklist.md`
- `pytest tests/test_binary_adapter.py tests/test_cpp_runner.py::test_run_binary_injects_sanitizer_env tests/test_cpp_runner.py::test_run_binary_passes_env_to_sandbox -q`

------
https://chatgpt.com/codex/tasks/task_e_68a19e9968d483318a39abe246a6f5ed