### PR TITLE
Finalize trainer Dockerfile determinism

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -42,7 +42,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Generate project layout scaffold script for hrm-coder directory tree
     [X] Author runner.Dockerfile with g++, CMake, GoogleTest, isolate/nsjail, and sanitizer toolchain
         - Installed coverage utilities and compiled gtest; locale/timezone pinned for determinism
-    [~] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
+    [?] Author trainer.Dockerfile with CUDA, PyTorch, and deterministic flags
     [~] Create Makefile targets for data, train, eval, report, and tooling (CMake + ctest integration)
         - Added build_trainer target for trainer Docker image
         - Added lint target invoking pre-commit hooks

--- a/trainer.Dockerfile
+++ b/trainer.Dockerfile
@@ -1,7 +1,7 @@
 # trainer.Dockerfile - image for HRM training environment
 FROM pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime
 
-# Pin locale, timezone, and CUDA determinism settings
+# Pin locale, timezone, and deterministic CUDA/cuDNN/NCCL settings
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
@@ -12,6 +12,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_LAUNCH_BLOCKING=1 \
     CUDNN_DETERMINISTIC=1 \
     CUDNN_BENCHMARK=0 \
+    TORCH_CUDNN_V8_API_ENABLE=1 \
+    NCCL_P2P_DISABLE=1 \
+    NCCL_IB_DISABLE=1 \
     OMP_NUM_THREADS=1 \
     MKL_NUM_THREADS=1 \
     NUMEXPR_NUM_THREADS=1


### PR DESCRIPTION
## Summary
- add CuDNN v8 and NCCL determinism env vars in trainer Dockerfile
- mark trainer Dockerfile checklist entry ready for review

## Testing
- `pre-commit run --files trainer.Dockerfile docs/hrmCoder_checklist.md`

------
https://chatgpt.com/codex/tasks/task_e_68a1b8ea1e7883319308d8311ebe7847