### PR TITLE
docs: finalize risk register

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -35,8 +35,8 @@ Save new code files in: C:\repos\hrm-coder
         - Added ADR 0001 detailing isolate as default sandbox with nsjail/runsc fallbacks
         - Added ADR 0002 selecting MLflow for experiment tracking
         - Added ADR 0003 choosing FastAPI with htmx/Tailwind for the GUI stack
-    [?] Create initial risk register and mitigation plan
-        - Added initial risk register and mitigation plan docs
+    [X] Create initial risk register and mitigation plan
+        - Added and reviewed initial risk register and mitigation plan docs
 
 ** [ ] Phase 1: Repo Scaffold & Deterministic Environment
     [X] Generate project layout scaffold script for hrm-coder directory tree

--- a/docs/hrmCoder_overview.md
+++ b/docs/hrmCoder_overview.md
@@ -3,6 +3,8 @@
 
 * Public HRM work (paper + repo) shows Sudoku, mazes, and ARC; no code benchmarks or encoders yet. ([arXiv][1], [GitHub][2])
 
+For risk tracking and mitigation strategies, see [risk_register.md](risk_register.md) and [mitigation_plan.md](mitigation_plan.md).
+
 # 1) Objectives
 
 * **Robustness:** no flakiness; identical results on re-runs.

--- a/docs/hrmCoder_plan.md
+++ b/docs/hrmCoder_plan.md
@@ -4,6 +4,8 @@
 
 **Vision:** Build a reliable, reproducible **C++** HRM-powered coder that synthesizes and repairs programs on deterministic, judge-style benchmarks with **safe native execution**, **stable multi-signal rewards**, and **one-command automation** (data → train → eval).
 
+For the current risk register and mitigation strategies, see [risk_register.md](risk_register.md) and [mitigation_plan.md](mitigation_plan.md).
+
 **In-scope (v1):**
 
 1. Token-level C++ code generation on deterministic **intro competitive-programming** tasks (Codeforces-Intro, AtCoder-ABC subset) and a **HumanEval-CPP** port.

--- a/docs/risk_register.md
+++ b/docs/risk_register.md
@@ -13,15 +13,6 @@ This register tracks early risks for Phase 0 of HRM Coder and proposed mitigatio
 | R7 | Dataset contamination or sensitive data leakage | High | Low | Scan sources, track provenance, and perform manual reviews |
 | R8 | Logs or artifacts leaking credentials or PII | Medium | Low | Scrub logs and restrict artifact retention |
 
-## Mitigation Plan
-
-- **R1:** Harden sandbox profiles, apply strict seccomp, and run malicious sample tests in CI.
-- **R2:** Distribute `env_probe.py` and document required packages in README; fail fast when tools are missing.
-- **R3:** Keep dataset catalog with licenses and URLs; require contributors to record provenance.
-- **R4:** Pin toolchain versions, seeds, locale, and time zone; add deterministic build checks.
-- **R5:** Add stress tests for CPU and memory limits; monitor resource usage within sandbox.
-- **R6:** Pin dependency versions, verify checksums, and maintain a software bill of materials.
-- **R7:** Scan datasets for PII or license conflicts and review sources before inclusion.
-- **R8:** Scrub secrets from logs and limit access to artifacts containing runtime output.
+See [mitigation_plan.md](mitigation_plan.md) for detailed mitigation actions for each risk.
 
 This document will be updated as new risks are identified.


### PR DESCRIPTION
## Summary
- streamline risk register by referencing dedicated mitigation plan
- reference risk docs from overview and project plan
- mark risk-register task complete in development checklist

## Testing
- `pytest` *(partial: interrupted after 14 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b8e06b108331a39df68f1561ac21