### PR TITLE
Resolve config paths relative to project root

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -52,12 +52,12 @@ Save new code files in: C:\repos\hrm-coder
         - Added tooling target combining lint and test
         ~ Document train and eval target usage examples
         ~ Add coverage target aggregating ctest and pytest results
-    [~] Define Hydra config schema and default configs under conf/
+    [X] Define Hydra config schema and default configs under conf/
         - Added CPU and memory limit options to runner config defaults
         - Added helper to instantiate sandbox runners from configuration
         - Added network access toggle to runner config defaults
-        ~ Add paths configuration group for dataset, runs, and artifact directories
-        ~ Add unit test covering config loading and path resolution
+        - Added paths configuration group for dataset, runs, and artifact directories
+        - Added unit test covering config loading and path resolution
     [X] Configure pre-commit for C++ (clang-format, clang-tidy, cpplint, codespell) and Python aux tools
         - Added Makefile lint target to run pre-commit
     [X] Implement environment pinning and seed/tz/locale normalization module

--- a/hrm_coder/config.py
+++ b/hrm_coder/config.py
@@ -118,7 +118,8 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
     overrides:
         Optional sequence of Hydra override strings.
     """
-    config_dir = Path(__file__).parent / "conf"
+    config_dir = Path(__file__).resolve().parent / "conf"
+    project_root = config_dir.parent.parent
     with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
         cfg = compose(
             config_name="config",
@@ -134,8 +135,12 @@ def load_config(overrides: Sequence[str] | None = None) -> AppConfig:
         comp, _ = toolchain_detector.select_compiler()
         runner_cfg.compiler = comp or "g++"
 
+    def resolve_path(p: str) -> Path:
+        path = Path(p)
+        return (path if path.is_absolute() else project_root / path).resolve()
+
     paths_cfg = PathsConfig(
-        **{k: Path(v) for k, v in cfg_dict["paths"].items()}
+        **{k: resolve_path(v) for k, v in cfg_dict["paths"].items()}
     )
 
     return AppConfig(

--- a/hrm_coder/tests/test_config.py
+++ b/hrm_coder/tests/test_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from hrm_coder.config import load_config
 
 
@@ -16,10 +18,14 @@ def test_load_config_defaults():
     assert cfg.training.curriculum_stage == "visible"
     assert cfg.environment.seed == 0
     assert cfg.environment.timezone == "UTC"
+    project_root = Path(__file__).resolve().parents[2]
+    assert cfg.paths.data_root == project_root / "data"
+    assert cfg.paths.runs_root == project_root / "runs"
+    assert cfg.paths.artifacts_root == project_root / "artifacts"
 
 
 def test_load_config_override():
-    cfg = load_config([
+    overrides = [
         "model.learning_rate=0.01",
         "runner.timeout=10",
         "runner.memory_limit=512",
@@ -29,6 +35,9 @@ def test_load_config_override():
         "training.baseline_coef=0.7",
         "training.curriculum_stage=hidden",
         "environment.seed=123",
+    ]
+    cfg = load_config([
+        *overrides,
     ])
     assert cfg.model.learning_rate == 0.01
     assert cfg.runner.timeout == 10
@@ -39,3 +48,14 @@ def test_load_config_override():
     assert cfg.training.baseline_coef == 0.7
     assert cfg.training.curriculum_stage == "hidden"
     assert cfg.environment.seed == 123
+
+
+def test_load_config_path_override(tmp_path):
+    cfg = load_config([
+        f"paths.data_root={tmp_path / 'data'}",
+        f"paths.runs_root={tmp_path / 'runs'}",
+        f"paths.artifacts_root={tmp_path / 'artifacts'}",
+    ])
+    assert cfg.paths.data_root == tmp_path / "data"
+    assert cfg.paths.runs_root == tmp_path / "runs"
+    assert cfg.paths.artifacts_root == tmp_path / "artifacts"


### PR DESCRIPTION
## Summary
- resolve configuration paths against the project root
- cover path resolution and overrides in config tests
- mark Hydra config task complete in project checklist

## Testing
- `pytest hrm_coder/tests/test_config.py`
- `pre-commit run --files hrm_coder/config.py hrm_coder/tests/test_config.py docs/hrmCoder_checklist.md`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8fb85ec8331879f1b8424f26c36