### PR TITLE
Integrate C++ metrics into evaluation harness

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -153,4 +153,4 @@ Save new code files in: C:\repos\hrm-coder
         ~ Implement automatic $ORIGIN-based rpath injection for bundled libraries
         ~ Add sandboxed integration tests for dynamic and static linking paths
     [ ] Create C++ security test suite for resource abuse and restricted syscalls
-    [ ] Integrate C++ metrics and outcomes into common evaluator and reports
+    [X] Integrate C++ metrics and outcomes into common evaluator and reports

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -8,9 +8,11 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))  # noqa: E402
 import pytest  # noqa: E402
 
 from utils.eval_harness import (  # noqa: E402
+    aggregate_cpp_metrics,
     bundle_and_upload,
     compare_to_baseline,
     generate_comparison_report,
+    generate_report,
 )
 
 
@@ -58,3 +60,26 @@ def test_generate_comparison_report(tmp_path):
     assert report_file.exists()
     assert json.loads(report_file.read_text()) == comparison
     assert comparison["pass@1"]["delta"] == pytest.approx(0.2)
+
+
+def test_aggregate_cpp_metrics():
+    data = {
+        "t1": {"compile_status": "success", "compile_warnings": 1, "coverage": 0.5},
+        "t2": {"compile_status": "failure", "compile_warnings": 0, "coverage": None},
+    }
+    metrics = aggregate_cpp_metrics(data)
+    assert metrics["compile_success_rate"] == pytest.approx(0.5)
+    assert metrics["avg_compile_warnings"] == pytest.approx(0.5)
+    assert metrics["avg_coverage"] == pytest.approx(0.5)
+
+
+def test_generate_report_with_extra_metrics(tmp_path):
+    report_file = tmp_path / "report.json"
+    generate_report(
+        {"pass@1": 0.5},
+        str(report_file),
+        extra_metrics={"compile_success_rate": 0.8},
+    )
+    data = json.loads(report_file.read_text())
+    assert data["pass@1"] == pytest.approx(0.5)
+    assert data["compile_success_rate"] == pytest.approx(0.8)

--- a/utils/eval_harness.py
+++ b/utils/eval_harness.py
@@ -94,28 +94,77 @@ def detect_flaky_tests(run_results: List[Dict[str, bool]]) -> List[str]:
     return flaky
 
 
-def generate_report(metrics: Dict[str, Any], path: str) -> None:
+def aggregate_cpp_metrics(data: Dict[str, Dict[str, Any]]) -> Dict[str, float]:
+    """Aggregate C++-specific metrics from per-task results.
+
+    Parameters
+    ----------
+    data:
+        Mapping from task identifier to dictionaries containing keys such as
+        ``compile_status``, ``compile_warnings`` and ``coverage``.
+
+    Returns
+    -------
+    Dict[str, float]
+        Summary metrics including ``compile_success_rate``,
+        ``avg_compile_warnings`` and ``avg_coverage``.
+    """
+
+    total = len(data)
+    if total == 0:
+        return {
+            "compile_success_rate": 0.0,
+            "avg_compile_warnings": 0.0,
+            "avg_coverage": 0.0,
+        }
+
+    success = sum(
+        1 for m in data.values() if m.get("compile_status") == "success"
+    )
+    warnings = sum(int(m.get("compile_warnings", 0)) for m in data.values())
+    coverages = [
+        float(m.get("coverage"))
+        for m in data.values()
+        if m.get("coverage") is not None
+    ]
+    avg_cov = sum(coverages) / len(coverages) if coverages else 0.0
+    return {
+        "compile_success_rate": success / total,
+        "avg_compile_warnings": warnings / total,
+        "avg_coverage": avg_cov,
+    }
+
+
+def generate_report(
+    metrics: Dict[str, Any],
+    path: str,
+    extra_metrics: Dict[str, float] | None = None,
+) -> None:
     """Generate a simple report containing ``metrics``.
 
     The format is inferred from ``path`` extension: ``.md`` for Markdown,
     ``.html`` for HTML and any other extension for JSON.
+    ``extra_metrics`` can be provided to include additional metrics such as
+    aggregated C++ outcomes.
     """
+    data = dict(metrics)
+    if extra_metrics:
+        data.update(extra_metrics)
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     if p.suffix.lower() == ".md":
         lines = ["# Evaluation Report", ""]
-        for key, value in metrics.items():
+        for key, value in data.items():
             lines.append(f"- **{key}**: {value}")
         p.write_text("\n".join(lines))
     elif p.suffix.lower() in {".html", ".htm"}:
         rows = "\n".join(
-            f"<tr><th>{key}</th><td>{value}</td></tr>"
-            for key, value in metrics.items()
+            f"<tr><th>{key}</th><td>{value}</td></tr>" for key, value in data.items()
         )
         html = f"<html><body><table>{rows}</table></body></html>"
         p.write_text(html)
     else:
-        p.write_text(json.dumps(metrics, indent=2))
+        p.write_text(json.dumps(data, indent=2))
 
 
 def bundle_artifacts(paths: Iterable[str], bundle_path: str) -> None:


### PR DESCRIPTION
## Summary
- aggregate C++ compile metrics and coverage stats
- extend report generator to include additional metrics
- document completion of C++ metrics integration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1b94151c483318a5b4400c78c52c0