### PR TITLE
Handle $ORIGIN rpath and sandbox linking tests

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -146,11 +146,11 @@ Save new code files in: C:\repos\hrm-coder
         ~ Add integration tests exercising BinarySandboxAdapter with nsjail and gVisor backends
         ~ Document adapter usage and sanitizer configuration in developer docs
     [?] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
-    [~] Configure static versus dynamic linking inside jail with rpath handling and ccache
+    [?] Configure static versus dynamic linking inside jail with rpath handling and ccache
         - Added compile wrapper support for include paths, library directories, rpath, optional static builds, and ccache
         - Added helpers for building shared and static libraries to support library stubs in multi-file projects
         - Extended shared library builder with include, library, and rpath options for linking against dependent libraries
-        ~ Implement automatic $ORIGIN-based rpath injection for bundled libraries
-        ~ Add sandboxed integration tests for dynamic and static linking paths
+        - Implement automatic $ORIGIN-based rpath injection for bundled libraries
+        - Add sandboxed integration tests for dynamic and static linking paths
     [ ] Create C++ security test suite for resource abuse and restricted syscalls
     [ ] Integrate C++ metrics and outcomes into common evaluator and reports

--- a/docs/hrmCoder_overview.md
+++ b/docs/hrmCoder_overview.md
@@ -49,7 +49,7 @@ Augmentation (to reach \~1k samples without contamination):
 * **Runners:** language-specific:
 
   * Python: `pytest -q` inside sandbox; `pytest-timeout` plugin; cap stdout/stderr. ([Pytest Documentation][16], [LambdaTest][17])
-  * C++ (Phase-2): compile with `g++ -O2 -pipe -static -s` (if available) or dynamic with rpath inside the jail; run with the same limits (use isolate “box”). ([ucw.cz][18])
+  * C++ (Phase-2): compile with `g++ -O2 -pipe -static -s` (if available) or dynamic with `$ORIGIN` rpath inside the jail; optional `ccache` for speed; run with the same limits (use isolate “box”). ([ucw.cz][18])
 * **Caching:** hash(prompt+partial\_code+tests) → avoid re-running identical shards.
 * **Stability:** fix `PYTHONHASHSEED`, locale, time zone; no wall-clock in tests.
 

--- a/docs/hrmCoder_plan.md
+++ b/docs/hrmCoder_plan.md
@@ -233,7 +233,7 @@ Stubbed early with mock run objects and static artifact samples.
 
 ### P10 – Extended Judges & Linking (v2)
 
-* Multi-file projects; library stubs; rpath handling for dynamic builds in jail.
+* Multi-file projects; library stubs; automatic `$ORIGIN` rpath handling for dynamic builds in jail.
 * Optional **static** builds where feasible; **ccache** for speed.
 * Additional datasets (Kattis micro-set) with license review.
 * Security suite expansion (syscall denylist regression).

--- a/runners/cpp_runner.py
+++ b/runners/cpp_runner.py
@@ -25,7 +25,7 @@ from .io_judge import run_io_tests
 from .isolate import IsolateRunner
 from .sandbox_cache import SandboxCache
 from .binary_adapter import BinarySandboxAdapter, SANITIZER_ENV
