### PR TITLE
feat: expose compile command in C++ wrapper

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -139,7 +139,9 @@ Save new code files in: C:\repos\hrm-coder
     [X] Add ablation job configs and comparison report against token baseline
 
 ** [ ] Phase 10: C++ Runner and Codeforces Integration (v2)
-    [~] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
+    [X] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
+        - Default flags: `-std=c++17 -O2 -pipe -Wall -Wextra -fdiagnostics-color=never`
+        - Structured parsing of compiler warnings and errors
     [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
         - Injected default ASAN_OPTIONS and UBSAN_OPTIONS in run_binary for deterministic sanitized runs
         - Added BinarySandboxAdapter to route compiled binaries through sandbox with sanitizer environment

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -49,6 +49,7 @@ class CompileResult:
     success: bool
     stdout: str
     stderr: str
+    cmd: List[str]
     binary: Optional[Path]
     warnings: int
     errors: int
@@ -149,13 +150,14 @@ def compile_cpp_sources(
     warnings = sum(d.level == "warning" for d in diags)
     errors = sum(d.level == "error" for d in diags)
     return CompileResult(
-        success,
-        proc.stdout,
-        proc.stderr,
-        output_path if success else None,
-        warnings,
-        errors,
-        diags,
+        success=success,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        cmd=cmd,
+        binary=output_path if success else None,
+        warnings=warnings,
+        errors=errors,
+        diagnostics=diags,
     )
 
 
@@ -222,13 +224,14 @@ def compile_shared_library(
     warnings = sum(d.level == "warning" for d in diags)
     errors = sum(d.level == "error" for d in diags)
     return CompileResult(
-        success,
-        proc.stdout,
-        proc.stderr,
-        output_path if success else None,
-        warnings,
-        errors,
-        diags,
+        success=success,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        cmd=cmd,
+        binary=output_path if success else None,
+        warnings=warnings,
+        errors=errors,
+        diagnostics=diags,
     )
 
 
@@ -297,13 +300,14 @@ def compile_static_library(
         total_errors += sum(d.level == "error" for d in diags)
         if proc.returncode != 0:
             return CompileResult(
-                False,
-                "".join(stdout_parts),
-                "".join(stderr_parts),
-                None,
-                total_warnings,
-                total_errors,
-                diagnostics,
+                success=False,
+                stdout="".join(stdout_parts),
+                stderr="".join(stderr_parts),
+                cmd=cmd,
+                binary=None,
+                warnings=total_warnings,
+                errors=total_errors,
+                diagnostics=diagnostics,
             )
         objs.append(obj_path)
 
@@ -319,13 +323,14 @@ def compile_static_library(
     stderr_parts.append(ar_proc.stderr)
     success = ar_proc.returncode == 0
     return CompileResult(
-        success,
-        "".join(stdout_parts),
-        "".join(stderr_parts),
-        output_path if success else None,
-        total_warnings,
-        total_errors,
-        diagnostics,
+        success=success,
+        stdout="".join(stdout_parts),
+        stderr="".join(stderr_parts),
+        cmd=ar_cmd,
+        binary=output_path if success else None,
+        warnings=total_warnings,
+        errors=total_errors,
+        diagnostics=diagnostics,
     )
 
 


### PR DESCRIPTION
## Summary
- surface the full compiler command in `CompileResult` and propagate through compile helpers
- document completion of g++/clang++ compile wrapper with default optimized flags and diagnostics parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b9158dc0833182c96552c23f441b