### PR TITLE
doc: add native binary sandbox threat model

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -30,7 +30,8 @@ Save new code files in: C:\repos\hrm-coder
         - Added dataset catalog utility with hash validation and unit tests
         ~ Populate dataset licenses and SHA256 hashes in docs/dataset_catalog.json
     [X] Define acceptance metrics and thresholds for C++ (pass\@k, sanitizer-clean runs, timeout rate)
-    [~] Draft sandbox Threat Model and initial security requirements for native binaries
+    [X] Draft sandbox Threat Model and initial security requirements for native binaries
+        - Added sandbox threat model doc outlining assets, actors, threats, and mitigations
     [X] Write ADRs for sandbox choice, experiment tracker, and GUI stack
         - Added ADR 0001 detailing isolate as default sandbox with nsjail/runsc fallbacks
         - Added ADR 0002 selecting MLflow for experiment tracking

--- a/docs/sandbox_threat_model.md
+++ b/docs/sandbox_threat_model.md
@@ -1,32 +1,69 @@
 # Sandbox Threat Model
 
-This document outlines potential threats when executing untrusted native binaries during HRM Coder development.
+This document outlines threats and mitigations for executing untrusted native
+binaries during HRM Coder development.
 
 ## Assets
-- Host operating system and other processes
+- Host operating system, kernel, and other processes
+- Sandbox container image and configuration files
 - Dataset integrity and evaluation results
 - Credentials and network isolation guarantees
+- Build cache and intermediate artifacts
 
 ## Assumptions
-- Attackers can supply arbitrary C++ code snippets that are compiled and executed.
+- Attackers can supply arbitrary C++ code snippets that are compiled and run as
+  native binaries.
 - Sandboxing tools are available on the host (`isolate`, `nsjail`, or `runsc`).
 - Network access inside the sandbox is disabled.
+- Compiler toolchains and linked libraries are not implicitly trusted.
+
+## Threat Actors and Capabilities
+- Adversaries may embed inline assembly or raw syscalls to bypass runtime
+  checks.
+- Binaries may attempt to exploit kernel or sandbox vulnerabilities.
+- Attackers can generate large outputs or spawn processes to exhaust resources.
+- Binaries may try to read or tamper with datasets, caches, or host files.
 
 ## Threats
-1. **Escaping the sandbox** via kernel vulnerabilities or misconfiguration.
-2. **Resource exhaustion** such as fork bombs or excessive memory use.
-3. **Filesystem access** beyond the working directory, including `/proc` or host mounts.
-4. **Network access** attempts despite policy to remain offline.
-5. **Abuse of privileged syscalls** leading to privilege escalation.
+1. **Sandbox escape** via kernel vulnerabilities, misconfiguration, or shared
+   mounts.
+2. **Resource exhaustion** such as fork bombs, memory blowup, or large files.
+3. **Filesystem access** beyond the working directory, including `/proc`,
+   symlink traversal, or host mounts.
+4. **Network access** despite policy to remain offline.
+5. **Abuse of privileged syscalls** (`ptrace`, `mount`, `setuid`, etc.) leading
+   to privilege escalation.
+6. **Toolchain attacks** where compilers or linker flags modify files outside
+   the sandbox.
+7. **Side-channel leakage** via residual artifacts or shared caches between
+   runs.
 
 ## Security Requirements
-- Enforce strict CPU, memory, and wall-clock limits.
-- Run binaries as a non-root user with minimal capabilities.
-- Mount only a temporary working directory with read-only source files.
-- Apply seccomp or similar syscall filters restricting networking and dangerous operations.
-- Ensure repeatability: sandbox configuration is declarative and version controlled.
+
+### Environment
+- Enforce strict CPU, memory, process, file-size, and wall-clock limits.
+- Run binaries as a dedicated unprivileged user with no extra capabilities.
+- Mount only a temporary work directory; toolchain and sources are read-only.
+- Apply seccomp/BPF or similar filters; disable networking and device access.
+- Clear environment variables and block `LD_PRELOAD` or `ptrace` hooks.
+
+### Build & Execution
+- Compile with deterministic flags and sanitizers (ASan/UBSan) when enabled.
+- Link only against whitelisted system libraries; prefer static linking.
+- Hash binaries and treat them as ephemeral artifacts.
+- Capture stdout/stderr with size caps and record exit status.
+- Remove temporary files and mounts after execution completes.
+
+### Monitoring & Response
+- Log sandbox configuration and resource usage for each run.
+- Abort and flag any policy violations or sanitizer failures.
+- Version-control sandbox profiles to guarantee repeatability.
 
 ## Mitigations
-- Prefer `isolate` as the default sandbox; fall back to `nsjail` or `runsc` if available.
-- Run integration tests using intentionally malicious samples to verify containment.
-- Log sandbox diagnostics and enforce zero-tolerance for escapes or policy violations.
+- Prefer `isolate` as the default sandbox; fall back to `nsjail` or `runsc` if
+  available.
+- Keep host kernels and sandbox runtimes patched.
+- Run integration tests using malicious samples (fork bomb, file read, network
+  open) to verify containment.
+- Audit logs for anomalies and block forbidden syscalls or paths.
+- Adopt defense in depth: containerization, sandboxing, and unprivileged users.


### PR DESCRIPTION
## Summary
- outline assets, threats, and mitigation strategies for executing untrusted native binaries
- document security requirements for build and runtime environments
- mark phase 0 checklist item complete

## Testing
- `pre-commit run --files docs/hrmCoder_checklist.md docs/sandbox_threat_model.md`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8d886f8833195884676c73162e3