### PR TITLE
docs: document make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: data build_runner build_trainer train eval report lint smoke cpp-build cpp-test test tooling
 
 # Phase 1 scaffold targets
+# Pass extra command line arguments to individual targets via the ARGS
+# variable, for example:
+#
+#     make train ARGS='--seed 123'
 
 DATA_OUT ?= data/processed
 

--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -50,7 +50,7 @@ Save new code files in: C:\repos\hrm-coder
         - Added report target generating Markdown/HTML summaries from evaluation results
         - Added test target running pytest and ctest suites
         - Added tooling target combining lint and test
-        ~ Document train and eval target usage examples
+        - Document train and eval target usage examples
         ~ Add coverage target aggregating ctest and pytest results
     [~] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults

--- a/docs/hrmCoder_overview.md
+++ b/docs/hrmCoder_overview.md
@@ -100,9 +100,11 @@ Signals (0–1 scaled), averaged with tuned weights:
   * `runner`: minimal runtime per language + nsjail/isolate binaries.
 * **Make/Hydra**
 
-  * `make data DATASET=mbpp-s`
-  * `make train CFG=token_baseline`
-  * `make eval CKPT=...`
+* `make data ARGS='--catalog docs/dataset_catalog.json'`
+* `make train ARGS='model.learning_rate=1e-3'`
+* `make eval ARGS='results.json reports/'`
+* `make report ARGS='results.json reports/summary'`
+* `make tooling`
 * **GitHub Actions**
 
   * Lint & unit tests for harness.


### PR DESCRIPTION
## Summary
- clarify how to pass extra CLI arguments to Makefile targets
- document data, train, eval, report, and tooling targets in overview
- mark checklist item for train/eval usage examples as complete

## Testing
- `pre-commit run --files Makefile docs/hrmCoder_overview.md docs/hrmCoder_checklist.md`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b8f2b4848331832859ebd9000d81