### PR TITLE
feat: integrate cpp metrics into evaluator

### DIFF
--- a/hrm_coder/eval_cli.py
+++ b/hrm_coder/eval_cli.py
@@ -54,6 +54,11 @@ def _parse_args() -> argparse.Namespace:
         help="JSON files mapping task id → status string for incident rates",
     )
     parser.add_argument(
+        "--cpp-metrics",
+        default=None,
+        help="JSON file mapping task id to C++ metrics",
+    )
+    parser.add_argument(
         "--bundle",
         default=None,
         help="Path to write a bundled tar.gz of reports and raw JSON",
@@ -72,7 +77,9 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _load_incident_runs(paths: Sequence[str] | None) -> Sequence[dict[str, str]]:
+def _load_incident_runs(
+    paths: Sequence[str] | None,
+) -> Sequence[dict[str, str]]:
     return [json.loads(Path(p).read_text()) for p in paths] if paths else []
 
 
@@ -91,6 +98,7 @@ def main() -> None:  # pragma: no cover - exercised via tests
         run_paths=args.runs,
         baseline_path=args.baseline,
         incident_paths=args.incidents,
+        cpp_metrics_path=args.cpp_metrics,
         bundle_path=args.bundle,
         upload_dir=args.upload,
     )
@@ -99,7 +107,7 @@ def main() -> None:  # pragma: no cover - exercised via tests
     incident_runs = _load_incident_runs(args.incidents)
     incident_summary = incident_rates(incident_runs) if incident_runs else {}
     sanitizer_failures = sum(
-        status == "sanitizer"
+        status == "sanitizer_error"
         for run in incident_runs
         for status in run.values()
     )
@@ -129,4 +137,3 @@ def main() -> None:  # pragma: no cover - exercised via tests
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
-

--- a/hrm_coder/evaluation.py
+++ b/hrm_coder/evaluation.py
@@ -100,7 +100,12 @@ def flaky_tasks(runs: Sequence[Dict[str, bool]]) -> List[str]:
 
 def incident_rates(
     runs: Sequence[Dict[str, str]],
-    incident_types: Sequence[str] = ("timeout", "sanitizer"),
+    incident_types: Sequence[str] = (
+        "timeout",
+        "sanitizer_error",
+        "compile_error",
+        "runtime_error",
+    ),
 ) -> Dict[str, float]:
     """Compute rates of specified incident types across runs.
 
@@ -110,7 +115,7 @@ def incident_rates(
         Sequence of mappings from task identifier to a status string.
     incident_types:
         Iterable of status values to measure. Defaults to ``("timeout",
-        "sanitizer")``.
+        "sanitizer_error", "compile_error", "runtime_error")``.
     """
 
     counts = {inc: 0 for inc in incident_types}
@@ -127,10 +132,56 @@ def incident_rates(
     }
 
 
+def aggregate_cpp_metrics(
+    data: Dict[str, Dict[str, object]]
+) -> Dict[str, float]:
+    """Aggregate C++-specific metrics from per-task results.
+
+    Parameters
+    ----------
+    data:
+        Mapping from task identifier to dictionaries containing keys such as
+        ``compile_status``, ``compile_warnings`` and ``coverage``.
+
+    Returns
+    -------
+    Dict[str, float]
+        Summary metrics including ``compile_success_rate``,
+        ``avg_compile_warnings`` and ``avg_coverage``.
+    """
+
+    total = len(data)
+    if total == 0:
+        return {
+            "compile_success_rate": 0.0,
+            "avg_compile_warnings": 0.0,
+            "avg_coverage": 0.0,
+        }
+
+    success = sum(
+        1 for m in data.values() if m.get("compile_status") == "success"
+    )
+    warnings = sum(
+        int(m.get("compile_warnings", 0)) for m in data.values()
+    )
+    coverages = [
+        float(m.get("coverage"))
+        for m in data.values()
+        if m.get("coverage") is not None
+    ]
+    avg_cov = sum(coverages) / len(coverages) if coverages else 0.0
+    return {
+        "compile_success_rate": success / total,
+        "avg_compile_warnings": warnings / total,
+        "avg_coverage": avg_cov,
+    }
+
+
 def markdown_report(
     metrics: Dict[int, float],
     flaky: Sequence[str],
     incidents: Dict[str, float] | None = None,
+    extra_metrics: Dict[str, float] | None = None,
 ) -> str:
     """Generate a Markdown report for the evaluation metrics."""
 
