### PR TITLE
Add Codeforces harness result summarizer

### DIFF
--- a/runners/codeforces_harness.py
+++ b/runners/codeforces_harness.py
@@ -83,4 +83,62 @@ def run_io_harness(
         return run_codeforces_task(sources, task_dir, **kwargs)
 
 
-__all__ = ["IOPair", "build_io_harness", "run_io_harness"]
+def summarize_result(result: dict) -> dict:
+    """Summarize a Codeforces harness execution result.
+
+    Parameters
+    ----------
+    result:
+        Dictionary produced by :func:`run_io_harness` or
+        :func:`~runners.cpp_runner.run_codeforces_task`.
+
+    Returns
+    -------
+    dict
+        Summary containing an overall ``verdict`` (``"OK"``, ``"WA"``,
+        ``"TL"``, ``"ML"``, ``"RE"``, or ``"CE"``), whether all tests
+        ``passed``, and counts of passed versus total tests.
+    """
+
+    compile_status = result.get("compile_status", "")
+    tests = result.get("results", [])
+    passed_tests = sum(1 for t in tests if t.get("passed"))
+    total_tests = len(tests)
+
+    verdict = "OK"
+    if compile_status != "success":
+        verdict = "CE"
+    else:
+        for t in tests:
+            err = t.get("error_type")
+            if err == "timeout":
+                verdict = "TL"
+                break
+            if err in {"policy_violation", "sanitizer_error"}:
+                verdict = "RE"
+                break
+            if err == "runtime_error":
+                stderr = t.get("stderr", "").lower()
+                if "memory" in stderr or "bad_alloc" in stderr:
+                    verdict = "ML"
+                else:
+                    verdict = "RE"
+                break
+            if not t.get("passed"):
+                verdict = "WA"
+                break
+
+    return {
+        "verdict": verdict,
+        "passed": verdict == "OK",
+        "passed_tests": passed_tests,
+        "total_tests": total_tests,
+    }
+
+
+__all__ = [
+    "IOPair",
+    "build_io_harness",
+    "run_io_harness",
+    "summarize_result",
+]

--- a/tests/test_codeforces_harness.py
+++ b/tests/test_codeforces_harness.py
@@ -3,7 +3,11 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))  # noqa: E402
 
-from runners.codeforces_harness import IOPair, run_io_harness  # noqa: E402
+from runners.codeforces_harness import (  # noqa: E402
+    IOPair,
+    run_io_harness,
+    summarize_result,
+)
 
 
 def _write_program(path: pathlib.Path, code: str) -> pathlib.Path:
@@ -26,6 +30,23 @@ def test_multiple_tests(tmp_path: pathlib.Path) -> None:
     ]
     result = run_io_harness([src], tests, sanitize=False)
     assert [r["passed"] for r in result["results"]] == [True, True]
+    summary = summarize_result(result)
+    assert summary["verdict"] == "OK"
+
+
+def test_wrong_answer(tmp_path: pathlib.Path) -> None:
+    src = _write_program(
+        tmp_path / "wa.cpp",
+        (
+            "#include <iostream>\n"
+            "int main(){int a,b; if(!(std::cin>>a>>b)) return 0; "
+            "std::cout<<a+b-1;}\n"
+        ),
+    )
+    tests = [IOPair("1 2\n", "3\n")]
+    result = run_io_harness([src], tests, sanitize=False)
+    summary = summarize_result(result)
+    assert summary["verdict"] == "WA"
 
 
 def test_time_limit_enforced(tmp_path: pathlib.Path) -> None:
@@ -33,6 +54,8 @@ def test_time_limit_enforced(tmp_path: pathlib.Path) -> None:
     tests = [IOPair("", "")]
     result = run_io_harness([src], tests, time_limit_ms=50, sanitize=False)
     assert result["results"][0]["error_type"] == "timeout"
+    summary = summarize_result(result)
+    assert summary["verdict"] == "TL"
 
 
 def test_memory_limit_enforced(tmp_path: pathlib.Path) -> None:
@@ -46,3 +69,13 @@ def test_memory_limit_enforced(tmp_path: pathlib.Path) -> None:
     tests = [IOPair("", "")]
     result = run_io_harness([src], tests, memory_limit_kb=1024, sanitize=False)
     assert not result["results"][0]["passed"]
+    summary = summarize_result(result)
+    assert summary["verdict"] in {"ML", "RE"}
+
+
+def test_compile_error(tmp_path: pathlib.Path) -> None:
+    src = _write_program(tmp_path / "bad.cpp", "int main() {\n")
+    tests = [IOPair("", "")]
+    result = run_io_harness([src], tests, sanitize=False)
+    summary = summarize_result(result)
+    assert summary["verdict"] == "CE"


### PR DESCRIPTION
## Summary
- add Codeforces harness result summarizer generating Codeforces-style verdicts and pass counts
- test harness builder and summarizer across multiple tests including WA, TL, ML and compile errors

## Testing
- `pytest tests/test_codeforces_harness.py -q`
- `pytest tests/test_io_judge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b926609c83319e355caeb6dea334