### PR TITLE
Add Codeforces I/O harness builder and tests

### DIFF
--- a/runners/codeforces_harness.py
+++ b/runners/codeforces_harness.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Utilities to build and execute Codeforces-style I/O test harnesses.
+
+These helpers create a temporary directory layout mirroring the
+``build_codeforces_intro_dataset`` output so that compiled C++ sources can be
+run against multiple ``*.in``/``*.out`` pairs. Time and memory limits are
+stored in ``meta.json`` and honoured by
+``runners.cpp_runner.run_codeforces_task``.
+"""
+
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .cpp_runner import run_codeforces_task
+
+
+@dataclass
+class IOPair:
+    """Simple container for an input/output example."""
+
+    input: str
+    output: str
+
+
+def build_io_harness(
+    tests: Sequence[IOPair],
+    dest: Path,
+    *,
+    time_limit_ms: int = 2000,
+    memory_limit_kb: int = 256_000,
+) -> Path:
+    """Write ``tests`` to ``dest`` in the Codeforces task layout.
+
+    Parameters
+    ----------
+    tests:
+        Sequence of :class:`IOPair` examples.
+    dest:
+        Destination directory that will contain a ``tests`` subdirectory and
+        ``meta.json`` with time and memory limits.
+    time_limit_ms, memory_limit_kb:
+        Limits stored alongside the test files to mirror the dataset format.
+    """
+
+    dest = Path(dest)
+    tests_dir = dest / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    for idx, io in enumerate(tests):
+        (tests_dir / f"{idx}.in").write_text(io.input)
+        (tests_dir / f"{idx}.out").write_text(io.output)
+    meta = {"time_limit_ms": time_limit_ms, "memory_limit_kb": memory_limit_kb}
+    (dest / "meta.json").write_text(json.dumps(meta))
+    return dest
+
+
+def run_io_harness(
+    sources: Sequence[Path],
+    tests: Sequence[IOPair],
+    *,
+    time_limit_ms: int = 2000,
+    memory_limit_kb: int = 256_000,
+    **kwargs,
+) -> dict:
+    """Compile ``sources`` and execute them against ``tests``.
+
+    A temporary harness directory is created under the hood using
+    :func:`build_io_harness` and discarded after execution.
+    Additional keyword arguments are forwarded to
+    :func:`~runners.cpp_runner.run_codeforces_task`.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        task_dir = build_io_harness(
+            tests,
+            Path(tmp),
+            time_limit_ms=time_limit_ms,
+            memory_limit_kb=memory_limit_kb,
+        )
+        return run_codeforces_task(sources, task_dir, **kwargs)
+
+
+__all__ = ["IOPair", "build_io_harness", "run_io_harness"]

--- a/tests/test_codeforces_harness.py
+++ b/tests/test_codeforces_harness.py
@@ -1,0 +1,48 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from runners.codeforces_harness import IOPair, run_io_harness  # noqa: E402
+
+
+def _write_program(path: pathlib.Path, code: str) -> pathlib.Path:
+    path.write_text(code)
+    return path
+
+
+def test_multiple_tests(tmp_path: pathlib.Path) -> None:
+    src = _write_program(
+        tmp_path / "main.cpp",
+        (
+            "#include <iostream>\n"
+            "int main(){int a,b; if(!(std::cin>>a>>b)) return 0; "
+            "std::cout<<a+b;}\n"
+        ),
+    )
+    tests = [
+        IOPair("1 2\n", "3\n"),
+        IOPair("10 30\n", "40\n"),
+    ]
+    result = run_io_harness([src], tests, sanitize=False)
+    assert [r["passed"] for r in result["results"]] == [True, True]
+
+
+def test_time_limit_enforced(tmp_path: pathlib.Path) -> None:
+    src = _write_program(tmp_path / "loop.cpp", "int main(){while(true){};}\n")
+    tests = [IOPair("", "")]
+    result = run_io_harness([src], tests, time_limit_ms=50, sanitize=False)
+    assert result["results"][0]["error_type"] == "timeout"
+
+
+def test_memory_limit_enforced(tmp_path: pathlib.Path) -> None:
+    src = _write_program(
+        tmp_path / "mem.cpp",
+        (
+            "#include <vector>\n"
+            "int main(){std::vector<int> v(1<<26); return v.size();}\n"
+        ),
+    )
+    tests = [IOPair("", "")]
+    result = run_io_harness([src], tests, memory_limit_kb=1024, sanitize=False)
+    assert not result["results"][0]["passed"]


### PR DESCRIPTION
## Summary
- add utility to build Codeforces-style I/O harness directories and compare results
- support running sources against multiple test files with time/memory limits
- test harness covers multiple cases, timeouts, and memory cap enforcement

## Testing
- `pre-commit run --files runners/codeforces_harness.py tests/test_codeforces_harness.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a19ea601cc8331b38cc9cbc84bfc05