### PR TITLE
docs: describe sandbox binary adapter

### DIFF
--- a/docs/hrmCoder_checklist.md
+++ b/docs/hrmCoder_checklist.md
@@ -144,11 +144,11 @@ Save new code files in: C:\repos\hrm-coder
     [X] Implement g++/clang++ compile wrapper with optimized flags and diagnostics parsing
         - Default flags: `-std=c++17 -O2 -pipe -Wall -Wextra -fdiagnostics-color=never`
         - Structured parsing of compiler warnings and errors
-    [~] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
+    [?] Implement sandbox execution adapter for compiled binaries with sanitizer support (ASan/UBSan)
         - Injected default ASAN_OPTIONS and UBSAN_OPTIONS in run_binary for deterministic sanitized runs
         - Added BinarySandboxAdapter to route compiled binaries through sandbox with sanitizer environment
         - Added integration tests exercising BinarySandboxAdapter with nsjail and gVisor backends
-        ~ Document adapter usage and sanitizer configuration in developer docs
+        - Documented adapter usage and sanitizer configuration in developer docs
     [?] Implement Codeforces I/O harness builder and result comparator (multiple test files, TL/ML handling)
     [?] Configure static versus dynamic linking inside jail with rpath handling and ccache
         - Added compile wrapper support for include paths, library directories, rpath, optional static builds, and ccache

--- a/docs/hrmCoder_sandbox_adapter.md
+++ b/docs/hrmCoder_sandbox_adapter.md
@@ -1,0 +1,38 @@
+# Sandbox Binary Adapter
+
+`BinarySandboxAdapter` runs compiled executables inside a sandbox backend
+while applying deterministic sanitizer settings.  It works with
+`IsolateRunner`, `NSJailRunner`, and `GVisorRunner` and forwards resource
+limits such as CPU time, memory, and stdout/stderr caps.
+
+## Usage
+
+```python
+from runners import IsolateRunner, BinarySandboxAdapter
+
+runner = IsolateRunner()
+adapter = BinarySandboxAdapter(runner)
+
+code, out, err = adapter.run(binary_path, timeout=2.0,
+                             memory_limit=256 * 1024 * 1024)
+```
+
+The adapter mounts the binary's directory read-only and executes the
+process in a temporary working directory with networking disabled and a
+single-process limit.
+
+## Sanitizer environment
+
+By default the adapter injects stable settings for AddressSanitizer and
+UndefinedBehaviorSanitizer:
+
+- `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:color=never`
+- `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:color=never`
+
+Custom mappings may be passed through the ``sanitizer_env`` constructor
+argument.  ``run(..., sanitize_env=False)`` disables injection or allows
+overrides via the ``env`` parameter.
+
+`runners.cpp_runner.run_binary` automatically creates a
+`BinarySandboxAdapter` when a sandbox runner is provided.
+


### PR DESCRIPTION
## Summary
- document BinarySandboxAdapter usage and sanitizer environment variables
- mark sandbox adapter task as documented in project checklist

## Testing
- `pytest tests/test_binary_adapter.py::test_binary_adapter_injects_sanitizers tests/test_binary_adapter.py::test_binary_adapter_passes_limits tests/test_cpp_runner.py::test_run_binary_injects_sanitizer_env -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1c5953ca4833180f9485673015e03