### PR TITLE
Add file size limit support to gVisor runner

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -15,7 +15,7 @@ Save new code files in: C:\repos\hrm-coder
     [X] Inventory HRM repo APIs and identify injection points for C++ token/AST decoders
     [?] Setup project operation within isolate/gVisor runner images
         - Added run_in_sandbox utility script for executing arbitrary commands in the selected sandbox backend
-    [~] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
+    [X] Evaluate isolate and gVisor adapters against nsjail for reuse and gaps
         - Added sandbox detection utility for isolate, nsjail, and gVisor runsc runtime
         - Added default sandbox selection helper to prefer isolate and fall back to nsjail or runsc
         - Integrated sandbox auto-selection into runner configuration
@@ -25,7 +25,7 @@ Save new code files in: C:\repos\hrm-coder
         - Added environment variable and output limit support to gVisor runner
         - Documented feature parity matrix for isolate, nsjail, and gVisor adapters
         - Added integration tests verifying resource limit enforcement across adapters
-        ~ Investigate file size limit enforcement support in gVisor runner
+        - Implemented file size limit enforcement support in gVisor runner
     [X] Compile dataset catalog (Codeforces-Intro, AtCoder ABC subset, Kattis micro-set, HumanEval-CPP port) with licenses and hashes (see docs/dataset_catalog.json)
         - Added dataset catalog utility with hash validation and unit tests
         - Populated dataset licenses and SHA256 hashes in docs/dataset_catalog.json

--- a/docs/hrmCoder_sandbox_matrix.md
+++ b/docs/hrmCoder_sandbox_matrix.md
@@ -14,7 +14,7 @@ The table below compares capabilities across the supported sandbox adapters.
 | Environment variables    | ✅       | ✅     | ✅ |
 | Stdout/stderr capture    | ✅       | ✅     | ✅ |
 | Output size trimming     | ✅       | ✅     | ✅ |
-| File size limit          | ✅       | ✅     | ❌ *pending* |
+| File size limit          | ✅       | ✅     | ✅ |
 
 *`gVisor` support mirrors Docker's `runsc` runtime. CPU and wall time limits are
-not currently exposed and file size limits require further investigation.*
+not currently exposed.*

--- a/runners/gvisor.py
+++ b/runners/gvisor.py
@@ -39,6 +39,7 @@ class GVisorRunner:
         workdir: Optional[str] = None,
         readonly_dirs: Optional[Iterable[str]] = None,
         env: Optional[Mapping[str, str]] = None,
+        fsize: Optional[int] = None,
     ) -> List[str]:
         """Build a ``docker run`` command that executes ``command`` under
         gVisor.
@@ -83,6 +84,8 @@ class GVisorRunner:
         if env is not None:
             for key, value in env.items():
                 docker_cmd.extend(["-e", f"{key}={value}"])
+        if fsize is not None:
+            docker_cmd.extend(["--ulimit", f"fsize={fsize}"])
         docker_cmd.append(self.image)
         docker_cmd.extend(command)
         return docker_cmd
@@ -107,6 +110,7 @@ class GVisorRunner:
             raise SandboxError(
                 f"docker executable not found: {self.docker_path}"
             )
+        max_limit = max(stdout_limit or 0, stderr_limit or 0)
         cmd = self.build_command(
             command,
             time_limit=time_limit,
@@ -116,6 +120,7 @@ class GVisorRunner:
             workdir=workdir,
             readonly_dirs=readonly_dirs,
             env=env,
+            fsize=max_limit if max_limit else None,
         )
         proc = subprocess.run(
             cmd,

--- a/tests/test_gvisor.py
+++ b/tests/test_gvisor.py
@@ -37,6 +37,13 @@ def test_build_command_with_env():
     assert "BAZ=QUX" in cmd
 
 
+def test_build_command_with_fsize():
+    runner = GVisorRunner(docker_path="docker", image="ubuntu:latest")
+    cmd = runner.build_command(["/bin/true"], fsize=1234)
+    assert "--ulimit" in cmd
+    assert "fsize=1234" in cmd
+
+
 def test_run_truncates_output(monkeypatch):
     runner = GVisorRunner(docker_path="docker", image="ubuntu:latest")
 
@@ -54,3 +61,23 @@ def test_run_truncates_output(monkeypatch):
     proc = runner.run(["/bin/echo", "hi"], stdout_limit=10, stderr_limit=5)
     assert proc.stdout == "A" * 10
     assert proc.stderr == "B" * 5
+
+
+def test_run_includes_fsize(monkeypatch):
+    runner = GVisorRunner(docker_path="docker", image="ubuntu:latest")
+    monkeypatch.setattr(shutil, "which", lambda p: "/usr/bin/docker")
+
+    import subprocess
+
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner.run(["/bin/echo", "hi"], stdout_limit=10)
+    cmd = captured["cmd"]
+    assert "--ulimit" in cmd
+    assert "fsize=10" in cmd


### PR DESCRIPTION
## Summary
- enforce file size limits via `--ulimit fsize` in gVisor adapter
- document gVisor parity with nsjail/isolate and mark checklist item complete
- cover gVisor file size handling in unit tests

## Testing
- `pytest tests/test_gvisor.py tests/test_binary_adapter.py::test_binary_adapter_gvisor -q`
- `pre-commit run --files runners/gvisor.py tests/test_gvisor.py docs/hrmCoder_sandbox_matrix.md docs/hrmCoder_checklist.md`

------
https://chatgpt.com/codex/tasks/task_e_68a1c535ae0883318d50b8b25ecb6341