### PR TITLE
feat: support include dirs and rpath tasks

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -131,5 +131,7 @@ Save new code files in: C:\repos\hrm-coder
         - Added compile wrapper support for include paths, library directories, rpath, optional static builds, and ccache
         - Added helpers for building shared and static libraries to support library stubs in multi-file projects
         - Extended shared library builder with include, library, and rpath options for linking against dependent libraries
+        ~ Implement automatic $ORIGIN-based rpath injection for bundled libraries
+        ~ Add sandboxed integration tests for dynamic and static linking paths
     [ ] Create C++ security test suite for resource abuse and restricted syscalls
     [ ] Integrate C++ metrics and outcomes into common evaluator and reports

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -62,6 +62,7 @@ def compile_cpp_sources(
     *,
     compiler: str = "g++",
     flags: Optional[Iterable[str]] = None,
+    include_dirs: Optional[Iterable[Path]] = None,
     sanitize: bool = True,
     static: bool = False,
     library_dirs: Optional[Iterable[Path]] = None,
@@ -93,6 +94,8 @@ def compile_cpp_sources(
         Whether to include address and undefined behaviour sanitizers.
     static:
         Request a static build by passing ``-static`` when True.
+    include_dirs:
+        Extra directories to search for headers during compilation (``-I``).
     library_dirs:
         Extra directories to search for libraries during linking (``-L``).
     libraries:
@@ -126,6 +129,9 @@ def compile_cpp_sources(
 
     cmd += [str(s) for s in sources] + ["-o", str(output_path)] + list(flags)
 
+    if include_dirs is not None:
+        for d in include_dirs:
+            cmd.extend(["-I", str(d)])
     if library_dirs is not None:
         for d in library_dirs:
             cmd.extend(["-L", str(d)])
@@ -157,6 +163,10 @@ def compile_shared_library(
     *,
     compiler: str = "g++",
     flags: Optional[Iterable[str]] = None,
+    include_dirs: Optional[Iterable[Path]] = None,
+    library_dirs: Optional[Iterable[Path]] = None,
+    libraries: Optional[Iterable[str]] = None,
+    rpath: Optional[Iterable[Path]] = None,
     sanitize: bool = True,
     use_ccache: bool = False,
 ) -> CompileResult:
@@ -164,8 +174,8 @@ def compile_shared_library(
 
     This helper produces a ``.so`` suitable for linking against binaries
     compiled with :func:`compile_cpp_sources`.  It mirrors that function's
-    support for optional sanitizers and ``ccache`` to encourage deterministic
-    yet repeatable builds.
+    support for optional sanitizers, include and library directories, rpath
+    entries, and ``ccache`` to encourage deterministic yet repeatable builds.
     """
 
     if flags is None:
@@ -190,6 +200,18 @@ def compile_shared_library(
 
     cmd += [str(s) for s in sources] + ["-o", str(output_path)] + list(flags)
 
+    if include_dirs is not None:
+        for d in include_dirs:
+            cmd.extend(["-I", str(d)])
+    if library_dirs is not None:
+        for d in library_dirs:
+            cmd.extend(["-L", str(d)])
+    if libraries is not None:
+        for lib in libraries:
+            cmd.extend(["-l", lib])
+    if rpath is not None:
+        for p in rpath:
+            cmd.append(f"-Wl,-rpath,{p}")
     proc = subprocess.run(
         cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
@@ -211,6 +233,7 @@ def compile_static_library(
     *,
     compiler: str = "g++",
     flags: Optional[Iterable[str]] = None,
+    include_dirs: Optional[Iterable[Path]] = None,
     sanitize: bool = True,
     use_ccache: bool = False,
 ) -> CompileResult:
@@ -219,7 +242,8 @@ def compile_static_library(
     This helper builds each source into an object file and archives them
     together using ``ar``.  It mirrors :func:`compile_shared_library` so that
     Phase 10 experiments can easily link against lightweight library stubs
-    without relying on dynamic libraries.
+    without relying on dynamic libraries. ``include_dirs`` allows headers to be
+    referenced from external locations during compilation.
     """
 
     if flags is None:
@@ -249,6 +273,9 @@ def compile_static_library(
         if use_ccache and shutil.which("ccache") is not None:
             cmd = ["ccache", compiler]
         cmd += [str(src), "-c", "-o", str(obj_path)] + list(flags)
+        if include_dirs is not None:
+            for d in include_dirs:
+                cmd.extend(["-I", str(d)])
         proc = subprocess.run(
             cmd,
             capture_output=True,
@@ -299,6 +326,7 @@ def compile_cpp(
     *,
     compiler: str = "g++",
     flags: Optional[Iterable[str]] = None,
+    include_dirs: Optional[Iterable[Path]] = None,
     sanitize: bool = True,
 ) -> CompileResult:
     """Compile a single C++ ``source`` file.
@@ -313,6 +341,7 @@ def compile_cpp(
         output,
         compiler=compiler,
         flags=flags,
+        include_dirs=include_dirs,
         sanitize=sanitize,
     )
 
@@ -506,6 +535,7 @@ def run_codeforces_tests(
     *,
     compiler: str = "g++",
     flags: Optional[Iterable[str]] = None,
+    include_dirs: Optional[Iterable[Path]] = None,
     sanitize: bool = True,
     timeout: float = 2.0,
     memory_limit: Optional[int] = None,
@@ -560,6 +590,8 @@ def run_codeforces_tests(
             parts.append(f.encode())
         parts.append(b"sanitize" if sanitize else b"no_sanitize")
         parts.append(b"static" if static else b"dynamic")
+        for d in sorted(str(p) for p in include_dirs or []):
+            parts.append(d.encode())
         for d in sorted(str(p) for p in library_dirs or []):
             parts.append(d.encode())
         for lib in sorted(libraries or []):
@@ -678,6 +710,7 @@ def run_codeforces_tests(
             sources,
             compiler=compiler,
             flags=compile_flags,
+            include_dirs=include_dirs,
             sanitize=sanitize,
             static=static,
             library_dirs=library_dirs,

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -43,6 +43,37 @@ int main() { std::cout << add(1, 2); }
     assert stdout.strip() == "3"
 
 
+def test_compile_with_include_dirs(tmp_path: Path) -> None:
+    """Compile sources that rely on external include directories."""
+    inc = tmp_path / "inc"
+    inc.mkdir()
+    (inc / "math.hpp").write_text("int add(int,int);\n")
+
+    helper = tmp_path / "math.cpp"
+    helper.write_text(
+        """
+#include "math.hpp"
+int add(int a,int b){return a+b;}
+"""
+    )
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+#include "math.hpp"
+int main(){std::cout<<add(3,4);}
+"""
+    )
+
+    res = compile_cpp_sources([helper, main], include_dirs=[inc])
+    assert res.success and res.binary is not None
+
+    code, stdout, _ = run_binary(res.binary)
+    assert code == 0
+    assert stdout.strip() == "7"
+
+
 def test_shared_library_link(tmp_path: Path) -> None:
     """Build a shared library and link it into a main program."""
     lib_src = tmp_path / "double.cpp"


### PR DESCRIPTION
## Summary
- allow C++ build helpers to accept header include directories
- expand Codeforces runner to cache include dirs and forward to compiler
- track remaining rpath integration steps in Phase 10 checklist

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py docs/hrmCoder_checklist.md`
- `pytest tests/test_cpp_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68a19eb0308083318b03e5618e6dd042