-from utils.diagnostics import Diagnostic, compiler_diagnostics, parse_compiler_diagnostics
+from utils.diagnostics import Diagnostic, parse_compiler_diagnostics
 
 
 DEFAULT_FLAGS: List[str] = [
@@ -605,14 +605,18 @@ def run_codeforces_tests(
     total_warnings = 0
     total_errors = 0
 
-    with tempfile.TemporaryDirectory() as lib_tmp:
-        lib_dirs: List[Path] = []
+    with tempfile.TemporaryDirectory() as build_tmp:
+        build_dir = Path(build_tmp)
+        lib_dirs: set[Path] = set()
         lib_names: List[str] = []
-        rpath_list: List[Path] = list(rpath) if rpath is not None else []
+        rpath_list: List[Path] = []
+        if rpath is not None:
+            rpath_list.extend(rpath)
 
         if shared_libs:
+            rpath_list.append(Path("$ORIGIN"))
             for name, srcs in shared_libs.items():
-                out = Path(lib_tmp) / f"lib{name}.so"
+                out = build_dir / f"lib{name}.so"
                 res = compile_shared_library(
                     srcs,
                     output=out,
@@ -620,6 +624,7 @@ def run_codeforces_tests(
                     flags=compile_flags,
                     sanitize=sanitize,
                     use_ccache=use_ccache,
+                    rpath=[Path("$ORIGIN")],
                 )
                 stdout_parts.append(res.stdout)
                 stderr_parts.append(res.stderr)
@@ -638,13 +643,12 @@ def run_codeforces_tests(
                     if cache is not None and key is not None:
                         cache.store(key, data)
                     return data
-                lib_dirs.append(out.parent)
+                lib_dirs.add(out.parent)
                 lib_names.append(name)
-                rpath_list.append(out.parent)
 
         if static_libs:
             for name, srcs in static_libs.items():
-                out = Path(lib_tmp) / f"lib{name}.a"
+                out = build_dir / f"lib{name}.a"
                 res = compile_static_library(
                     srcs,
                     output=out,
@@ -670,24 +674,29 @@ def run_codeforces_tests(
                     if cache is not None and key is not None:
                         cache.store(key, data)
                     return data
-                lib_dirs.append(out.parent)
+                lib_dirs.add(out.parent)
                 lib_names.append(name)
 
-        if library_dirs is not None:
-            library_dirs = list(library_dirs) + lib_dirs
-        else:
-            library_dirs = lib_dirs
-        if libraries is not None:
-            libraries = list(libraries) + lib_names
-        else:
-            libraries = lib_names
-        if rpath is not None:
-            rpath = list(rpath) + rpath_list
-        else:
-            rpath = rpath_list
+        if lib_dirs:
+            if library_dirs is not None:
+                library_dirs = list(library_dirs) + list(lib_dirs)
+            else:
+                library_dirs = list(lib_dirs)
+        if lib_names:
+            if libraries is not None:
+                libraries = list(libraries) + lib_names
+            else:
+                libraries = lib_names
+        if rpath_list:
+            if rpath is not None:
+                rpath = list(rpath) + rpath_list
+            else:
+                rpath = rpath_list
 
+        output_path = build_dir / "main"
         compile_res = compile_cpp_sources(
             sources,
+            output=output_path,
             compiler=compiler,
             flags=compile_flags,
             include_dirs=include_dirs,

--- a/tests/test_cpp_runner.py
+++ b/tests/test_cpp_runner.py
@@ -3,6 +3,7 @@ import json
 import re
 import subprocess
 import sys
+import shutil
 
 import pytest  # noqa: F401
 
@@ -18,6 +19,57 @@ from runners.cpp_runner import (  # noqa: E402
     run_codeforces_task,
 )
 from runners.sandbox_cache import SandboxCache  # noqa: E402
+
+
+class DummySandbox:
+    """Minimal sandbox mimic that relocates binaries before execution."""
+
+    def run(
+        self,
+        command,
+        *,
+        time_limit,
+        wall_time,
+        memory,
+        stdin,
+        workdir,
+        readonly_dirs,
+        env,
+        stdout_limit=None,
+        stderr_limit=None,
+    ):
+        host_dir = Path(readonly_dirs[0])
+        internal_dir = Path(workdir) / host_dir.relative_to("/")
+        internal_dir.mkdir(parents=True, exist_ok=True)
+        for f in host_dir.iterdir():
+            shutil.copy(f, internal_dir / f.name)
+        backup = host_dir.with_name(host_dir.name + "_orig")
+        host_dir.rename(backup)
+        try:
+            internal_cmd = [str(internal_dir / Path(command[0]).name)]
+            proc = subprocess.run(
+                internal_cmd,
+                input=stdin,
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=workdir,
+            )
+            stdout = (
+                proc.stdout[: stdout_limit]
+                if stdout_limit is not None
+                else proc.stdout
+            )
+            stderr = (
+                proc.stderr[: stderr_limit]
+                if stderr_limit is not None
+                else proc.stderr
+            )
+            return subprocess.CompletedProcess(
+                internal_cmd, proc.returncode, stdout, stderr
+            )
+        finally:
+            shutil.rmtree(backup, ignore_errors=True)
 
 
 def test_compile_multi_file(tmp_path: Path) -> None:
@@ -430,6 +482,57 @@ int main(){int x; if(!(std::cin>>x)) return 0; std::cout<<times_two(x);}
 
     res = run_codeforces_tests(
         [main], tests_dir, shared_libs={"double": [lib_src]}
+    )
+    assert res["results"][0]["passed"]
+
+
+def test_run_codeforces_tests_shared_libs_sandbox(tmp_path: Path) -> None:
+    """Shared libs should resolve via $ORIGIN inside a sandbox."""
+    lib_src = tmp_path / "double.cpp"
+    lib_src.write_text('extern "C" int times_two(int x){return 2*x;}\n')
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+extern "C" int times_two(int);
+int main(){int x; if(!(std::cin>>x)) return 0; std::cout<<times_two(x);}
+""",
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("3\n")
+    (tests_dir / "a.out").write_text("6\n")
+
+    sandbox = DummySandbox()
+    res = run_codeforces_tests(
+        [main], tests_dir, shared_libs={"double": [lib_src]}, sandbox=sandbox
+    )
+    assert res["results"][0]["passed"]
+
+
+def test_run_codeforces_tests_static_lib_sandbox(tmp_path: Path) -> None:
+    """Link a static library and run inside the sandbox."""
+    lib_src = tmp_path / "math.cpp"
+    lib_src.write_text("int add(int a,int b){return a+b;}\n")
+
+    main = tmp_path / "main.cpp"
+    main.write_text(
+        """
+#include <iostream>
+extern int add(int,int);
+int main(){int x; if(!(std::cin>>x)) return 0; std::cout<<add(x,1);}
+""",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "a.in").write_text("4\n")
+    (tests_dir / "a.out").write_text("5\n")
+
+    sandbox = DummySandbox()
+    res = run_codeforces_tests(
+        [main], tests_dir, static_libs={"math": [lib_src]}, sandbox=sandbox
     )
     assert res["results"][0]["passed"]
 


### PR DESCRIPTION
## Summary
- bundle shared libraries with automatic `$ORIGIN` rpath and ccache support
- add DummySandbox tests covering dynamic and static library linking
- document rpath/ccache configuration in HRM Coder guides

## Testing
- `pre-commit run --files runners/cpp_runner.py tests/test_cpp_runner.py docs/hrmCoder_overview.md docs/hrmCoder_checklist.md docs/hrmCoder_plan.md`
- `pytest tests/test_cpp_runner.py::test_run_codeforces_tests_shared_libs tests/test_cpp_runner.py::test_run_codeforces_tests_shared_libs_sandbox tests/test_cpp_runner.py::test_run_codeforces_tests_static_lib_sandbox -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1b92ea150833191c59818be224276