### PR TITLE
Add sandbox feature matrix and limit tests

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -23,8 +23,8 @@ Save new code files in: C:\repos\hrm-coder
         - Added sandbox smoke test script to verify basic command execution in available backends
         - Added audit CLI with optional JSON output for programmatic environment checks
         - Added environment variable and output limit support to gVisor runner
-        ~ Document feature parity matrix for isolate, nsjail, and gVisor adapters
-        ~ Add integration tests verifying resource limit enforcement across adapters
+        - Documented feature parity matrix for isolate, nsjail, and gVisor adapters
+        - Added integration tests verifying resource limit enforcement across adapters
         ~ Investigate file size limit enforcement support in gVisor runner
     [~] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
         - Added dataset catalog utility with hash validation and unit tests

--- a/docs/hrmCoder_sandbox_matrix.md
+++ b/docs/hrmCoder_sandbox_matrix.md
@@ -1,0 +1,20 @@
+# Sandbox Feature Parity
+
+The table below compares capabilities across the supported sandbox adapters.
+
+| Capability                | isolate | nsjail | gVisor (runsc) |
+|--------------------------|:-------:|:------:|:--------------:|
+| CPU time limit           | ✅       | ✅     | ❌ *not implemented* |
+| Wall clock limit         | ✅       | ✅     | ❌ *not implemented* |
+| Memory limit             | ✅       | ✅     | ✅ |
+| Process count limit      | ✅       | ✅     | ✅ |
+| Network isolation        | ✅       | ✅     | ✅ |
+| Read-only mounts         | ✅       | ✅     | ✅ |
+| Working directory mount  | ✅       | ✅     | ✅ |
+| Environment variables    | ✅       | ✅     | ✅ |
+| Stdout/stderr capture    | ✅       | ✅     | ✅ |
+| Output size trimming     | ✅       | ✅     | ✅ |
+| File size limit          | ✅       | ✅     | ❌ *pending* |
+
+*`gVisor` support mirrors Docker's `runsc` runtime. CPU and wall time limits are
+not currently exposed and file size limits require further investigation.*

--- a/tests/test_sandbox_limits.py
+++ b/tests/test_sandbox_limits.py
@@ -1,0 +1,59 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from runners.gvisor import GVisorRunner  # noqa: E402
+from runners.isolate import IsolateRunner  # noqa: E402
+from runners.nsjail import NSJailRunner  # noqa: E402
+
+
+def _available_runners() -> List[Tuple[str, object]]:
+    runners: List[Tuple[str, object]] = []
+    if shutil.which("isolate") is not None:
+        runners.append(("isolate", IsolateRunner()))
+    if shutil.which("nsjail") is not None:
+        runners.append(("nsjail", NSJailRunner()))
+    if shutil.which("docker") is not None:
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--runtime=runsc",
+            "python:3.11-slim",
+            "python",
+            "-c",
+            "print('hi')",
+        ]
+        proc = subprocess.run(cmd, capture_output=True)
+        if proc.returncode == 0:
+            runners.append(("gvisor", GVisorRunner(image="python:3.11-slim")))
+    return runners
+
+
+@pytest.mark.parametrize("name, runner", _available_runners())
+def test_time_limit_enforced(name: str, runner: object) -> None:
+    if name == "gvisor":
+        pytest.skip("gVisor does not expose a CPU time or wall clock limit")
+    proc = runner.run(
+        [sys.executable, "-c", "while True: pass"],
+        time_limit=1,
+        wall_time=1,
+    )
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize("name, runner", _available_runners())
+def test_memory_limit_enforced(name: str, runner: object) -> None:
+    cmd = [
+        sys.executable,
+        "-c",
+        "a = 'x' * (200 * 1024 * 1024); print(len(a))",
+    ]
+    proc = runner.run(cmd, memory=32 * 1024)
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary
- document feature parity across isolate, nsjail, and gVisor adapters
- add integration tests covering CPU and memory limit enforcement in available sandboxes
- note progress in checklist for sandbox evaluation tasks

## Testing
- `pre-commit run --files docs/hrmCoder_sandbox_matrix.md docs/hrmCoder_checklist.md tests/test_sandbox_limits.py`
- `pytest tests/test_sandbox_limits.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1b8c5a02883319ca6be091b2e07da