@@ -138,6 +189,12 @@ def markdown_report(
     for k, value in sorted(metrics.items()):
         lines.append(f"| {k} | {value:.3f} |")
     lines.append("")
+    if extra_metrics:
+        lines.append("## Additional Metrics")
+        lines.extend(
+            f"- {name}: {val:.3f}" for name, val in extra_metrics.items()
+        )
+        lines.append("")
     if incidents:
         lines.append("## Incident Rates")
         lines.extend(
@@ -156,6 +213,7 @@ def html_report(
     metrics: Dict[int, float],
     flaky: Sequence[str],
     incidents: Dict[str, float] | None = None,
+    extra_metrics: Dict[str, float] | None = None,
 ) -> str:
     """Generate a minimal HTML report for the evaluation metrics."""
 
@@ -164,9 +222,9 @@ def html_report(
         for k, value in sorted(metrics.items())
     )
     if flaky:
-        flaky_html = "<ul>" + "".join(
-            f"<li>{task}</li>" for task in flaky
-        ) + "</ul>"
+        flaky_html = (
+            "<ul>" + "".join(f"<li>{task}</li>" for task in flaky) + "</ul>"
+        )
     else:
         flaky_html = "<p>No flaky tasks detected.</p>"
     if incidents:
@@ -180,10 +238,22 @@ def html_report(
         )
     else:
         incidents_html = "<p>No incidents recorded.</p>"
+    if extra_metrics:
+        extra_html = (
+            "<ul>"
+            + "".join(
+                f"<li>{name}: {val:.3f}</li>"
+                for name, val in extra_metrics.items()
+            )
+            + "</ul>"
+        )
+    else:
+        extra_html = ""
     return (
         "<h1>Evaluation Report</h1>"
         "<table><tr><th>k</th><th>pass@k</th></tr>"
         f"{rows}</table>"
+        f"{extra_html}"
         f"{incidents_html}"
         f"{flaky_html}"
     )
@@ -281,6 +351,7 @@ def generate_reports(
     run_paths: Sequence[str] | None = None,
     baseline_path: str | None = None,
     incident_paths: Sequence[str] | None = None,
+    cpp_metrics_path: str | None = None,
     bundle_path: str | None = None,
     upload_dir: str | None = None,
 ) -> Dict[int, float]:
@@ -303,6 +374,11 @@ def generate_reports(
     incident_paths:
         Optional JSON files mapping task id → status string, used to
         compute incident rates such as timeouts and sanitizer failures.
+    cpp_metrics_path:
+        Optional JSON file mapping task id → C++ metrics containing
+        ``compile_status``, ``compile_warnings`` and optional ``coverage``
+        fields. When provided aggregated metrics are included in the
+        generated reports.
     bundle_path:
         Optional path for a bundled ``.tar.gz`` archive containing the
         generated reports and raw JSON. If ``None`` the bundle is skipped
@@ -336,6 +412,12 @@ def generate_reports(
         else None
     )
 
+    cpp_metrics = (
+        aggregate_cpp_metrics(json.loads(Path(cpp_metrics_path).read_text()))
+        if cpp_metrics_path
+        else None
+    )
+
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -346,11 +428,14 @@ def generate_reports(
     )
 
     (out_dir / "report.md").write_text(
-        markdown_report(metrics, flaky, incidents)
+        markdown_report(metrics, flaky, incidents, cpp_metrics)
     )
     (out_dir / "report.html").write_text(
-        html_report(metrics, flaky, incidents)
+        html_report(metrics, flaky, incidents, cpp_metrics)
     )
+
+    if cpp_metrics is not None:
+        (out_dir / "cpp_metrics.json").write_text(json.dumps(cpp_metrics))
 
     bundle_file: str | None = None
 
@@ -372,6 +457,8 @@ def generate_reports(
             out_dir / "results.json",
             out_dir / "metrics.json",
         ]
+        if cpp_metrics is not None:
+            files.append(out_dir / "cpp_metrics.json")
         if baseline_path is not None:
             files.extend(
                 [out_dir / "baseline.md", out_dir / "baseline.html"]
@@ -419,6 +506,11 @@ def main() -> None:  # pragma: no cover - CLI entry point
         help="JSON files of run status strings for incident rate computation",
     )
     parser.add_argument(
+        "--cpp-metrics",
+        default=None,
+        help="JSON file mapping task id to C++ metrics",
+    )
+    parser.add_argument(
         "--bundle",
         default=None,
         help="Path to write a bundled tar.gz of reports and JSON",
@@ -436,6 +528,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
         run_paths=args.runs,
         baseline_path=args.baseline,
         incident_paths=args.incidents,
+        cpp_metrics_path=args.cpp_metrics,
         bundle_path=args.bundle,
         upload_dir=args.upload,
     )

--- a/hrm_coder/tests/test_evaluation.py
+++ b/hrm_coder/tests/test_evaluation.py
@@ -41,15 +41,18 @@ def test_determinism_and_flaky_detection():
 def test_report_generation():
     metrics = {1: 0.5}
     incidents = {"timeout": 0.1}
-    report_md = markdown_report(metrics, ['t2'], incidents)
+    extras = {"compile_success_rate": 0.5}
+    report_md = markdown_report(metrics, ['t2'], incidents, extras)
     assert '| 1 | 0.500 |' in report_md
     assert 'Flaky Tasks' in report_md
     assert 'timeout' in report_md
+    assert 'compile_success_rate' in report_md
 
-    report_html = html_report(metrics, [], incidents)
+    report_html = html_report(metrics, [], incidents, extras)
     assert '<td>1</td><td>0.500</td>' in report_html
     assert 'No flaky tasks' in report_html
     assert 'timeout' in report_html
+    assert 'compile_success_rate' in report_html
 
 
 def test_baseline_comparison(tmp_path):
@@ -72,11 +75,12 @@ def test_baseline_comparison(tmp_path):
 def test_incident_rates():
     runs = [
         {"a": "timeout", "b": "pass"},
-        {"a": "sanitizer", "b": "timeout"},
+        {"a": "sanitizer_error", "b": "compile_error"},
     ]
     rates = incident_rates(runs)
-    assert rates["timeout"] == pytest.approx(2 / 4)
-    assert rates["sanitizer"] == pytest.approx(1 / 4)
+    assert rates["timeout"] == pytest.approx(1 / 4)
+    assert rates["sanitizer_error"] == pytest.approx(1 / 4)
+    assert rates["compile_error"] == pytest.approx(1 / 4)
 
 
 def test_generate_reports(tmp_path):
@@ -91,8 +95,30 @@ def test_generate_reports(tmp_path):
 
     incident1_file = tmp_path / "inc1.json"
     incident2_file = tmp_path / "inc2.json"
-    incident1_file.write_text(json.dumps({"t1": "timeout", "t2": "pass"}))
-    incident2_file.write_text(json.dumps({"t1": "pass", "t2": "timeout"}))
+    incident1_file.write_text(
+        json.dumps({"t1": "timeout", "t2": "pass"})
+    )
+    incident2_file.write_text(
+        json.dumps({"t1": "pass", "t2": "sanitizer_error"})
+    )
+
+    cpp_metrics_file = tmp_path / "cpp_metrics.json"
+    cpp_metrics_file.write_text(
+        json.dumps(
+            {
+                "t1": {
+                    "compile_status": "success",
+                    "compile_warnings": 1,
+                    "coverage": 0.5,
+                },
+                "t2": {
+                    "compile_status": "compile_error",
+                    "compile_warnings": 0,
+                    "coverage": 0.0,
+                },
+            }
+        )
+    )
 
     baseline_file = tmp_path / "baseline.json"
     baseline_file.write_text(json.dumps({"pass@1": 0.0, "pass@2": 0.0}))
@@ -107,6 +133,7 @@ def test_generate_reports(tmp_path):
         run_paths=[str(run1_file), str(run2_file)],
         baseline_path=str(baseline_file),
         incident_paths=[str(incident1_file), str(incident2_file)],
+        cpp_metrics_path=str(cpp_metrics_file),
         bundle_path=str(bundle_path),
         upload_dir=str(upload_dir),
     )
@@ -115,7 +142,9 @@ def test_generate_reports(tmp_path):
     report_md = (tmp_path / "report.md").read_text()
     assert "Flaky Tasks" in report_md and "t2" in report_md
     assert "Incident Rates" in report_md
+    assert "compile_success_rate" in report_md
     assert (tmp_path / "report.html").exists()
+    assert (tmp_path / "cpp_metrics.json").exists()
     assert (tmp_path / "baseline.md").exists()
     assert (tmp_path / "baseline.html").exists()
     assert bundle_path.exists()


### PR DESCRIPTION
## Summary
- track compile and runtime errors in incident rates
- aggregate C++ compile warnings and coverage into evaluation reports
- allow eval CLI to accept per-task C++ metrics

## Testing
- `pre-commit run --files hrm_coder/evaluation.py hrm_coder/eval_cli.py hrm_coder/tests/test_evaluation.py`
- `pytest hrm_coder/tests/test_evaluation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a19eca6f6c833198927005c33c33f4